### PR TITLE
Fix 32bit maxheap

### DIFF
--- a/pyemma/pyemma.cfg
+++ b/pyemma/pyemma.cfg
@@ -14,6 +14,7 @@ format = %%(asctime)s %%(name)-12s %%(levelname)-8s %%(message)s
 # ';' for Windows
 classpath = 
 initHeap = 32m
-maxHeap = 2000m
+# on 32 bit JVM default is 1280m, on 64 bit its 2000m
+maxHeap = 
 optionalArgs = 
 


### PR DESCRIPTION
pystallone fails to start on 32bit systems, because we're requesting to much heap space. This PR fixes this behaviour.
