### PR TITLE
[mle_trev_tests] skip some matrices sizes in randomized test

### DIFF
--- a/pyemma/msm/estimation/tests/test_mle_trev.py
+++ b/pyemma/msm/estimation/tests/test_mle_trev.py
@@ -9,21 +9,21 @@ from pyemma.msm.estimation import tmatrix as apicall
 
 class Test_mle_trev(unittest.TestCase):
     def test_mle_trev(self):
-        for n in xrange(3,100):
-            C  = (1000*np.random.rand(n,n)).astype(int)
+        for n in xrange(3, 100, 5):
+            C = (1000*np.random.rand(n, n)).astype(int)
             while not is_connected(C):
-                C  = (1000*np.random.rand(n,n)).astype(int)
-            
-            T_cython_sparse = mtrs(scipy.sparse.csr_matrix(C)).toarray()
-            
-            T_python = etmr(C)
-            T_api_dense = apicall(C,reversible=True)
-            T_api_sparse = apicall(scipy.sparse.csr_matrix(C),reversible=True).toarray() 
+                C = (1000*np.random.rand(n, n)).astype(int)
 
-            self.assertTrue(np.allclose(T_cython_sparse,T_python))
-            self.assertTrue(np.allclose(T_api_sparse,T_python))
-            self.assertTrue(np.allclose(T_api_dense,T_python))
+            T_cython_sparse = mtrs(scipy.sparse.csr_matrix(C)).toarray()
+
+            T_python = etmr(C)
+            T_api_dense = apicall(C, reversible=True)
+            T_api_sparse = apicall(scipy.sparse.csr_matrix(C), reversible=True).toarray() 
+
+            self.assertTrue(np.allclose(T_cython_sparse, T_python))
+            self.assertTrue(np.allclose(T_api_sparse, T_python))
+            self.assertTrue(np.allclose(T_api_dense, T_python))
 
 if __name__ == '__main__':
     unittest.main()
-    
+

--- a/pyemma/msm/estimation/tests/test_mle_trev_given_pi.py
+++ b/pyemma/msm/estimation/tests/test_mle_trev_given_pi.py
@@ -8,21 +8,20 @@ from pyemma.msm.estimation.dense.transition_matrix import transition_matrix_reve
 from pyemma.msm.estimation import tmatrix as apicall
 
 class Test_mle_trev_given_pi(unittest.TestCase):
-    
+
     def setUp(self):
         self.eps = 1.0E-6
-    
+
     def test_mle_trev_given_pi(self):
-        for n in xrange(3,100):
-            C  = (1000*np.random.rand(n,n)).astype(int)
-            #print C
+        for n in xrange(3, 100, 5):
+            C = (1000*np.random.rand(n,n)).astype(int)
             pi = np.random.rand(n)
-            pi /= sum(pi)   
+            pi /= sum(pi)
 
             T_cython_dense = mtrgpd(C,pi,eps=self.eps)
             T_cython_sparse = mtrgps(scipy.sparse.csr_matrix(C),pi,eps=self.eps).toarray()
 
-            Cf  = C.astype(float)
+            Cf = C.astype(float)
             for i in xrange(n):
                 if Cf[i,i] == 0:
                     Cf[i,i] = self.eps
@@ -40,4 +39,4 @@ class Test_mle_trev_given_pi(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-    
+


### PR DESCRIPTION
range step size is now 5, to reduce number of input matrices
