### PR TITLE
[testing] use numpy.testing.assert_allclose for nicer error messages. 

### DIFF
--- a/pyemma/msm/analysis/dense/committor_test.py
+++ b/pyemma/msm/analysis/dense/committor_test.py
@@ -6,6 +6,7 @@ r"""Unit tests for the committor module
 
 import unittest
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 
 import committor
 
@@ -172,13 +173,13 @@ class TestCommittor(unittest.TestCase):
         P=self.bdc.transition_matrix()
         un=committor.forward_committor(P, [0, 1], [8, 9])
         u=self.bdc.committor_forward(1, 8)              
-        self.assertTrue(np.allclose(un, u))
+        assert_allclose(un, u)
 
     def test_backward_comittor(self):
         P=self.bdc.transition_matrix()
         un=committor.backward_committor(P, [0, 1], [8, 9])
         u=self.bdc.committor_backward(1, 8)        
-        self.assertTrue(np.allclose(un, u))
+        assert_allclose(un, u)
 
         
 

--- a/pyemma/msm/analysis/dense/correlations_test.py
+++ b/pyemma/msm/analysis/dense/correlations_test.py
@@ -5,6 +5,7 @@ Created on Jun 3, 2014
 '''
 import unittest
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 
 from committor_test import BirthDeathChain
 
@@ -128,7 +129,7 @@ class TestCorrelations(unittest.TestCase):
         
         result = correlations.time_relaxations_direct(self.T, p0, obs, times)
         
-        self.assertTrue(np.allclose(expected, result))
+        assert_allclose(expected, result)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/msm/analysis/dense/decomposition_test.py
+++ b/pyemma/msm/analysis/dense/decomposition_test.py
@@ -8,6 +8,7 @@ import unittest
 import warnings
 
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 
 from scipy.linalg import eig, eigvals
 
@@ -40,13 +41,13 @@ class TestDecomposition(unittest.TestCase):
         P=self.bdc.transition_matrix()
         mu=self.bdc.stationary_distribution()
         mun=stationary_distribution_from_eigenvector(P)
-        self.assertTrue(np.allclose(mu, mun))
+        assert_allclose(mu, mun)
 
     def test_statdist_iteration(self):
         P=self.bdc.transition_matrix()
         mu=self.bdc.stationary_distribution()
         mun=stationary_distribution_from_backward_iteration(P)
-        self.assertTrue(np.allclose(mu, mun))
+        assert_allclose(mu, mun)
 
     def test_eigenvalues(self):
         P=self.bdc.transition_matrix()
@@ -56,11 +57,11 @@ class TestDecomposition(unittest.TestCase):
         
         """k=None"""
         evn=eigenvalues(P)
-        self.assertTrue(np.allclose(ev, evn))
+        assert_allclose(ev, evn)
         
         """k is not None"""
         evn=eigenvalues(P, k=self.k)
-        self.assertTrue(np.allclose(ev[0:self.k], evn))
+        assert_allclose(ev[0:self.k], evn)
 
     def test_eigenvectors(self):
         P=self.bdc.transition_matrix()
@@ -71,17 +72,17 @@ class TestDecomposition(unittest.TestCase):
 
         """k=None"""
         Rn=eigenvectors(P)
-        self.assertTrue(np.allclose(R, Rn))
+        assert_allclose(R, Rn)
 
         Ln=eigenvectors(P, right=False)
-        self.assertTrue(np.allclose(L, Ln))
+        assert_allclose(L, Ln)
 
         """k is not None"""
         Rn=eigenvectors(P, k=self.k)
-        self.assertTrue(np.allclose(R[:,0:self.k], Rn))
+        assert_allclose(R[:,0:self.k], Rn)
 
         Ln=eigenvectors(P, right=False, k=self.k)
-        self.assertTrue(np.allclose(L[:,0:self.k], Ln))
+        assert_allclose(L[:,0:self.k], Ln)
 
     def test_rdl_decomposition(self):
         P=self.bdc.transition_matrix()
@@ -93,25 +94,25 @@ class TestDecomposition(unittest.TestCase):
         Rn, Dn, Ln=rdl_decomposition(P)        
         Xn=np.dot(Ln, Rn)
         """Right-eigenvectors"""
-        self.assertTrue(np.allclose(np.dot(P, Rn), np.dot(Rn, Dn)))
+        assert_allclose(np.dot(P, Rn), np.dot(Rn, Dn))
         """Left-eigenvectors"""
-        self.assertTrue(np.allclose(np.dot(Ln, P), np.dot(Dn, Ln)))
+        assert_allclose(np.dot(Ln, P), np.dot(Dn, Ln))
         """Orthonormality"""
-        self.assertTrue(np.allclose(Xn, np.eye(self.dim)))
+        assert_allclose(Xn, np.eye(self.dim))
         """Probability vector"""
-        self.assertTrue(np.allclose(np.sum(Ln[0,:]), 1.0))
+        assert_allclose(np.sum(Ln[0,:]), 1.0)
 
         """k is not None"""
         Rn, Dn, Ln=rdl_decomposition(P, k=self.k)        
         Xn=np.dot(Ln, Rn)               
         """Right-eigenvectors"""
-        self.assertTrue(np.allclose(np.dot(P, Rn), np.dot(Rn, Dn)))
+        assert_allclose(np.dot(P, Rn), np.dot(Rn, Dn))
         """Left-eigenvectors"""
-        self.assertTrue(np.allclose(np.dot(Ln, P), np.dot(Dn, Ln)))
+        assert_allclose(np.dot(Ln, P), np.dot(Dn, Ln))
         """Orthonormality"""
-        self.assertTrue(np.allclose(Xn, np.eye(self.k)))
+        assert_allclose(Xn, np.eye(self.k))
         """Probability vector"""
-        self.assertTrue(np.allclose(np.sum(Ln[0,:]), 1.0))
+        assert_allclose(np.sum(Ln[0,:]), 1.0)
 
         """Reversible"""
 
@@ -119,29 +120,29 @@ class TestDecomposition(unittest.TestCase):
         Rn, Dn, Ln=rdl_decomposition(P, norm='reversible')        
         Xn=np.dot(Ln, Rn)
         """Right-eigenvectors"""
-        self.assertTrue(np.allclose(np.dot(P, Rn), np.dot(Rn, Dn)))
+        assert_allclose(np.dot(P, Rn), np.dot(Rn, Dn))
         """Left-eigenvectors"""
-        self.assertTrue(np.allclose(np.dot(Ln, P), np.dot(Dn, Ln)))
+        assert_allclose(np.dot(Ln, P), np.dot(Dn, Ln))
         """Orthonormality"""
-        self.assertTrue(np.allclose(Xn, np.eye(self.dim)))
+        assert_allclose(Xn, np.eye(self.dim))
         """Probability vector"""
-        self.assertTrue(np.allclose(np.sum(Ln[0,:]), 1.0))   
+        assert_allclose(np.sum(Ln[0,:]), 1.0)   
         """Reversibility"""
-        self.assertTrue(np.allclose(Ln.transpose(), mu[:,np.newaxis]*Rn))
+        assert_allclose(Ln.transpose(), mu[:,np.newaxis]*Rn)
 
         """k is not None"""
         Rn, Dn, Ln=rdl_decomposition(P, norm='reversible', k=self.k)        
         Xn=np.dot(Ln, Rn)
         """Right-eigenvectors"""
-        self.assertTrue(np.allclose(np.dot(P, Rn), np.dot(Rn, Dn)))
+        assert_allclose(np.dot(P, Rn), np.dot(Rn, Dn))
         """Left-eigenvectors"""
-        self.assertTrue(np.allclose(np.dot(Ln, P), np.dot(Dn, Ln)))
+        assert_allclose(np.dot(Ln, P), np.dot(Dn, Ln))
         """Orthonormality"""
-        self.assertTrue(np.allclose(Xn, np.eye(self.k)))
+        assert_allclose(Xn, np.eye(self.k))
         """Probability vector"""
-        self.assertTrue(np.allclose(np.sum(Ln[0,:]), 1.0))   
+        assert_allclose(np.sum(Ln[0,:]), 1.0)   
         """Reversibility"""
-        self.assertTrue(np.allclose(Ln.transpose(), mu[:,np.newaxis]*Rn))
+        assert_allclose(Ln.transpose(), mu[:,np.newaxis]*Rn)
 
     def test_timescales(self):
         P=self.bdc.transition_matrix()
@@ -152,22 +153,22 @@ class TestDecomposition(unittest.TestCase):
 
         """k=None"""
         tsn=timescales(P)
-        self.assertTrue(np.allclose(ts[1:], tsn[1:]))
+        assert_allclose(ts[1:], tsn[1:])
 
         """k is not None"""
         tsn=timescales(P, k=self.k)
-        self.assertTrue(np.allclose(ts[1:self.k], tsn[1:]))
+        assert_allclose(ts[1:self.k], tsn[1:])
         
 
         """tau=7"""
         
         """k=None"""
         tsn=timescales(P, tau=7)
-        self.assertTrue(np.allclose(7*ts[1:], tsn[1:]))
+        assert_allclose(7*ts[1:], tsn[1:])
 
         """k is not None"""
         tsn=timescales(P, k=self.k, tau=7)
-        self.assertTrue(np.allclose(7*ts[1:self.k], tsn[1:]))
+        assert_allclose(7*ts[1:self.k], tsn[1:])
 
 class TestTimescales(unittest.TestCase):
     
@@ -184,7 +185,7 @@ class TestTimescales(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             tsn=timescales(self.W)
-            self.assertTrue(np.allclose(tsn, ts))
+            assert_allclose(tsn, ts)
             assert issubclass(w[-1].category, SpectralWarning)
 
     def test_timescales_2(self):
@@ -194,7 +195,7 @@ class TestTimescales(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             tsn=timescales(0.5*self.T+0.5*self.P)
-            self.assertTrue(np.allclose(tsn, ts))
+            assert_allclose(tsn, ts)
             assert issubclass(w[-1].category, ImaginaryEigenValueWarning)        
         
 if __name__=="__main__":

--- a/pyemma/msm/analysis/dense/expectations_test.py
+++ b/pyemma/msm/analysis/dense/expectations_test.py
@@ -6,6 +6,7 @@ r"""This module provides unit tests for the expectations module
 
 import unittest
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 from scipy.linalg import eig
 
 import expectations
@@ -39,7 +40,7 @@ class TestExpectedCounts(unittest.TestCase):
         be carried out by a simple multiplication
         """        
         EC_true=N*self.mu[:,np.newaxis]*T
-        self.assertTrue(np.allclose(EC_true, EC_n))
+        assert_allclose(EC_true, EC_n)
 
         N=2000
         EC_n=expectations.expected_counts(p0, T, N)
@@ -49,13 +50,13 @@ class TestExpectedCounts(unittest.TestCase):
         be carried out by a simple multiplication
         """        
         EC_true=N*self.mu[:,np.newaxis]*T
-        self.assertTrue(np.allclose(EC_true, EC_n))
+        assert_allclose(EC_true, EC_n)
 
         """Zero length chain"""
         N=0
         EC_n=expectations.expected_counts(p0, T, N)
         EC_true=np.zeros(T.shape)
-        self.assertTrue(np.allclose(EC_true, EC_n))
+        assert_allclose(EC_true, EC_n)
 
 class TestExpectedCountsStationary(unittest.TestCase):
     def setUp(self):
@@ -81,12 +82,12 @@ class TestExpectedCountsStationary(unittest.TestCase):
         """Compute mu on the fly"""
         EC_n=expectations.expected_counts_stationary(T, N)
         EC_true=N*self.mu[:,np.newaxis]*T
-        self.assertTrue(np.allclose(EC_true, EC_n))
+        assert_allclose(EC_true, EC_n)
 
         """Use precomputed mu"""
         EC_n=expectations.expected_counts_stationary(T, N, mu=self.mu)
         EC_true=N*self.mu[:,np.newaxis]*T
-        self.assertTrue(np.allclose(EC_true, EC_n))
+        assert_allclose(EC_true, EC_n)
     
         
 
@@ -120,13 +121,13 @@ class TestEcMatrixVector(unittest.TestCase):
         be carried out by a simple multiplication
         """        
         EC_true=N*self.mu[:,np.newaxis]*T
-        self.assertTrue(np.allclose(EC_true, EC_n))
+        assert_allclose(EC_true, EC_n)
 
         """Zero length chain"""
         N=0
         EC_n=expectations.ec_matrix_vector(p0, T, N)
         EC_true=np.zeros(T.shape)
-        self.assertTrue(np.allclose(EC_true, EC_n))
+        assert_allclose(EC_true, EC_n)
 
 class TestEcGeometricSeries(unittest.TestCase):
     def setUp(self):
@@ -158,13 +159,13 @@ class TestEcGeometricSeries(unittest.TestCase):
         be carried out by a simple multiplication
         """        
         EC_true=N*self.mu[:,np.newaxis]*T
-        self.assertTrue(np.allclose(EC_true, EC_n))
+        assert_allclose(EC_true, EC_n)
 
         """Zero length chain"""
         N=0
         EC_n=expectations.ec_geometric_series(p0, T, N)
         EC_true=np.zeros(T.shape)
-        self.assertTrue(np.allclose(EC_true, EC_n))
+        assert_allclose(EC_true, EC_n)
 
 class TestGeometricSeries(unittest.TestCase):
     def setUp(self):
@@ -186,10 +187,10 @@ class TestGeometricSeries(unittest.TestCase):
 
     def test_geometric_series(self):
         x=expectations.geometric_series(self.q, self.n)     
-        self.assertTrue(np.allclose(x, self.s))
+        assert_allclose(x, self.s)
 
         x=expectations.geometric_series(self.q_array, self.n)        
-        self.assertTrue(np.allclose(x, self.s_array))
+        assert_allclose(x, self.s_array)
 
         """Assert ValueError for negative n"""
         with self.assertRaises(ValueError):

--- a/pyemma/msm/analysis/dense/fingerprints_test.py
+++ b/pyemma/msm/analysis/dense/fingerprints_test.py
@@ -7,6 +7,7 @@ r"""Unit test for the fingerprint module
 import unittest
 
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 
 from decomposition import rdl_decomposition, timescales
 
@@ -69,54 +70,54 @@ class TestFingerprint(unittest.TestCase):
         """k=None, tau=1"""
         acorr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L,self.obs1)
         tsn, acorr_ampn=fingerprint_correlation(self.T, self.obs1)
-        self.assertTrue(np.allclose(tsn, self.ts))
-        self.assertTrue(np.allclose(acorr_ampn, acorr_amp))
+        assert_allclose(tsn, self.ts)
+        assert_allclose(acorr_ampn, acorr_amp)
 
         """k=None, tau=7.5"""
         tau=self.tau
         tsn, acorr_ampn=fingerprint_correlation(self.T, self.obs1, tau=tau)
-        self.assertTrue(np.allclose(tsn, tau*self.ts))
-        self.assertTrue(np.allclose(acorr_ampn, acorr_amp))
+        assert_allclose(tsn, tau*self.ts)
+        assert_allclose(acorr_ampn, acorr_amp)
 
         """k=4, tau=1"""
         k=self.k
         acorr_amp=np.dot(self.mu*self.obs1, self.R[:,0:k])*np.dot(self.L[0:k,:],self.obs1)
         tsn, acorr_ampn=fingerprint_correlation(self.T, self.obs1, k=k)
-        self.assertTrue(np.allclose(tsn, self.ts[0:k]))
-        self.assertTrue(np.allclose(acorr_ampn, acorr_amp))
+        assert_allclose(tsn, self.ts[0:k])
+        assert_allclose(acorr_ampn, acorr_amp)
 
         """k=4, tau=7.5"""
         tau=self.tau
         tsn, acorr_ampn=fingerprint_correlation(self.T, self.obs1, k=k, tau=tau)
-        self.assertTrue(np.allclose(tsn, tau*self.ts[0:k]))
-        self.assertTrue(np.allclose(acorr_ampn, acorr_amp))
+        assert_allclose(tsn, tau*self.ts[0:k])
+        assert_allclose(acorr_ampn, acorr_amp)
 
         """Cross-correlation"""
 
         """k=None, tau=1"""
         corr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L,self.obs2)
         tsn, corr_ampn=fingerprint_correlation(self.T, self.obs1, obs2=self.obs2)
-        self.assertTrue(np.allclose(tsn, self.ts))
-        self.assertTrue(np.allclose(corr_ampn, corr_amp))
+        assert_allclose(tsn, self.ts)
+        assert_allclose(corr_ampn, corr_amp)
 
         """k=None, tau=7.5"""
         tau=self.tau
         tsn, corr_ampn=fingerprint_correlation(self.T, self.obs1, obs2=self.obs2, tau=tau)
-        self.assertTrue(np.allclose(tsn, tau*self.ts))
-        self.assertTrue(np.allclose(corr_ampn, corr_amp))
+        assert_allclose(tsn, tau*self.ts)
+        assert_allclose(corr_ampn, corr_amp)
 
         """k=4, tau=1"""
         k=self.k
         corr_amp=np.dot(self.mu*self.obs1, self.R[:,0:k])*np.dot(self.L[0:k,:],self.obs2)
         tsn, corr_ampn=fingerprint_correlation(self.T, self.obs1, obs2=self.obs2, k=k)
-        self.assertTrue(np.allclose(tsn, self.ts[0:k]))
-        self.assertTrue(np.allclose(corr_ampn, corr_amp))
+        assert_allclose(tsn, self.ts[0:k])
+        assert_allclose(corr_ampn, corr_amp)
 
         """k=4, tau=7.5"""
         tau=self.tau
         tsn, corr_ampn=fingerprint_correlation(self.T, self.obs1, obs2=self.obs2, k=k, tau=tau)
-        self.assertTrue(np.allclose(tsn, tau*self.ts[0:k]))
-        self.assertTrue(np.allclose(corr_ampn, corr_amp))
+        assert_allclose(tsn, tau*self.ts[0:k])
+        assert_allclose(corr_ampn, corr_amp)
 
     def test_fingerprint_relaxation(self):
         one_vec=np.ones(self.T.shape[0])
@@ -124,29 +125,29 @@ class TestFingerprint(unittest.TestCase):
         """k=None"""
         relax_amp=np.dot(self.p0, self.R)*np.dot(self.L, self.obs1)
         tsn, relax_ampn=fingerprint_relaxation(self.T, self.p0, self.obs1)        
-        self.assertTrue(np.allclose(tsn, self.ts))
-        self.assertTrue(np.allclose(relax_ampn, relax_amp))        
+        assert_allclose(tsn, self.ts)
+        assert_allclose(relax_ampn, relax_amp)        
 
         """k=4"""
         k=self.k
         relax_amp=np.dot(self.p0, self.R[:,0:k])*np.dot(self.L[0:k,:], self.obs1)
         tsn, relax_ampn=fingerprint_relaxation(self.T, self.p0, self.obs1, k=k)        
-        self.assertTrue(np.allclose(tsn, self.ts[0:k]))        
-        self.assertTrue(np.allclose(relax_ampn, relax_amp))        
+        assert_allclose(tsn, self.ts[0:k])        
+        assert_allclose(relax_ampn, relax_amp)        
 
     def test_fingerprint(self):
         """k=None"""
         amp=np.dot(self.p0*self.obs1, self.R)*np.dot(self.L, self.obs2)
         tsn, ampn=fingerprint(self.T, self.obs1, obs2=self.obs2, p0=self.p0)
-        self.assertTrue(np.allclose(tsn, self.ts))
-        self.assertTrue(np.allclose(ampn, amp))        
+        assert_allclose(tsn, self.ts)
+        assert_allclose(ampn, amp)        
 
         """k=4"""
         k=self.k
         amp=np.dot(self.p0*self.obs1, self.R[:,0:k])*np.dot(self.L[0:k,:], self.obs2)
         tsn, ampn=fingerprint(self.T, self.obs1, obs2=self.obs2, p0=self.p0, k=k)
-        self.assertTrue(np.allclose(tsn, self.ts[0:k]))
-        self.assertTrue(np.allclose(ampn, amp))  
+        assert_allclose(tsn, self.ts[0:k])
+        assert_allclose(ampn, amp)  
 
 ################################################################################
 # Expectation
@@ -175,7 +176,7 @@ class TestExpectation(unittest.TestCase):
     def test_expectation(self):
         exp=np.dot(self.mu, self.obs1)
         expn=expectation(self.T, self.obs1)
-        self.assertTrue(np.allclose(exp, expn))
+        assert_allclose(exp, expn)
 
 ################################################################################
 # Correlation
@@ -223,14 +224,14 @@ class TestCorrelation(unittest.TestCase):
         acorr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L, self.obs1)
         acorr=np.dot(self.ev_t, acorr_amp)
         acorrn=correlation_decomp(self.T, self.obs1, times=self.times)
-        self.assertTrue(np.allclose(acorrn, acorr))
+        assert_allclose(acorrn, acorr)
 
         """k=4"""
         k=self.k
         acorr_amp=np.dot(self.mu*self.obs1, self.R[:,0:k])*np.dot(self.L[0:k,:], self.obs1)
         acorr=np.dot(self.ev_t[:,0:k], acorr_amp)
         acorrn=correlation_decomp(self.T, self.obs1, times=self.times, k=k)
-        self.assertTrue(np.allclose(acorrn, acorr))              
+        assert_allclose(acorrn, acorr)              
     
         """Cross-correlation"""
 
@@ -238,27 +239,27 @@ class TestCorrelation(unittest.TestCase):
         corr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L, self.obs2)
         corr=np.dot(self.ev_t, corr_amp)    
         corrn=correlation_decomp(self.T, self.obs1, obs2=self.obs2, times=self.times)
-        self.assertTrue(np.allclose(corrn, corr))
+        assert_allclose(corrn, corr)
 
         """k=4"""
         k=self.k
         corr_amp=np.dot(self.mu*self.obs1, self.R[:,0:k])*np.dot(self.L[0:k,:], self.obs2)
         corr=np.dot(self.ev_t[:,0:k], corr_amp)
         corrn=correlation_decomp(self.T, self.obs1, obs2=self.obs2, times=self.times, k=k)
-        self.assertTrue(np.allclose(corrn, corr))
+        assert_allclose(corrn, corr)
 
     def test_correlation_matvec(self):
         """Auto-correlation"""
         acorr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L, self.obs1)
         acorr=np.dot(self.ev_t, acorr_amp)
         acorrn=correlation_matvec(self.T, self.obs1, times=self.times)
-        self.assertTrue(np.allclose(acorrn, acorr))
+        assert_allclose(acorrn, acorr)
     
         """Cross-correlation"""
         corr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L, self.obs2)
         corr=np.dot(self.ev_t, corr_amp)    
         corrn=correlation_matvec(self.T, self.obs1, obs2=self.obs2, times=self.times)
-        self.assertTrue(np.allclose(corrn, corr))
+        assert_allclose(corrn, corr)
 
     def test_correlation(self):
         """Auto-correlation"""
@@ -267,14 +268,14 @@ class TestCorrelation(unittest.TestCase):
         acorr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L, self.obs1)
         acorr=np.dot(self.ev_t, acorr_amp)
         acorrn=correlation(self.T, self.obs1, times=self.times)
-        self.assertTrue(np.allclose(acorrn, acorr))
+        assert_allclose(acorrn, acorr)
 
         """k=4"""
         k=self.k
         acorr_amp=np.dot(self.mu*self.obs1, self.R[:,0:k])*np.dot(self.L[0:k,:], self.obs1)
         acorr=np.dot(self.ev_t[:,0:k], acorr_amp)
         acorrn=correlation(self.T, self.obs1, times=self.times, k=k)
-        self.assertTrue(np.allclose(acorrn, acorr))              
+        assert_allclose(acorrn, acorr)              
     
         """Cross-correlation"""
 
@@ -282,14 +283,14 @@ class TestCorrelation(unittest.TestCase):
         corr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L, self.obs2)
         corr=np.dot(self.ev_t, corr_amp)    
         corrn=correlation(self.T, self.obs1, obs2=self.obs2, times=self.times)
-        self.assertTrue(np.allclose(corrn, corr))
+        assert_allclose(corrn, corr)
 
         """k=4"""
         k=self.k
         corr_amp=np.dot(self.mu*self.obs1, self.R[:,0:k])*np.dot(self.L[0:k,:], self.obs2)
         corr=np.dot(self.ev_t[:,0:k], corr_amp)
         corrn=correlation(self.T, self.obs1, obs2=self.obs2, times=self.times, k=k)
-        self.assertTrue(np.allclose(corrn, corr))   
+        assert_allclose(corrn, corr)   
 
 ################################################################################
 # Relaxation
@@ -337,35 +338,35 @@ class TestRelaxation(unittest.TestCase):
         relax_amp=np.dot(self.p0, self.R)*np.dot(self.L, self.obs)
         relax=np.dot(self.ev_t, relax_amp)        
         relaxn=relaxation_decomp(self.T, self.p0, self.obs, times=self.times)        
-        self.assertTrue(np.allclose(relaxn, relax))        
+        assert_allclose(relaxn, relax)        
         
         """k=4"""
         k=self.k
         relax_amp=np.dot(self.p0, self.R[:,0:k])*np.dot(self.L[0:k,:], self.obs)
         relax=np.dot(self.ev_t[:,0:k], relax_amp)        
         relaxn=relaxation_decomp(self.T, self.p0, self.obs, k=k, times=self.times) 
-        self.assertTrue(np.allclose(relaxn, relax))               
+        assert_allclose(relaxn, relax)               
 
     def test_relaxation_matvec(self):        
         """k=None"""
         relax_amp=np.dot(self.p0, self.R)*np.dot(self.L, self.obs)
         relax=np.dot(self.ev_t, relax_amp)        
         relaxn=relaxation_matvec(self.T, self.p0, self.obs, times=self.times)        
-        self.assertTrue(np.allclose(relaxn, relax))               
+        assert_allclose(relaxn, relax)               
 
     def test_relaxation(self):        
         """k=None"""
         relax_amp=np.dot(self.p0, self.R)*np.dot(self.L, self.obs)
         relax=np.dot(self.ev_t, relax_amp)        
         relaxn=relaxation(self.T, self.p0, self.obs, times=self.times)        
-        self.assertTrue(np.allclose(relaxn, relax))        
+        assert_allclose(relaxn, relax)        
         
         """k=4"""
         k=self.k
         relax_amp=np.dot(self.p0, self.R[:,0:k])*np.dot(self.L[0:k,:], self.obs)
         relax=np.dot(self.ev_t[:,0:k], relax_amp)        
         relaxn=relaxation(self.T, self.p0, self.obs, k=k, times=self.times) 
-        self.assertTrue(np.allclose(relaxn, relax))
+        assert_allclose(relaxn, relax)
 
 ################################################################################
 # Helper functions
@@ -382,15 +383,15 @@ class TestPropagate(unittest.TestCase):
 
         yn=propagate(A, x, 1)
         y=np.dot(A, x)
-        self.assertTrue(np.allclose(yn, y))
+        assert_allclose(yn, y)
         
         yn=propagate(A, x, 2)
         y=np.dot(A, np.dot(A, x))
-        self.assertTrue(np.allclose(yn, y))
+        assert_allclose(yn, y)
 
         yn=propagate(A, x, 100)
         y=np.dot(np.linalg.matrix_power(A, 100), x)
-        self.assertTrue(np.allclose(yn, y))
+        assert_allclose(yn, y)
         
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/msm/analysis/dense/mean_first_passage_time_test.py
+++ b/pyemma/msm/analysis/dense/mean_first_passage_time_test.py
@@ -6,6 +6,7 @@ r"""Unit tests for the mean first passage time module
 import unittest
 
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 
 from mean_first_passage_time import mfpt
 
@@ -32,13 +33,13 @@ class TestMfpt(unittest.TestCase):
 
     def test_mfpt(self):
         x=mfpt(self.P, 0)
-        self.assertTrue(np.allclose(x, self.m0))
+        assert_allclose(x, self.m0)
 
         x=mfpt(self.P, 1)
-        self.assertTrue(np.allclose(x, self.m1))
+        assert_allclose(x, self.m1)
 
         x=mfpt(self.P, 2)
-        self.assertTrue(np.allclose(x, self.m2))
+        assert_allclose(x, self.m2)
         
 if __name__=="__main__":
     unittest.main()

--- a/pyemma/msm/analysis/dense/sensitivity_test.py
+++ b/pyemma/msm/analysis/dense/sensitivity_test.py
@@ -11,6 +11,7 @@ against numerical differentiation results.
 
 import unittest
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 
 from sensitivity import timescale_sensitivity, eigenvalue_sensitivity, mfpt_sensitivity,\
     forward_committor_sensitivity, backward_committor_sensitivity, eigenvector_sensitivity,\
@@ -114,46 +115,46 @@ class TestExpectations(unittest.TestCase):
 
     def test_eigenvalue_sensitivity(self):
                 
-        self.assertTrue(np.allclose(eigenvalue_sensitivity(self.T,0), self.S0))      
-        self.assertTrue(np.allclose(eigenvalue_sensitivity(self.T,1), self.S1))      
+        assert_allclose(eigenvalue_sensitivity(self.T,0), self.S0)      
+        assert_allclose(eigenvalue_sensitivity(self.T,1), self.S1)      
         
     def test_timescale_sensitivity(self):
                     
-        self.assertTrue(np.allclose(timescale_sensitivity(self.T,1), self.TS1))   
+        assert_allclose(timescale_sensitivity(self.T,1), self.TS1)   
         
     def test_forward_committor_sensitivity(self):
             
-        self.assertTrue(np.allclose(forward_committor_sensitivity(self.T4, [0], [3], 0), self.S4zero))      
-        self.assertTrue(np.allclose(forward_committor_sensitivity(self.T4, [0], [3], 1), self.qS41))      
-        self.assertTrue(np.allclose(forward_committor_sensitivity(self.T4, [0], [3], 2), self.qS42))      
-        self.assertTrue(np.allclose(forward_committor_sensitivity(self.T4, [0], [3], 3), self.S4zero))      
+        assert_allclose(forward_committor_sensitivity(self.T4, [0], [3], 0), self.S4zero)      
+        assert_allclose(forward_committor_sensitivity(self.T4, [0], [3], 1), self.qS41)      
+        assert_allclose(forward_committor_sensitivity(self.T4, [0], [3], 2), self.qS42)      
+        assert_allclose(forward_committor_sensitivity(self.T4, [0], [3], 3), self.S4zero)      
 
     def test_backward_committor_sensitivity(self):
         
-        self.assertTrue(np.allclose(backward_committor_sensitivity(self.T4, [0], [3], 1), self.qSI41))      
+        assert_allclose(backward_committor_sensitivity(self.T4, [0], [3], 1), self.qSI41)      
                 
     def test_mfpt_sensitivity(self):
         
-        self.assertTrue(np.allclose(mfpt_sensitivity(self.T4, 0, 0), self.S4zero))    
-        self.assertTrue(np.allclose(mfpt_sensitivity(self.T4, 0, 1), self.mS01))      
-        self.assertTrue(np.allclose(mfpt_sensitivity(self.T4, 0, 2), self.mS02))      
-        self.assertTrue(np.allclose(mfpt_sensitivity(self.T4, 3, 2), self.mS32))  
+        assert_allclose(mfpt_sensitivity(self.T4, 0, 0), self.S4zero)    
+        assert_allclose(mfpt_sensitivity(self.T4, 0, 1), self.mS01)      
+        assert_allclose(mfpt_sensitivity(self.T4, 0, 2), self.mS02)      
+        assert_allclose(mfpt_sensitivity(self.T4, 3, 2), self.mS32)  
         
     def test_eigenvector_sensitivity(self):
-        self.assertTrue(np.allclose(eigenvector_sensitivity(self.T4, 1 , 1), self.mV11, atol=1e-5))      
-        self.assertTrue(np.allclose(eigenvector_sensitivity(self.T4, 2 , 2), self.mV22, atol=1e-5))      
-        self.assertTrue(np.allclose(eigenvector_sensitivity(self.T4, 0 , 3), self.mV03, atol=1e-5))  
+        assert_allclose(eigenvector_sensitivity(self.T4, 1 , 1), self.mV11, atol=1e-5)      
+        assert_allclose(eigenvector_sensitivity(self.T4, 2 , 2), self.mV22, atol=1e-5)      
+        assert_allclose(eigenvector_sensitivity(self.T4, 0 , 3), self.mV03, atol=1e-5)  
                 
-        self.assertTrue(np.allclose(eigenvector_sensitivity(self.T4, 0 , 1, right=False), self.mV01left, atol=1e-5))   
+        assert_allclose(eigenvector_sensitivity(self.T4, 0 , 1, right=False), self.mV01left, atol=1e-5)   
                  
     def test_stationary_sensitivity(self):    
-        self.assertTrue(np.allclose(stationary_distribution_sensitivity(self.T4, 1), self.pS1, atol=1e-5))      
+        assert_allclose(stationary_distribution_sensitivity(self.T4, 1), self.pS1, atol=1e-5)      
 
     def test_expectation_sensitivity(self):
         a=np.array([0.0, 3.0, 0.0, 0.0])
         S=3.0*self.pS1
         Sn=expectation_sensitivity(self.T4, a)
-        self.assertTrue(np.allclose(Sn, S))
+        assert_allclose(Sn, S)
         
         
         

--- a/pyemma/msm/analysis/sparse/committor_test.py
+++ b/pyemma/msm/analysis/sparse/committor_test.py
@@ -5,6 +5,7 @@ r"""Unit tests for the committor module
 """
 import unittest
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 
 from scipy.sparse import diags
 
@@ -188,13 +189,13 @@ class TestCommittor(unittest.TestCase):
         P=self.bdc.transition_matrix_sparse()
         un=committor.forward_committor(P, range(10), range(90,100))
         u=self.bdc.committor_forward(9, 90)               
-        self.assertTrue(np.allclose(un, u))
+        assert_allclose(un, u)
 
     def test_backward_comittor(self):
         P=self.bdc.transition_matrix_sparse()
         un=committor.backward_committor(P, range(10), range(90,100))
         u=self.bdc.committor_backward(9, 90)               
-        self.assertTrue(np.allclose(un, u))
+        assert_allclose(un, u)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/msm/analysis/sparse/decomposition_test.py
+++ b/pyemma/msm/analysis/sparse/decomposition_test.py
@@ -7,6 +7,7 @@ import unittest
 import warnings
 
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 
 from scipy.linalg import eig, eigvals
 from scipy.sparse import csr_matrix
@@ -41,13 +42,13 @@ class TestDecomposition(unittest.TestCase):
         P=self.bdc.transition_matrix_sparse()
         mu=self.bdc.stationary_distribution()
         mun=stationary_distribution_from_eigenvector(P, ncv=self.ncv)
-        self.assertTrue(np.allclose(mu, mun))
+        assert_allclose(mu, mun)
 
     def test_statdist_iteration(self):
         P=self.bdc.transition_matrix_sparse()
         mu=self.bdc.stationary_distribution()
         mun=stationary_distribution_from_backward_iteration(P)
-        self.assertTrue(np.allclose(mu, mun))
+        assert_allclose(mu, mun)
 
     def test_eigenvalues(self):
         P=self.bdc.transition_matrix()
@@ -62,11 +63,11 @@ class TestDecomposition(unittest.TestCase):
         
         """k is not None"""
         evn=eigenvalues(P, k=self.k)
-        self.assertTrue(np.allclose(ev[0:self.k], evn))
+        assert_allclose(ev[0:self.k], evn)
 
         """k is not None and ncv is not None"""
         evn=eigenvalues(P, k=self.k, ncv=self.ncv)
-        self.assertTrue(np.allclose(ev[0:self.k], evn))
+        assert_allclose(ev[0:self.k], evn)
 
     def test_eigenvectors(self):
         P_dense=self.bdc.transition_matrix()
@@ -87,17 +88,17 @@ class TestDecomposition(unittest.TestCase):
 
         """k is not None"""
         Rn=eigenvectors(P, k=self.k)        
-        self.assertTrue(np.allclose(vals[np.newaxis,:]*Rn, P.dot(Rn)))
+        assert_allclose(vals[np.newaxis,:]*Rn, P.dot(Rn))
 
         Ln=eigenvectors(P, right=False, k=self.k)
-        self.assertTrue(np.allclose(P.transpose().dot(Ln), vals[np.newaxis,:]*Ln))
+        assert_allclose(P.transpose().dot(Ln), vals[np.newaxis,:]*Ln)
 
         """k is not None and ncv is not None"""
         Rn=eigenvectors(P, k=self.k, ncv=self.ncv)        
-        self.assertTrue(np.allclose(vals[np.newaxis,:]*Rn, P.dot(Rn)))
+        assert_allclose(vals[np.newaxis,:]*Rn, P.dot(Rn))
 
         Ln=eigenvectors(P, right=False, k=self.k, ncv=self.ncv)
-        self.assertTrue(np.allclose(P.transpose().dot(Ln), vals[np.newaxis,:]*Ln))
+        assert_allclose(P.transpose().dot(Ln), vals[np.newaxis,:]*Ln)
 
     def test_rdl_decomposition(self):
         P=self.bdc.transition_matrix_sparse()
@@ -113,25 +114,25 @@ class TestDecomposition(unittest.TestCase):
         Rn, Dn, Ln=rdl_decomposition(P, k=self.k)        
         Xn=np.dot(Ln, Rn)
         """Right-eigenvectors"""
-        self.assertTrue(np.allclose(P.dot(Rn), np.dot(Rn, Dn)))    
+        assert_allclose(P.dot(Rn), np.dot(Rn, Dn))    
         """Left-eigenvectors"""
-        self.assertTrue(np.allclose(P.transpose().dot(Ln.transpose()).transpose(), np.dot(Dn, Ln)))               
+        assert_allclose(P.transpose().dot(Ln.transpose()).transpose(), np.dot(Dn, Ln))               
         """Orthonormality"""
-        self.assertTrue(np.allclose(Xn, np.eye(self.k)))
+        assert_allclose(Xn, np.eye(self.k))
         """Probability vector"""
-        self.assertTrue(np.allclose(np.sum(Ln[0,:]), 1.0))
+        assert_allclose(np.sum(Ln[0,:]), 1.0)
 
         """k is not None, ncv is not None"""
         Rn, Dn, Ln=rdl_decomposition(P, k=self.k, ncv=self.ncv)        
         Xn=np.dot(Ln, Rn)
         """Right-eigenvectors"""
-        self.assertTrue(np.allclose(P.dot(Rn), np.dot(Rn, Dn)))    
+        assert_allclose(P.dot(Rn), np.dot(Rn, Dn))    
         """Left-eigenvectors"""
-        self.assertTrue(np.allclose(P.transpose().dot(Ln.transpose()).transpose(), np.dot(Dn, Ln)))               
+        assert_allclose(P.transpose().dot(Ln.transpose()).transpose(), np.dot(Dn, Ln))               
         """Orthonormality"""
-        self.assertTrue(np.allclose(Xn, np.eye(self.k)))
+        assert_allclose(Xn, np.eye(self.k))
         """Probability vector"""
-        self.assertTrue(np.allclose(np.sum(Ln[0,:]), 1.0))
+        assert_allclose(np.sum(Ln[0,:]), 1.0)
 
         """Reversible"""
 
@@ -143,29 +144,29 @@ class TestDecomposition(unittest.TestCase):
         Rn, Dn, Ln=rdl_decomposition(P, k=self.k, norm='reversible')        
         Xn=np.dot(Ln, Rn)
         """Right-eigenvectors"""
-        self.assertTrue(np.allclose(P.dot(Rn), np.dot(Rn, Dn)))    
+        assert_allclose(P.dot(Rn), np.dot(Rn, Dn))    
         """Left-eigenvectors"""
-        self.assertTrue(np.allclose(P.transpose().dot(Ln.transpose()).transpose(), np.dot(Dn, Ln)))               
+        assert_allclose(P.transpose().dot(Ln.transpose()).transpose(), np.dot(Dn, Ln))               
         """Orthonormality"""
-        self.assertTrue(np.allclose(Xn, np.eye(self.k)))
+        assert_allclose(Xn, np.eye(self.k))
         """Probability vector"""
-        self.assertTrue(np.allclose(np.sum(Ln[0,:]), 1.0))
+        assert_allclose(np.sum(Ln[0,:]), 1.0)
         """Reversibility"""
-        self.assertTrue(np.allclose(Ln.transpose(), mu[:,np.newaxis]*Rn))
+        assert_allclose(Ln.transpose(), mu[:,np.newaxis]*Rn)
 
         """k is not None ncv is not None"""
         Rn, Dn, Ln=rdl_decomposition(P, k=self.k, norm='reversible', ncv=self.ncv)        
         Xn=np.dot(Ln, Rn)
         """Right-eigenvectors"""
-        self.assertTrue(np.allclose(P.dot(Rn), np.dot(Rn, Dn)))    
+        assert_allclose(P.dot(Rn), np.dot(Rn, Dn))    
         """Left-eigenvectors"""
-        self.assertTrue(np.allclose(P.transpose().dot(Ln.transpose()).transpose(), np.dot(Dn, Ln)))               
+        assert_allclose(P.transpose().dot(Ln.transpose()).transpose(), np.dot(Dn, Ln))               
         """Orthonormality"""
-        self.assertTrue(np.allclose(Xn, np.eye(self.k)))
+        assert_allclose(Xn, np.eye(self.k))
         """Probability vector"""
-        self.assertTrue(np.allclose(np.sum(Ln[0,:]), 1.0))
+        assert_allclose(np.sum(Ln[0,:]), 1.0)
         """Reversibility"""
-        self.assertTrue(np.allclose(Ln.transpose(), mu[:,np.newaxis]*Rn))
+        assert_allclose(Ln.transpose(), mu[:,np.newaxis]*Rn)
 
     def test_timescales(self):
         P_dense=self.bdc.transition_matrix()
@@ -181,18 +182,18 @@ class TestDecomposition(unittest.TestCase):
 
         """k is not None"""
         tsn=timescales(P, k=self.k)
-        self.assertTrue(np.allclose(ts[1:self.k], tsn[1:]))
+        assert_allclose(ts[1:self.k], tsn[1:])
 
         """k is not None, ncv is not None"""
         tsn=timescales(P, k=self.k, ncv=self.ncv)
-        self.assertTrue(np.allclose(ts[1:self.k], tsn[1:]))
+        assert_allclose(ts[1:self.k], tsn[1:])
         
 
         """tau=7"""      
 
         """k is not None"""
         tsn=timescales(P, k=self.k, tau=7)
-        self.assertTrue(np.allclose(7*ts[1:self.k], tsn[1:]))
+        assert_allclose(7*ts[1:self.k], tsn[1:])
 
 if __name__=="__main__":
     unittest.main()

--- a/pyemma/msm/analysis/sparse/fingerprints_test.py
+++ b/pyemma/msm/analysis/sparse/fingerprints_test.py
@@ -7,6 +7,7 @@ r"""Unit test for the fingerprint module
 import unittest
 
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 
 from decomposition import rdl_decomposition, timescales
 
@@ -65,14 +66,14 @@ class TestFingerprint(unittest.TestCase):
         k=self.k
         acorr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L,self.obs1)
         tsn, acorr_ampn=fingerprint_correlation(self.T, self.obs1, k=k)
-        self.assertTrue(np.allclose(tsn, self.ts))
-        self.assertTrue(np.allclose(acorr_ampn, acorr_amp))
+        assert_allclose(tsn, self.ts)
+        assert_allclose(acorr_ampn, acorr_amp)
 
         """k=4, tau=7.5"""
         tau=self.tau
         tsn, acorr_ampn=fingerprint_correlation(self.T, self.obs1, k=k, tau=tau)
-        self.assertTrue(np.allclose(tsn, tau*self.ts))
-        self.assertTrue(np.allclose(acorr_ampn, acorr_amp))
+        assert_allclose(tsn, tau*self.ts)
+        assert_allclose(acorr_ampn, acorr_amp)
 
         """Cross-correlation"""
 
@@ -80,29 +81,29 @@ class TestFingerprint(unittest.TestCase):
         k=self.k
         corr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L,self.obs2)
         tsn, corr_ampn=fingerprint_correlation(self.T, self.obs1, obs2=self.obs2, k=k)
-        self.assertTrue(np.allclose(tsn, self.ts))
-        self.assertTrue(np.allclose(corr_ampn, corr_amp))
+        assert_allclose(tsn, self.ts)
+        assert_allclose(corr_ampn, corr_amp)
 
         """k=4, tau=7.5"""
         tau=self.tau
         tsn, corr_ampn=fingerprint_correlation(self.T, self.obs1, obs2=self.obs2, k=k, tau=tau)
-        self.assertTrue(np.allclose(tsn, tau*self.ts))
-        self.assertTrue(np.allclose(corr_ampn, corr_amp))
+        assert_allclose(tsn, tau*self.ts)
+        assert_allclose(corr_ampn, corr_amp)
 
     def test_fingerprint_relaxation(self):
         one_vec=np.ones(self.T.shape[0])
 
         relax_amp=np.dot(self.p0, self.R)*np.dot(self.L, self.obs1)
         tsn, relax_ampn=fingerprint_relaxation(self.T, self.p0, self.obs1, k=self.k)        
-        self.assertTrue(np.allclose(tsn, self.ts))
-        self.assertTrue(np.allclose(relax_ampn, relax_amp))        
+        assert_allclose(tsn, self.ts)
+        assert_allclose(relax_ampn, relax_amp)        
 
     def test_fingerprint(self):
         k=self.k
         amp=np.dot(self.p0*self.obs1, self.R)*np.dot(self.L, self.obs2)
         tsn, ampn=fingerprint(self.T, self.obs1, obs2=self.obs2, p0=self.p0, k=k)
-        self.assertTrue(np.allclose(tsn, self.ts))
-        self.assertTrue(np.allclose(ampn, amp))       
+        assert_allclose(tsn, self.ts)
+        assert_allclose(ampn, amp)       
 
 ################################################################################
 # Correlation
@@ -149,7 +150,7 @@ class TestCorrelation(unittest.TestCase):
         acorr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L, self.obs1)
         acorr=np.dot(self.ev_t, acorr_amp)
         acorrn=correlation_decomp(self.T, self.obs1, k=self.k, times=self.times)
-        self.assertTrue(np.allclose(acorrn, acorr))
+        assert_allclose(acorrn, acorr)
 
         """Cross-correlation"""
 
@@ -157,7 +158,7 @@ class TestCorrelation(unittest.TestCase):
         corr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L, self.obs2)
         corr=np.dot(self.ev_t, corr_amp)    
         corrn=correlation_decomp(self.T, self.obs1, obs2=self.obs2, k=self.k, times=self.times)
-        self.assertTrue(np.allclose(corrn, corr))        
+        assert_allclose(corrn, corr)        
 
     def test_correlation_matvec(self):
         """Auto-correlation"""
@@ -168,7 +169,7 @@ class TestCorrelation(unittest.TestCase):
             P_t=np.linalg.matrix_power(P, times[i])
             acorr[i]=np.dot(self.mu*self.obs1, np.dot(P_t, self.obs1))              
         acorrn=correlation_matvec(self.T, self.obs1, times=self.times)
-        self.assertTrue(np.allclose(acorrn, acorr))
+        assert_allclose(acorrn, acorr)
     
         """Cross-correlation"""
         corr=np.zeros(len(times))
@@ -176,21 +177,21 @@ class TestCorrelation(unittest.TestCase):
             P_t=np.linalg.matrix_power(P, times[i])
             corr[i]=np.dot(self.mu*self.obs1, np.dot(P_t, self.obs2))        
         corrn=correlation_matvec(self.T, self.obs1, obs2=self.obs2, times=self.times)
-        self.assertTrue(np.allclose(corrn, corr))
+        assert_allclose(corrn, corr)
 
     def test_correlation(self):
         """Auto-correlation"""
         acorr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L, self.obs1)
         acorr=np.dot(self.ev_t, acorr_amp)
         acorrn=correlation(self.T, self.obs1, k=self.k, times=self.times)
-        self.assertTrue(np.allclose(acorrn, acorr))
+        assert_allclose(acorrn, acorr)
 
   
         """Cross-correlation"""
         corr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L, self.obs2)
         corr=np.dot(self.ev_t, corr_amp)    
         corrn=correlation(self.T, self.obs1, obs2=self.obs2, k=self.k, times=self.times)
-        self.assertTrue(np.allclose(corrn, corr))
+        assert_allclose(corrn, corr)
 
 
 ################################################################################
@@ -239,7 +240,7 @@ class TestRelaxation(unittest.TestCase):
         relax_amp=np.dot(self.p0, self.R)*np.dot(self.L, self.obs)
         relax=np.dot(self.ev_t, relax_amp)        
         relaxn=relaxation_decomp(self.T, self.p0, self.obs, k=self.k, times=self.times)        
-        self.assertTrue(np.allclose(relaxn, relax))               
+        assert_allclose(relaxn, relax)               
 
     def test_relaxation_matvec(self):  
         times=self.times
@@ -249,13 +250,13 @@ class TestRelaxation(unittest.TestCase):
             P_t=np.linalg.matrix_power(P, times[i])
             relax[i]=np.dot(self.p0, np.dot(P_t, self.obs))              
         relaxn=relaxation_matvec(self.T, self.p0, self.obs, times=self.times)
-        self.assertTrue(np.allclose(relaxn, relax))      
+        assert_allclose(relaxn, relax)      
 
     def test_relaxation(self):        
         relax_amp=np.dot(self.p0, self.R)*np.dot(self.L, self.obs)
         relax=np.dot(self.ev_t, relax_amp)        
         relaxn=relaxation(self.T, self.p0, self.obs, k=self.k, times=self.times)        
-        self.assertTrue(np.allclose(relaxn, relax))               
+        assert_allclose(relaxn, relax)               
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/msm/analysis/sparse/mean_first_passage_time_test.py
+++ b/pyemma/msm/analysis/sparse/mean_first_passage_time_test.py
@@ -6,6 +6,7 @@ r"""Unit tests for the mean first passage time module
 import unittest
 
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 import scipy.sparse
 
 from mean_first_passage_time import mfpt
@@ -34,13 +35,13 @@ class TestMfpt(unittest.TestCase):
 
     def test_mfpt(self):
         x=mfpt(self.P, 0)
-        self.assertTrue(np.allclose(x, self.m0))
+        assert_allclose(x, self.m0)
 
         x=mfpt(self.P, 1)
-        self.assertTrue(np.allclose(x, self.m1))
+        assert_allclose(x, self.m1)
 
         x=mfpt(self.P, 2)
-        self.assertTrue(np.allclose(x, self.m2))
+        assert_allclose(x, self.m2)
         
 if __name__=="__main__":
     unittest.main()

--- a/pyemma/msm/analysis/tests/test_committor.py
+++ b/pyemma/msm/analysis/tests/test_committor.py
@@ -6,6 +6,7 @@ r"""Unit tests for the committor API-function
 
 import unittest
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 
 from pyemma.msm.analysis import committor
 
@@ -29,13 +30,13 @@ class TestCommittorDense(unittest.TestCase):
         P=self.bdc.transition_matrix()
         un=committor(P, [0, 1], [8, 9], forward=True)
         u=self.bdc.committor_forward(1, 8)              
-        self.assertTrue(np.allclose(un, u))
+        assert_allclose(un, u)
 
     def test_backward_comittor(self):
         P=self.bdc.transition_matrix()
         un=committor(P, [0, 1], [8, 9], forward=False)
         u=self.bdc.committor_backward(1, 8)        
-        self.assertTrue(np.allclose(un, u))
+        assert_allclose(un, u)
         
 class TestCommittorSparse(unittest.TestCase):
     def setUp(self):
@@ -55,13 +56,13 @@ class TestCommittorSparse(unittest.TestCase):
         P=self.bdc.transition_matrix_sparse()
         un=committor(P, range(10), range(90,100), forward=True)
         u=self.bdc.committor_forward(9, 90)               
-        self.assertTrue(np.allclose(un, u))
+        assert_allclose(un, u)
 
     def test_backward_comittor(self):
         P=self.bdc.transition_matrix_sparse()
         un=committor(P, range(10), range(90,100), forward=False)
         u=self.bdc.committor_backward(9, 90)               
-        self.assertTrue(np.allclose(un, u))
+        assert_allclose(un, u)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/msm/analysis/tests/test_decomposition.py
+++ b/pyemma/msm/analysis/tests/test_decomposition.py
@@ -7,6 +7,7 @@ import unittest
 import warnings
 
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 
 from scipy.linalg import eig, eigvals
 from scipy.sparse import csr_matrix
@@ -42,7 +43,7 @@ class TestDecompositionDense(unittest.TestCase):
         P=self.bdc.transition_matrix()
         mu=self.bdc.stationary_distribution()
         mun=stationary_distribution(P)
-        self.assertTrue(np.allclose(mu, mun))
+        assert_allclose(mu, mun)
 
     def test_eigenvalues(self):
         P=self.bdc.transition_matrix()
@@ -52,11 +53,11 @@ class TestDecompositionDense(unittest.TestCase):
         
         """k=None"""
         evn=eigenvalues(P)
-        self.assertTrue(np.allclose(ev, evn))
+        assert_allclose(ev, evn)
         
         """k is not None"""
         evn=eigenvalues(P, k=self.k)
-        self.assertTrue(np.allclose(ev[0:self.k], evn))
+        assert_allclose(ev[0:self.k], evn)
 
     def test_eigenvectors(self):
         P=self.bdc.transition_matrix()
@@ -67,17 +68,17 @@ class TestDecompositionDense(unittest.TestCase):
 
         """k=None"""
         Rn=eigenvectors(P)
-        self.assertTrue(np.allclose(R, Rn))
+        assert_allclose(R, Rn)
 
         Ln=eigenvectors(P, right=False)
-        self.assertTrue(np.allclose(L, Ln))
+        assert_allclose(L, Ln)
 
         """k is not None"""
         Rn=eigenvectors(P, k=self.k)
-        self.assertTrue(np.allclose(R[:,0:self.k], Rn))
+        assert_allclose(R[:,0:self.k], Rn)
 
         Ln=eigenvectors(P, right=False, k=self.k)
-        self.assertTrue(np.allclose(L[:,0:self.k], Ln))
+        assert_allclose(L[:,0:self.k], Ln)
 
     def test_rdl_decomposition(self):
         P=self.bdc.transition_matrix()
@@ -89,25 +90,25 @@ class TestDecompositionDense(unittest.TestCase):
         Rn, Dn, Ln=rdl_decomposition(P)        
         Xn=np.dot(Ln, Rn)
         """Right-eigenvectors"""
-        self.assertTrue(np.allclose(np.dot(P, Rn), np.dot(Rn, Dn)))
+        assert_allclose(np.dot(P, Rn), np.dot(Rn, Dn))
         """Left-eigenvectors"""
-        self.assertTrue(np.allclose(np.dot(Ln, P), np.dot(Dn, Ln)))
+        assert_allclose(np.dot(Ln, P), np.dot(Dn, Ln))
         """Orthonormality"""
-        self.assertTrue(np.allclose(Xn, np.eye(self.dim)))
+        assert_allclose(Xn, np.eye(self.dim))
         """Probability vector"""
-        self.assertTrue(np.allclose(np.sum(Ln[0,:]), 1.0))
+        assert_allclose(np.sum(Ln[0,:]), 1.0)
 
         """k is not None"""
         Rn, Dn, Ln=rdl_decomposition(P, k=self.k)        
         Xn=np.dot(Ln, Rn)               
         """Right-eigenvectors"""
-        self.assertTrue(np.allclose(np.dot(P, Rn), np.dot(Rn, Dn)))
+        assert_allclose(np.dot(P, Rn), np.dot(Rn, Dn))
         """Left-eigenvectors"""
-        self.assertTrue(np.allclose(np.dot(Ln, P), np.dot(Dn, Ln)))
+        assert_allclose(np.dot(Ln, P), np.dot(Dn, Ln))
         """Orthonormality"""
-        self.assertTrue(np.allclose(Xn, np.eye(self.k)))
+        assert_allclose(Xn, np.eye(self.k))
         """Probability vector"""
-        self.assertTrue(np.allclose(np.sum(Ln[0,:]), 1.0))
+        assert_allclose(np.sum(Ln[0,:]), 1.0)
 
         """Reversible"""
 
@@ -115,29 +116,29 @@ class TestDecompositionDense(unittest.TestCase):
         Rn, Dn, Ln=rdl_decomposition(P, norm='reversible')        
         Xn=np.dot(Ln, Rn)
         """Right-eigenvectors"""
-        self.assertTrue(np.allclose(np.dot(P, Rn), np.dot(Rn, Dn)))
+        assert_allclose(np.dot(P, Rn), np.dot(Rn, Dn))
         """Left-eigenvectors"""
-        self.assertTrue(np.allclose(np.dot(Ln, P), np.dot(Dn, Ln)))
+        assert_allclose(np.dot(Ln, P), np.dot(Dn, Ln))
         """Orthonormality"""
-        self.assertTrue(np.allclose(Xn, np.eye(self.dim)))
+        assert_allclose(Xn, np.eye(self.dim))
         """Probability vector"""
-        self.assertTrue(np.allclose(np.sum(Ln[0,:]), 1.0))   
+        assert_allclose(np.sum(Ln[0,:]), 1.0)   
         """Reversibility"""
-        self.assertTrue(np.allclose(Ln.transpose(), mu[:,np.newaxis]*Rn))
+        assert_allclose(Ln.transpose(), mu[:,np.newaxis]*Rn)
 
         """k is not None"""
         Rn, Dn, Ln=rdl_decomposition(P, norm='reversible', k=self.k)        
         Xn=np.dot(Ln, Rn)
         """Right-eigenvectors"""
-        self.assertTrue(np.allclose(np.dot(P, Rn), np.dot(Rn, Dn)))
+        assert_allclose(np.dot(P, Rn), np.dot(Rn, Dn))
         """Left-eigenvectors"""
-        self.assertTrue(np.allclose(np.dot(Ln, P), np.dot(Dn, Ln)))
+        assert_allclose(np.dot(Ln, P), np.dot(Dn, Ln))
         """Orthonormality"""
-        self.assertTrue(np.allclose(Xn, np.eye(self.k)))
+        assert_allclose(Xn, np.eye(self.k))
         """Probability vector"""
-        self.assertTrue(np.allclose(np.sum(Ln[0,:]), 1.0))   
+        assert_allclose(np.sum(Ln[0,:]), 1.0)   
         """Reversibility"""
-        self.assertTrue(np.allclose(Ln.transpose(), mu[:,np.newaxis]*Rn))
+        assert_allclose(Ln.transpose(), mu[:,np.newaxis]*Rn)
 
     def test_timescales(self):
         P=self.bdc.transition_matrix()
@@ -148,22 +149,22 @@ class TestDecompositionDense(unittest.TestCase):
 
         """k=None"""
         tsn=timescales(P)
-        self.assertTrue(np.allclose(ts[1:], tsn[1:]))
+        assert_allclose(ts[1:], tsn[1:])
 
         """k is not None"""
         tsn=timescales(P, k=self.k)
-        self.assertTrue(np.allclose(ts[1:self.k], tsn[1:]))
+        assert_allclose(ts[1:self.k], tsn[1:])
         
 
         """tau=7"""
         
         """k=None"""
         tsn=timescales(P, tau=7)
-        self.assertTrue(np.allclose(7*ts[1:], tsn[1:]))
+        assert_allclose(7*ts[1:], tsn[1:])
 
         """k is not None"""
         tsn=timescales(P, k=self.k, tau=7)
-        self.assertTrue(np.allclose(7*ts[1:self.k], tsn[1:]))
+        assert_allclose(7*ts[1:self.k], tsn[1:])
 
 class TestTimescalesDense(unittest.TestCase):
     
@@ -180,7 +181,7 @@ class TestTimescalesDense(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             tsn=timescales(self.W)
-            self.assertTrue(np.allclose(tsn, ts))
+            assert_allclose(tsn, ts)
             assert issubclass(w[-1].category, SpectralWarning)
 
     def test_timescales_2(self):
@@ -190,7 +191,7 @@ class TestTimescalesDense(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             tsn=timescales(0.5*self.T+0.5*self.P)
-            self.assertTrue(np.allclose(tsn, ts))
+            assert_allclose(tsn, ts)
             assert issubclass(w[-1].category, ImaginaryEigenValueWarning)        
 
 ################################################################################
@@ -219,7 +220,7 @@ class TestDecompositionSparse(unittest.TestCase):
         P=self.bdc.transition_matrix_sparse()
         mu=self.bdc.stationary_distribution()
         mun=stationary_distribution(P)
-        self.assertTrue(np.allclose(mu, mun))
+        assert_allclose(mu, mun)
 
     def test_eigenvalues(self):
         P=self.bdc.transition_matrix_sparse()
@@ -234,11 +235,11 @@ class TestDecompositionSparse(unittest.TestCase):
         
         """k is not None"""
         evn=eigenvalues(P, k=self.k)
-        self.assertTrue(np.allclose(ev[0:self.k], evn))
+        assert_allclose(ev[0:self.k], evn)
 
         """k is not None and ncv is not None"""
         evn=eigenvalues(P, k=self.k, ncv=self.ncv)
-        self.assertTrue(np.allclose(ev[0:self.k], evn))
+        assert_allclose(ev[0:self.k], evn)
 
     def test_eigenvectors(self):
         P_dense=self.bdc.transition_matrix()
@@ -259,17 +260,17 @@ class TestDecompositionSparse(unittest.TestCase):
 
         """k is not None"""
         Rn=eigenvectors(P, k=self.k)        
-        self.assertTrue(np.allclose(vals[np.newaxis,:]*Rn, P.dot(Rn)))
+        assert_allclose(vals[np.newaxis,:]*Rn, P.dot(Rn))
 
         Ln=eigenvectors(P, right=False, k=self.k)
-        self.assertTrue(np.allclose(P.transpose().dot(Ln), vals[np.newaxis,:]*Ln))
+        assert_allclose(P.transpose().dot(Ln), vals[np.newaxis,:]*Ln)
 
         """k is not None and ncv is not None"""
         Rn=eigenvectors(P, k=self.k, ncv=self.ncv)        
-        self.assertTrue(np.allclose(vals[np.newaxis,:]*Rn, P.dot(Rn)))
+        assert_allclose(vals[np.newaxis,:]*Rn, P.dot(Rn))
 
         Ln=eigenvectors(P, right=False, k=self.k, ncv=self.ncv)
-        self.assertTrue(np.allclose(P.transpose().dot(Ln), vals[np.newaxis,:]*Ln))
+        assert_allclose(P.transpose().dot(Ln), vals[np.newaxis,:]*Ln)
 
     def test_rdl_decomposition(self):
         P=self.bdc.transition_matrix_sparse()
@@ -285,25 +286,25 @@ class TestDecompositionSparse(unittest.TestCase):
         Rn, Dn, Ln=rdl_decomposition(P, k=self.k)        
         Xn=np.dot(Ln, Rn)
         """Right-eigenvectors"""
-        self.assertTrue(np.allclose(P.dot(Rn), np.dot(Rn, Dn)))    
+        assert_allclose(P.dot(Rn), np.dot(Rn, Dn))    
         """Left-eigenvectors"""
-        self.assertTrue(np.allclose(P.transpose().dot(Ln.transpose()).transpose(), np.dot(Dn, Ln)))               
+        assert_allclose(P.transpose().dot(Ln.transpose()).transpose(), np.dot(Dn, Ln))               
         """Orthonormality"""
-        self.assertTrue(np.allclose(Xn, np.eye(self.k)))
+        assert_allclose(Xn, np.eye(self.k))
         """Probability vector"""
-        self.assertTrue(np.allclose(np.sum(Ln[0,:]), 1.0))
+        assert_allclose(np.sum(Ln[0,:]), 1.0)
 
         """k is not None, ncv is not None"""
         Rn, Dn, Ln=rdl_decomposition(P, k=self.k, ncv=self.ncv)        
         Xn=np.dot(Ln, Rn)
         """Right-eigenvectors"""
-        self.assertTrue(np.allclose(P.dot(Rn), np.dot(Rn, Dn)))    
+        assert_allclose(P.dot(Rn), np.dot(Rn, Dn))    
         """Left-eigenvectors"""
-        self.assertTrue(np.allclose(P.transpose().dot(Ln.transpose()).transpose(), np.dot(Dn, Ln)))               
+        assert_allclose(P.transpose().dot(Ln.transpose()).transpose(), np.dot(Dn, Ln))               
         """Orthonormality"""
-        self.assertTrue(np.allclose(Xn, np.eye(self.k)))
+        assert_allclose(Xn, np.eye(self.k))
         """Probability vector"""
-        self.assertTrue(np.allclose(np.sum(Ln[0,:]), 1.0))
+        assert_allclose(np.sum(Ln[0,:]), 1.0)
 
         """Reversible"""
 
@@ -315,29 +316,29 @@ class TestDecompositionSparse(unittest.TestCase):
         Rn, Dn, Ln=rdl_decomposition(P, k=self.k, norm='reversible')        
         Xn=np.dot(Ln, Rn)
         """Right-eigenvectors"""
-        self.assertTrue(np.allclose(P.dot(Rn), np.dot(Rn, Dn)))    
+        assert_allclose(P.dot(Rn), np.dot(Rn, Dn))    
         """Left-eigenvectors"""
-        self.assertTrue(np.allclose(P.transpose().dot(Ln.transpose()).transpose(), np.dot(Dn, Ln)))               
+        assert_allclose(P.transpose().dot(Ln.transpose()).transpose(), np.dot(Dn, Ln))               
         """Orthonormality"""
-        self.assertTrue(np.allclose(Xn, np.eye(self.k)))
+        assert_allclose(Xn, np.eye(self.k))
         """Probability vector"""
-        self.assertTrue(np.allclose(np.sum(Ln[0,:]), 1.0))
+        assert_allclose(np.sum(Ln[0,:]), 1.0)
         """Reversibility"""
-        self.assertTrue(np.allclose(Ln.transpose(), mu[:,np.newaxis]*Rn))
+        assert_allclose(Ln.transpose(), mu[:,np.newaxis]*Rn)
 
         """k is not None ncv is not None"""
         Rn, Dn, Ln=rdl_decomposition(P, k=self.k, norm='reversible', ncv=self.ncv)        
         Xn=np.dot(Ln, Rn)
         """Right-eigenvectors"""
-        self.assertTrue(np.allclose(P.dot(Rn), np.dot(Rn, Dn)))    
+        assert_allclose(P.dot(Rn), np.dot(Rn, Dn))    
         """Left-eigenvectors"""
-        self.assertTrue(np.allclose(P.transpose().dot(Ln.transpose()).transpose(), np.dot(Dn, Ln)))               
+        assert_allclose(P.transpose().dot(Ln.transpose()).transpose(), np.dot(Dn, Ln))               
         """Orthonormality"""
-        self.assertTrue(np.allclose(Xn, np.eye(self.k)))
+        assert_allclose(Xn, np.eye(self.k))
         """Probability vector"""
-        self.assertTrue(np.allclose(np.sum(Ln[0,:]), 1.0))
+        assert_allclose(np.sum(Ln[0,:]), 1.0)
         """Reversibility"""
-        self.assertTrue(np.allclose(Ln.transpose(), mu[:,np.newaxis]*Rn))
+        assert_allclose(Ln.transpose(), mu[:,np.newaxis]*Rn)
 
     def test_timescales(self):
         P_dense=self.bdc.transition_matrix()
@@ -353,18 +354,18 @@ class TestDecompositionSparse(unittest.TestCase):
 
         """k is not None"""
         tsn=timescales(P, k=self.k)
-        self.assertTrue(np.allclose(ts[1:self.k], tsn[1:]))
+        assert_allclose(ts[1:self.k], tsn[1:])
 
         """k is not None, ncv is not None"""
         tsn=timescales(P, k=self.k, ncv=self.ncv)
-        self.assertTrue(np.allclose(ts[1:self.k], tsn[1:]))
+        assert_allclose(ts[1:self.k], tsn[1:])
         
 
         """tau=7"""      
 
         """k is not None"""
         tsn=timescales(P, k=self.k, tau=7)
-        self.assertTrue(np.allclose(7*ts[1:self.k], tsn[1:]))
+        assert_allclose(7*ts[1:self.k], tsn[1:])
         
         
 if __name__=="__main__":

--- a/pyemma/msm/analysis/tests/test_expectations.py
+++ b/pyemma/msm/analysis/tests/test_expectations.py
@@ -6,6 +6,7 @@ r"""This module provides unit tests for the expectations function in API
 
 import unittest
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 from scipy.linalg import eig
 
 import scipy
@@ -50,7 +51,7 @@ class TestExpectedCountsDense(unittest.TestCase):
         """        
         EC_true=N*self.mu[:,np.newaxis]*T
 
-        self.assertTrue(np.allclose(EC_true, EC_n))
+        assert_allclose(EC_true, EC_n)
 
         N=2000
         EC_n=expected_counts(T, p0, N)
@@ -60,13 +61,13 @@ class TestExpectedCountsDense(unittest.TestCase):
         be carried out by a simple multiplication
         """        
         EC_true=N*self.mu[:,np.newaxis]*T
-        self.assertTrue(np.allclose(EC_true, EC_n))
+        assert_allclose(EC_true, EC_n)
 
         """Zero length chain"""
         N=0
         EC_n=expected_counts(T, p0, N)
         EC_true=np.zeros(T.shape)
-        self.assertTrue(np.allclose(EC_true, EC_n))
+        assert_allclose(EC_true, EC_n)
 
 class TestExpectedCountsStationaryDense(unittest.TestCase):
     def setUp(self):
@@ -92,12 +93,12 @@ class TestExpectedCountsStationaryDense(unittest.TestCase):
         """Compute mu on the fly"""
         EC_n=expected_counts_stationary(T, N)
         EC_true=N*self.mu[:,np.newaxis]*T
-        self.assertTrue(np.allclose(EC_true, EC_n))
+        assert_allclose(EC_true, EC_n)
 
         """Use precomputed mu"""
         EC_n=expected_counts_stationary(T, N, mu=self.mu)
         EC_true=N*self.mu[:,np.newaxis]*T
-        self.assertTrue(np.allclose(EC_true, EC_n))
+        assert_allclose(EC_true, EC_n)
 
 ################################################################################
 # Sparse

--- a/pyemma/msm/analysis/tests/test_fingerprints.py
+++ b/pyemma/msm/analysis/tests/test_fingerprints.py
@@ -7,6 +7,7 @@ r"""Unit test for the fingerprint API-functions
 import unittest
 
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 
 from pyemma.msm.analysis import rdl_decomposition, timescales
 from pyemma.msm.analysis import fingerprint_correlation, fingerprint_relaxation
@@ -65,54 +66,54 @@ class TestFingerprintDense(unittest.TestCase):
         """k=None, tau=1"""
         acorr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L,self.obs1)
         tsn, acorr_ampn=fingerprint_correlation(self.T, self.obs1)
-        self.assertTrue(np.allclose(tsn, self.ts))
-        self.assertTrue(np.allclose(acorr_ampn, acorr_amp))
+        assert_allclose(tsn, self.ts)
+        assert_allclose(acorr_ampn, acorr_amp)
 
         """k=None, tau=7.5"""
         tau=self.tau
         tsn, acorr_ampn=fingerprint_correlation(self.T, self.obs1, tau=tau)
-        self.assertTrue(np.allclose(tsn, tau*self.ts))
-        self.assertTrue(np.allclose(acorr_ampn, acorr_amp))
+        assert_allclose(tsn, tau*self.ts)
+        assert_allclose(acorr_ampn, acorr_amp)
 
         """k=4, tau=1"""
         k=self.k
         acorr_amp=np.dot(self.mu*self.obs1, self.R[:,0:k])*np.dot(self.L[0:k,:],self.obs1)
         tsn, acorr_ampn=fingerprint_correlation(self.T, self.obs1, k=k)
-        self.assertTrue(np.allclose(tsn, self.ts[0:k]))
-        self.assertTrue(np.allclose(acorr_ampn, acorr_amp))
+        assert_allclose(tsn, self.ts[0:k])
+        assert_allclose(acorr_ampn, acorr_amp)
 
         """k=4, tau=7.5"""
         tau=self.tau
         tsn, acorr_ampn=fingerprint_correlation(self.T, self.obs1, k=k, tau=tau)
-        self.assertTrue(np.allclose(tsn, tau*self.ts[0:k]))
-        self.assertTrue(np.allclose(acorr_ampn, acorr_amp))
+        assert_allclose(tsn, tau*self.ts[0:k])
+        assert_allclose(acorr_ampn, acorr_amp)
 
         """Cross-correlation"""
 
         """k=None, tau=1"""
         corr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L,self.obs2)
         tsn, corr_ampn=fingerprint_correlation(self.T, self.obs1, obs2=self.obs2)
-        self.assertTrue(np.allclose(tsn, self.ts))
-        self.assertTrue(np.allclose(corr_ampn, corr_amp))
+        assert_allclose(tsn, self.ts)
+        assert_allclose(corr_ampn, corr_amp)
 
         """k=None, tau=7.5"""
         tau=self.tau
         tsn, corr_ampn=fingerprint_correlation(self.T, self.obs1, obs2=self.obs2, tau=tau)
-        self.assertTrue(np.allclose(tsn, tau*self.ts))
-        self.assertTrue(np.allclose(corr_ampn, corr_amp))
+        assert_allclose(tsn, tau*self.ts)
+        assert_allclose(corr_ampn, corr_amp)
 
         """k=4, tau=1"""
         k=self.k
         corr_amp=np.dot(self.mu*self.obs1, self.R[:,0:k])*np.dot(self.L[0:k,:],self.obs2)
         tsn, corr_ampn=fingerprint_correlation(self.T, self.obs1, obs2=self.obs2, k=k)
-        self.assertTrue(np.allclose(tsn, self.ts[0:k]))
-        self.assertTrue(np.allclose(corr_ampn, corr_amp))
+        assert_allclose(tsn, self.ts[0:k])
+        assert_allclose(corr_ampn, corr_amp)
 
         """k=4, tau=7.5"""
         tau=self.tau
         tsn, corr_ampn=fingerprint_correlation(self.T, self.obs1, obs2=self.obs2, k=k, tau=tau)
-        self.assertTrue(np.allclose(tsn, tau*self.ts[0:k]))
-        self.assertTrue(np.allclose(corr_ampn, corr_amp))
+        assert_allclose(tsn, tau*self.ts[0:k])
+        assert_allclose(corr_ampn, corr_amp)
 
     def test_fingerprint_relaxation(self):
         one_vec=np.ones(self.T.shape[0])
@@ -120,15 +121,15 @@ class TestFingerprintDense(unittest.TestCase):
         """k=None"""
         relax_amp=np.dot(self.p0, self.R)*np.dot(self.L, self.obs1)
         tsn, relax_ampn=fingerprint_relaxation(self.T, self.p0, self.obs1)        
-        self.assertTrue(np.allclose(tsn, self.ts))
-        self.assertTrue(np.allclose(relax_ampn, relax_amp))        
+        assert_allclose(tsn, self.ts)
+        assert_allclose(relax_ampn, relax_amp)        
 
         """k=4"""
         k=self.k
         relax_amp=np.dot(self.p0, self.R[:,0:k])*np.dot(self.L[0:k,:], self.obs1)
         tsn, relax_ampn=fingerprint_relaxation(self.T, self.p0, self.obs1, k=k)        
-        self.assertTrue(np.allclose(tsn, self.ts[0:k]))        
-        self.assertTrue(np.allclose(relax_ampn, relax_amp))       
+        assert_allclose(tsn, self.ts[0:k])        
+        assert_allclose(relax_ampn, relax_amp)       
 
 class TestExpectation(unittest.TestCase):
     def setUp(self):
@@ -153,7 +154,7 @@ class TestExpectation(unittest.TestCase):
     def test_expectation(self):
         exp=np.dot(self.mu, self.obs1)
         expn=expectation(self.T, self.obs1)
-        self.assertTrue(np.allclose(exp, expn)) 
+        assert_allclose(exp, expn) 
 
 class TestCorrelationDense(unittest.TestCase):
     def setUp(self):
@@ -197,14 +198,14 @@ class TestCorrelationDense(unittest.TestCase):
         acorr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L, self.obs1)
         acorr=np.dot(self.ev_t, acorr_amp)
         acorrn=correlation(self.T, self.obs1, times=self.times)
-        self.assertTrue(np.allclose(acorrn, acorr))
+        assert_allclose(acorrn, acorr)
 
         """k=4"""
         k=self.k
         acorr_amp=np.dot(self.mu*self.obs1, self.R[:,0:k])*np.dot(self.L[0:k,:], self.obs1)
         acorr=np.dot(self.ev_t[:,0:k], acorr_amp)
         acorrn=correlation(self.T, self.obs1, times=self.times, k=k)
-        self.assertTrue(np.allclose(acorrn, acorr))              
+        assert_allclose(acorrn, acorr)              
     
         """Cross-correlation"""
 
@@ -212,14 +213,14 @@ class TestCorrelationDense(unittest.TestCase):
         corr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L, self.obs2)
         corr=np.dot(self.ev_t, corr_amp)    
         corrn=correlation(self.T, self.obs1, obs2=self.obs2, times=self.times)
-        self.assertTrue(np.allclose(corrn, corr))
+        assert_allclose(corrn, corr)
 
         """k=4"""
         k=self.k
         corr_amp=np.dot(self.mu*self.obs1, self.R[:,0:k])*np.dot(self.L[0:k,:], self.obs2)
         corr=np.dot(self.ev_t[:,0:k], corr_amp)
         corrn=correlation(self.T, self.obs1, obs2=self.obs2, times=self.times, k=k)
-        self.assertTrue(np.allclose(corrn, corr))   
+        assert_allclose(corrn, corr)   
 
 class TestRelaxationDense(unittest.TestCase):
     def setUp(self):
@@ -263,14 +264,14 @@ class TestRelaxationDense(unittest.TestCase):
         relax_amp=np.dot(self.p0, self.R)*np.dot(self.L, self.obs)
         relax=np.dot(self.ev_t, relax_amp)        
         relaxn=relaxation(self.T, self.p0, self.obs, times=self.times)        
-        self.assertTrue(np.allclose(relaxn, relax))        
+        assert_allclose(relaxn, relax)        
         
         """k=4"""
         k=self.k
         relax_amp=np.dot(self.p0, self.R[:,0:k])*np.dot(self.L[0:k,:], self.obs)
         relax=np.dot(self.ev_t[:,0:k], relax_amp)        
         relaxn=relaxation(self.T, self.p0, self.obs, k=k, times=self.times) 
-        self.assertTrue(np.allclose(relaxn, relax))
+        assert_allclose(relaxn, relax)
 
 ################################################################################
 # Sparse
@@ -325,14 +326,14 @@ class TestFingerprintSparse(unittest.TestCase):
         k=self.k
         acorr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L,self.obs1)
         tsn, acorr_ampn=fingerprint_correlation(self.T, self.obs1, k=k)
-        self.assertTrue(np.allclose(tsn, self.ts))
-        self.assertTrue(np.allclose(acorr_ampn, acorr_amp))
+        assert_allclose(tsn, self.ts)
+        assert_allclose(acorr_ampn, acorr_amp)
 
         """k=4, tau=7.5"""
         tau=self.tau
         tsn, acorr_ampn=fingerprint_correlation(self.T, self.obs1, k=k, tau=tau)
-        self.assertTrue(np.allclose(tsn, tau*self.ts))
-        self.assertTrue(np.allclose(acorr_ampn, acorr_amp))
+        assert_allclose(tsn, tau*self.ts)
+        assert_allclose(acorr_ampn, acorr_amp)
 
         """Cross-correlation"""
 
@@ -340,22 +341,22 @@ class TestFingerprintSparse(unittest.TestCase):
         k=self.k
         corr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L,self.obs2)
         tsn, corr_ampn=fingerprint_correlation(self.T, self.obs1, obs2=self.obs2, k=k)
-        self.assertTrue(np.allclose(tsn, self.ts))
-        self.assertTrue(np.allclose(corr_ampn, corr_amp))
+        assert_allclose(tsn, self.ts)
+        assert_allclose(corr_ampn, corr_amp)
 
         """k=4, tau=7.5"""
         tau=self.tau
         tsn, corr_ampn=fingerprint_correlation(self.T, self.obs1, obs2=self.obs2, k=k, tau=tau)
-        self.assertTrue(np.allclose(tsn, tau*self.ts))
-        self.assertTrue(np.allclose(corr_ampn, corr_amp))
+        assert_allclose(tsn, tau*self.ts)
+        assert_allclose(corr_ampn, corr_amp)
 
     def test_fingerprint_relaxation(self):
         one_vec=np.ones(self.T.shape[0])
 
         relax_amp=np.dot(self.p0, self.R)*np.dot(self.L, self.obs1)
         tsn, relax_ampn=fingerprint_relaxation(self.T, self.p0, self.obs1, k=self.k)        
-        self.assertTrue(np.allclose(tsn, self.ts))
-        self.assertTrue(np.allclose(relax_ampn, relax_amp))
+        assert_allclose(tsn, self.ts)
+        assert_allclose(relax_ampn, relax_amp)
 
 class TestCorrelationSparse(unittest.TestCase):
     def setUp(self):
@@ -397,14 +398,14 @@ class TestCorrelationSparse(unittest.TestCase):
         acorr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L, self.obs1)
         acorr=np.dot(self.ev_t, acorr_amp)
         acorrn=correlation(self.T, self.obs1, k=self.k, times=self.times)
-        self.assertTrue(np.allclose(acorrn, acorr))
+        assert_allclose(acorrn, acorr)
 
   
         """Cross-correlation"""
         corr_amp=np.dot(self.mu*self.obs1, self.R)*np.dot(self.L, self.obs2)
         corr=np.dot(self.ev_t, corr_amp)    
         corrn=correlation(self.T, self.obs1, obs2=self.obs2, k=self.k, times=self.times)
-        self.assertTrue(np.allclose(corrn, corr))    
+        assert_allclose(corrn, corr)    
 
 class TestRelaxationSparse(unittest.TestCase):
     def setUp(self):
@@ -447,7 +448,7 @@ class TestRelaxationSparse(unittest.TestCase):
         relax_amp=np.dot(self.p0, self.R)*np.dot(self.L, self.obs)
         relax=np.dot(self.ev_t, relax_amp)        
         relaxn=relaxation(self.T, self.p0, self.obs, k=self.k, times=self.times)        
-        self.assertTrue(np.allclose(relaxn, relax))                   
+        assert_allclose(relaxn, relax)                   
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/msm/analysis/tests/test_mfpt.py
+++ b/pyemma/msm/analysis/tests/test_mfpt.py
@@ -6,6 +6,7 @@ r"""Unit tests for the mean first passage time API-functions
 import unittest
 
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 import scipy.sparse
 
 from pyemma.msm.analysis import mfpt
@@ -37,13 +38,13 @@ class TestMfptDense(unittest.TestCase):
 
     def test_mfpt(self):
         x=mfpt(self.P, 0)
-        self.assertTrue(np.allclose(x, self.m0))
+        assert_allclose(x, self.m0)
 
         x=mfpt(self.P, 1)
-        self.assertTrue(np.allclose(x, self.m1))
+        assert_allclose(x, self.m1)
 
         x=mfpt(self.P, 2)
-        self.assertTrue(np.allclose(x, self.m2))
+        assert_allclose(x, self.m2)
 
 ################################################################################
 # Sparse
@@ -73,13 +74,13 @@ class TestMfptSparse(unittest.TestCase):
 
     def test_mfpt(self):
         x=mfpt(self.P, 0)
-        self.assertTrue(np.allclose(x, self.m0))
+        assert_allclose(x, self.m0)
 
         x=mfpt(self.P, 1)
-        self.assertTrue(np.allclose(x, self.m1))
+        assert_allclose(x, self.m1)
 
         x=mfpt(self.P, 2)
-        self.assertTrue(np.allclose(x, self.m2))
+        assert_allclose(x, self.m2)
         
 if __name__=="__main__":
     unittest.main()

--- a/pyemma/msm/analysis/tests/test_sensitivity.py
+++ b/pyemma/msm/analysis/tests/test_sensitivity.py
@@ -11,6 +11,7 @@ sensitivity matrices against numerical differentiation results.
 
 import unittest
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 
 from pyemma.msm.analysis import timescale_sensitivity, eigenvalue_sensitivity, mfpt_sensitivity,\
     committor_sensitivity, eigenvector_sensitivity,\
@@ -118,46 +119,46 @@ class TestSensitivitiesDense(unittest.TestCase):
 
     def test_eigenvalue_sensitivity(self):
                 
-        self.assertTrue(np.allclose(eigenvalue_sensitivity(self.T,0), self.S0))      
-        self.assertTrue(np.allclose(eigenvalue_sensitivity(self.T,1), self.S1))      
+        assert_allclose(eigenvalue_sensitivity(self.T,0), self.S0)      
+        assert_allclose(eigenvalue_sensitivity(self.T,1), self.S1)      
         
     def test_timescale_sensitivity(self):
                     
-        self.assertTrue(np.allclose(timescale_sensitivity(self.T,1), self.TS1))   
+        assert_allclose(timescale_sensitivity(self.T,1), self.TS1)   
         
     def test_forward_committor_sensitivity(self):
             
-        self.assertTrue(np.allclose(committor_sensitivity(self.T4, [0], [3], 0, forward=True), self.S4zero))      
-        self.assertTrue(np.allclose(committor_sensitivity(self.T4, [0], [3], 1, forward=True), self.qS41))      
-        self.assertTrue(np.allclose(committor_sensitivity(self.T4, [0], [3], 2, forward=True), self.qS42))      
-        self.assertTrue(np.allclose(committor_sensitivity(self.T4, [0], [3], 3, forward=True), self.S4zero))      
+        assert_allclose(committor_sensitivity(self.T4, [0], [3], 0, forward=True), self.S4zero)      
+        assert_allclose(committor_sensitivity(self.T4, [0], [3], 1, forward=True), self.qS41)      
+        assert_allclose(committor_sensitivity(self.T4, [0], [3], 2, forward=True), self.qS42)      
+        assert_allclose(committor_sensitivity(self.T4, [0], [3], 3, forward=True), self.S4zero)      
 
     def test_backward_committor_sensitivity(self):
         
-        self.assertTrue(np.allclose(committor_sensitivity(self.T4, [0], [3], 1, forward=False), self.qSI41))      
+        assert_allclose(committor_sensitivity(self.T4, [0], [3], 1, forward=False), self.qSI41)      
                 
     def test_mfpt_sensitivity(self):
         
-        self.assertTrue(np.allclose(mfpt_sensitivity(self.T4, 0, 0), self.S4zero))    
-        self.assertTrue(np.allclose(mfpt_sensitivity(self.T4, 0, 1), self.mS01))      
-        self.assertTrue(np.allclose(mfpt_sensitivity(self.T4, 0, 2), self.mS02))      
-        self.assertTrue(np.allclose(mfpt_sensitivity(self.T4, 3, 2), self.mS32))  
+        assert_allclose(mfpt_sensitivity(self.T4, 0, 0), self.S4zero)    
+        assert_allclose(mfpt_sensitivity(self.T4, 0, 1), self.mS01)      
+        assert_allclose(mfpt_sensitivity(self.T4, 0, 2), self.mS02)      
+        assert_allclose(mfpt_sensitivity(self.T4, 3, 2), self.mS32)  
         
     def test_eigenvector_sensitivity(self):
-        self.assertTrue(np.allclose(eigenvector_sensitivity(self.T4, 1 , 1), self.mV11, atol=1e-5))      
-        self.assertTrue(np.allclose(eigenvector_sensitivity(self.T4, 2 , 2), self.mV22, atol=1e-5))      
-        self.assertTrue(np.allclose(eigenvector_sensitivity(self.T4, 0 , 3), self.mV03, atol=1e-5))  
+        assert_allclose(eigenvector_sensitivity(self.T4, 1 , 1), self.mV11, atol=1e-5)      
+        assert_allclose(eigenvector_sensitivity(self.T4, 2 , 2), self.mV22, atol=1e-5)      
+        assert_allclose(eigenvector_sensitivity(self.T4, 0 , 3), self.mV03, atol=1e-5)  
                 
-        self.assertTrue(np.allclose(eigenvector_sensitivity(self.T4, 0 , 1, right=False), self.mV01left, atol=1e-5))   
+        assert_allclose(eigenvector_sensitivity(self.T4, 0 , 1, right=False), self.mV01left, atol=1e-5)   
                  
     def test_stationary_sensitivity(self):    
-        self.assertTrue(np.allclose(stationary_distribution_sensitivity(self.T4, 1), self.pS1, atol=1e-5))      
+        assert_allclose(stationary_distribution_sensitivity(self.T4, 1), self.pS1, atol=1e-5)      
 
     def test_expectation_sensitivity(self):
         a=np.array([0.0, 3.0, 0.0, 0.0])
         S=3.0*self.pS1
         Sn=expectation_sensitivity(self.T4, a)
-        self.assertTrue(np.allclose(Sn, S))              
+        assert_allclose(Sn, S)              
         
 
 if __name__=="__main__":

--- a/pyemma/msm/estimation/dense/covariance_test.py
+++ b/pyemma/msm/estimation/dense/covariance_test.py
@@ -6,6 +6,7 @@ r"""Unit tests for the covariance module
 import unittest
 
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 
 from covariance import tmatrix_cov, dirichlet_covariance, error_perturbation
 
@@ -33,10 +34,10 @@ class TestCovariance(unittest.TestCase):
 
     def test_tmatrix_cov(self):
         cov=tmatrix_cov(self.C)
-        self.assertTrue(np.allclose(cov, self.cov))
+        assert_allclose(cov, self.cov)
 
         cov=tmatrix_cov(self.C, row=1)
-        self.assertTrue(np.allclose(cov, self.cov[1, :, :]))
+        assert_allclose(cov, self.cov[1, :, :])
 
 class TestDirichletCovariance(unittest.TestCase):
     def setUp(self):
@@ -51,10 +52,10 @@ class TestDirichletCovariance(unittest.TestCase):
 
     def test_dirichlet_covariance(self):
         cov=dirichlet_covariance(self.alpha1)
-        self.assertTrue(np.allclose(cov, self.cov1))
+        assert_allclose(cov, self.cov1)
 
         cov=dirichlet_covariance(self.alpha2)
-        self.assertTrue(np.allclose(cov, self.cov2))
+        assert_allclose(cov, self.cov2)
         
 class TestErrorPerturbation(unittest.TestCase):
     def setUp(self):
@@ -94,10 +95,10 @@ class TestErrorPerturbation(unittest.TestCase):
 
     def test_error_perturbation(self):
         xn=error_perturbation(self.C, self.S1)
-        self.assertTrue(np.allclose(xn, self.x))
+        assert_allclose(xn, self.x)
 
         Xn=error_perturbation(self.C, self.S2)
-        self.assertTrue(np.allclose(Xn, self.X))
+        assert_allclose(Xn, self.X)
 
         
 

--- a/pyemma/msm/estimation/sparse/connectivity_test.py
+++ b/pyemma/msm/estimation/sparse/connectivity_test.py
@@ -7,6 +7,7 @@ r"""Unit tests for the connectivity module
 import unittest
 
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 import scipy.sparse
 
 import connectivity
@@ -105,19 +106,19 @@ class TestConnectedCountMatrix(unittest.TestCase):
     def test_connected_count_matrix(self):
         """Directed"""
         C_cc=connectivity.largest_connected_submatrix(self.C)
-        self.assertTrue(np.allclose(C_cc.toarray(), self.C_cc_directed))
+        assert_allclose(C_cc.toarray(), self.C_cc_directed)
 
         """Directed with user specified lcc"""
         C_cc=connectivity.largest_connected_submatrix(self.C, lcc=np.array([0, 1]))
-        self.assertTrue(np.allclose(C_cc.toarray(), self.C_cc_directed[0:2,0:2]))
+        assert_allclose(C_cc.toarray(), self.C_cc_directed[0:2,0:2])
 
         """Undirected"""
         C_cc=connectivity.largest_connected_submatrix(self.C, directed=False)
-        self.assertTrue(np.allclose(C_cc.toarray(), self.C_cc_undirected))
+        assert_allclose(C_cc.toarray(), self.C_cc_undirected)
 
         """Undirected with user specified lcc"""
         C_cc=connectivity.largest_connected_submatrix(self.C, lcc=np.array([0, 1]), directed=False)
-        self.assertTrue(np.allclose(C_cc.toarray(), self.C_cc_undirected[0:2,0:2]))
+        assert_allclose(C_cc.toarray(), self.C_cc_undirected[0:2,0:2])
         
 class TestIsConnected(unittest.TestCase):
         

--- a/pyemma/msm/estimation/sparse/count_matrix_test.py
+++ b/pyemma/msm/estimation/sparse/count_matrix_test.py
@@ -6,6 +6,7 @@ from os.path import abspath, join
 from os import pardir
 
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 import scipy.sparse
 
 from count_matrix import count_matrix, count_matrix_mult
@@ -49,41 +50,41 @@ class TestCountMatrix(unittest.TestCase):
     def test_count_matrix(self):
         """Small test cases"""
         C=count_matrix(self.S_short, 1, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.B1_lag))
+        assert_allclose(C, self.B1_lag)
 
         C=count_matrix(self.S_short, 2, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.B2_lag))
+        assert_allclose(C, self.B2_lag)
 
         C=count_matrix(self.S_short, 3, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.B3_lag))
+        assert_allclose(C, self.B3_lag)
 
         C=count_matrix(self.S_short, 1).toarray()
-        self.assertTrue(np.allclose(C, self.B1_sliding))
+        assert_allclose(C, self.B1_sliding)
 
         C=count_matrix(self.S_short, 2).toarray()
-        self.assertTrue(np.allclose(C, self.B2_sliding))
+        assert_allclose(C, self.B2_sliding)
 
         C=count_matrix(self.S_short, 3).toarray()
-        self.assertTrue(np.allclose(C, self.B3_sliding))
+        assert_allclose(C, self.B3_sliding)
 
         """Larger test cases"""
         C=count_matrix(self.S_long, 1, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.C1_lag))
+        assert_allclose(C, self.C1_lag)
 
         C=count_matrix(self.S_long, 7, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.C7_lag))
+        assert_allclose(C, self.C7_lag)
 
         C=count_matrix(self.S_long, 13, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.C13_lag))
+        assert_allclose(C, self.C13_lag)
 
         C=count_matrix(self.S_long, 1).toarray()
-        self.assertTrue(np.allclose(C, self.C1_sliding))
+        assert_allclose(C, self.C1_sliding)
 
         C=count_matrix(self.S_long, 7).toarray()
-        self.assertTrue(np.allclose(C, self.C7_sliding))
+        assert_allclose(C, self.C7_sliding)
 
         C=count_matrix(self.S_long, 13).toarray()
-        self.assertTrue(np.allclose(C, self.C13_sliding))
+        assert_allclose(C, self.C13_sliding)
 
         """Test raising of value error if lag greater than trajectory length"""
         with self.assertRaises(ValueError):
@@ -131,41 +132,41 @@ class TestCountMatrixtMult(unittest.TestCase):
     def test_count_matrix_mult(self):
         """Small test cases"""
         C=count_matrix_mult(self.dtrajs_short, 1, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.B1_lag))
+        assert_allclose(C, self.B1_lag)
 
         C=count_matrix_mult(self.dtrajs_short, 2, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.B2_lag))
+        assert_allclose(C, self.B2_lag)
 
         C=count_matrix_mult(self.dtrajs_short, 3, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.B3_lag))
+        assert_allclose(C, self.B3_lag)
 
         C=count_matrix_mult(self.dtrajs_short , 1).toarray()
-        self.assertTrue(np.allclose(C, self.B1_sliding))
+        assert_allclose(C, self.B1_sliding)
 
         C=count_matrix_mult(self.dtrajs_short , 2).toarray()
-        self.assertTrue(np.allclose(C, self.B2_sliding))
+        assert_allclose(C, self.B2_sliding)
 
         C=count_matrix_mult(self.dtrajs_short , 3).toarray()
-        self.assertTrue(np.allclose(C, self.B3_sliding))
+        assert_allclose(C, self.B3_sliding)
 
         """Larger test cases"""
         C=count_matrix_mult(self.dtrajs_long, 1, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.C1_lag))
+        assert_allclose(C, self.C1_lag)
 
         C=count_matrix_mult(self.dtrajs_long, 7, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.C7_lag))
+        assert_allclose(C, self.C7_lag)
 
         C=count_matrix_mult(self.dtrajs_long, 13, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.C13_lag))
+        assert_allclose(C, self.C13_lag)
 
         C=count_matrix_mult(self.dtrajs_long, 1).toarray()
-        self.assertTrue(np.allclose(C, self.C1_sliding))
+        assert_allclose(C, self.C1_sliding)
 
         C=count_matrix_mult(self.dtrajs_long, 7).toarray()
-        self.assertTrue(np.allclose(C, self.C7_sliding))
+        assert_allclose(C, self.C7_sliding)
 
         C=count_matrix_mult(self.dtrajs_long, 13).toarray()
-        self.assertTrue(np.allclose(C, self.C13_sliding))
+        assert_allclose(C, self.C13_sliding)
 
         """Test raising of value error if lag greater than trajectory length"""
         with self.assertRaises(ValueError):
@@ -200,10 +201,10 @@ class TestCountMatrixCooMult(unittest.TestCase):
     def test_count_matrix(self):
         """Small test cases"""
         C=count_matrix_coo_mult([self.S1,self.S2], 1, sliding=True).toarray()
-        self.assertTrue(np.allclose(C, self.B1_sliding))
+        assert_allclose(C, self.B1_sliding)
 
         C=count_matrix_coo_mult([self.S1,self.S2], 2, sliding=True).toarray()
-        self.assertTrue(np.allclose(C, self.B2_sliding))
+        assert_allclose(C, self.B2_sliding)
 
     def test_nstates_keyword(self):
         C=count_matrix_coo_mult([self.S1,self.S2], 1, sliding=True, nstates=10).toarray()
@@ -240,41 +241,41 @@ class TestCountMatrixCoo(unittest.TestCase):
     def test_count_matrix(self):
         """Small test cases"""
         C=count_matrix_coo(self.S_short, 1, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.B1_lag))
+        assert_allclose(C, self.B1_lag)
 
         C=count_matrix_coo(self.S_short, 2, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.B2_lag))
+        assert_allclose(C, self.B2_lag)
 
         C=count_matrix_coo(self.S_short, 3, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.B3_lag))
+        assert_allclose(C, self.B3_lag)
 
         C=count_matrix_coo(self.S_short, 1).toarray()
-        self.assertTrue(np.allclose(C, self.B1_sliding))
+        assert_allclose(C, self.B1_sliding)
 
         C=count_matrix_coo(self.S_short, 2).toarray()
-        self.assertTrue(np.allclose(C, self.B2_sliding))
+        assert_allclose(C, self.B2_sliding)
 
         C=count_matrix_coo(self.S_short, 3).toarray()
-        self.assertTrue(np.allclose(C, self.B3_sliding))
+        assert_allclose(C, self.B3_sliding)
 
         """Larger test cases"""
         C=count_matrix_coo(self.S_long, 1, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.C1_lag))
+        assert_allclose(C, self.C1_lag)
 
         C=count_matrix_coo(self.S_long, 7, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.C7_lag))
+        assert_allclose(C, self.C7_lag)
 
         C=count_matrix_coo(self.S_long, 13, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.C13_lag))
+        assert_allclose(C, self.C13_lag)
 
         C=count_matrix_coo(self.S_long, 1).toarray()
-        self.assertTrue(np.allclose(C, self.C1_sliding))
+        assert_allclose(C, self.C1_sliding)
 
         C=count_matrix_coo(self.S_long, 7).toarray()
-        self.assertTrue(np.allclose(C, self.C7_sliding))
+        assert_allclose(C, self.C7_sliding)
 
         C=count_matrix_coo(self.S_long, 13).toarray()
-        self.assertTrue(np.allclose(C, self.C13_sliding))
+        assert_allclose(C, self.C13_sliding)
 
         """Test raising of value error if lag greater than trajectory length"""
         with self.assertRaises(ValueError):
@@ -300,7 +301,7 @@ class TestAddCooMatrix(unittest.TestCase):
 
     def test_add_coo_matrix(self):
         C_test=add_coo_matrix(self.A, self.B)
-        self.assertTrue(np.allclose(C_test.toarray(), self.C.toarray()))
+        assert_allclose(C_test.toarray(), self.C.toarray())
 
 
 class TestMakeSquareCooMatrix(unittest.TestCase):
@@ -319,10 +320,10 @@ class TestMakeSquareCooMatrix(unittest.TestCase):
 
     def test_make_square_coo_matrix(self):
         A_test=make_square_coo_matrix(self.A)
-        self.assertTrue(np.allclose(A_test.toarray(), self.An_square))
+        assert_allclose(A_test.toarray(), self.An_square)
         
         B_test=make_square_coo_matrix(self.B)
-        self.assertTrue(np.allclose(B_test.toarray(), self.Bn_square))      
+        assert_allclose(B_test.toarray(), self.Bn_square)      
 
 ################################################################################
 # bincount
@@ -357,41 +358,41 @@ class TestCountMatrixBincount(unittest.TestCase):
     def test_count_matrix_bincount(self):
         """Small test cases"""
         C=count_matrix_bincount(self.S_short, 1, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.B1_lag))
+        assert_allclose(C, self.B1_lag)
 
         C=count_matrix_bincount(self.S_short, 2, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.B2_lag))
+        assert_allclose(C, self.B2_lag)
 
         C=count_matrix_bincount(self.S_short, 3, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.B3_lag))
+        assert_allclose(C, self.B3_lag)
 
         C=count_matrix_bincount(self.S_short, 1).toarray()
-        self.assertTrue(np.allclose(C, self.B1_sliding))
+        assert_allclose(C, self.B1_sliding)
 
         C=count_matrix_bincount(self.S_short, 2).toarray()
-        self.assertTrue(np.allclose(C, self.B2_sliding))
+        assert_allclose(C, self.B2_sliding)
 
         C=count_matrix_bincount(self.S_short, 3).toarray()
-        self.assertTrue(np.allclose(C, self.B3_sliding))
+        assert_allclose(C, self.B3_sliding)
 
         """Larger test cases"""
         C=count_matrix_bincount(self.S_long, 1, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.C1_lag))
+        assert_allclose(C, self.C1_lag)
 
         C=count_matrix_bincount(self.S_long, 7, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.C7_lag))
+        assert_allclose(C, self.C7_lag)
 
         C=count_matrix_bincount(self.S_long, 13, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.C13_lag))
+        assert_allclose(C, self.C13_lag)
 
         C=count_matrix_bincount(self.S_long, 1).toarray()
-        self.assertTrue(np.allclose(C, self.C1_sliding))
+        assert_allclose(C, self.C1_sliding)
 
         C=count_matrix_bincount(self.S_long, 7).toarray()
-        self.assertTrue(np.allclose(C, self.C7_sliding))
+        assert_allclose(C, self.C7_sliding)
 
         C=count_matrix_bincount(self.S_long, 13).toarray()
-        self.assertTrue(np.allclose(C, self.C13_sliding))
+        assert_allclose(C, self.C13_sliding)
 
         """Test raising of value error if lag greater than trajectory length"""
         with self.assertRaises(ValueError):
@@ -437,41 +438,41 @@ class TestCountMatrixBincountMult(unittest.TestCase):
     def test_count_matrix_bincount_mult(self):
         """Small test cases"""
         C=count_matrix_bincount_mult(self.dtrajs_short, 1, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.B1_lag))
+        assert_allclose(C, self.B1_lag)
 
         C=count_matrix_bincount_mult(self.dtrajs_short, 2, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.B2_lag))
+        assert_allclose(C, self.B2_lag)
 
         C=count_matrix_bincount_mult(self.dtrajs_short, 3, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.B3_lag))
+        assert_allclose(C, self.B3_lag)
 
         C=count_matrix_bincount_mult(self.dtrajs_short , 1).toarray()
-        self.assertTrue(np.allclose(C, self.B1_sliding))
+        assert_allclose(C, self.B1_sliding)
 
         C=count_matrix_bincount_mult(self.dtrajs_short , 2).toarray()
-        self.assertTrue(np.allclose(C, self.B2_sliding))
+        assert_allclose(C, self.B2_sliding)
 
         C=count_matrix_bincount_mult(self.dtrajs_short , 3).toarray()
-        self.assertTrue(np.allclose(C, self.B3_sliding))
+        assert_allclose(C, self.B3_sliding)
 
         """Larger test cases"""
         C=count_matrix_bincount_mult(self.dtrajs_long, 1, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.C1_lag))
+        assert_allclose(C, self.C1_lag)
 
         C=count_matrix_bincount_mult(self.dtrajs_long, 7, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.C7_lag))
+        assert_allclose(C, self.C7_lag)
 
         C=count_matrix_bincount_mult(self.dtrajs_long, 13, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.C13_lag))
+        assert_allclose(C, self.C13_lag)
 
         C=count_matrix_bincount_mult(self.dtrajs_long, 1).toarray()
-        self.assertTrue(np.allclose(C, self.C1_sliding))
+        assert_allclose(C, self.C1_sliding)
 
         C=count_matrix_bincount_mult(self.dtrajs_long, 7).toarray()
-        self.assertTrue(np.allclose(C, self.C7_sliding))
+        assert_allclose(C, self.C7_sliding)
 
         C=count_matrix_bincount_mult(self.dtrajs_long, 13).toarray()
-        self.assertTrue(np.allclose(C, self.C13_sliding))
+        assert_allclose(C, self.C13_sliding)
 
         """Test raising of value error if lag greater than trajectory length"""
         with self.assertRaises(ValueError):

--- a/pyemma/msm/estimation/sparse/likelihood_test.py
+++ b/pyemma/msm/estimation/sparse/likelihood_test.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 import scipy.sparse
 
 import likelihood
@@ -24,7 +25,7 @@ class TestTransitionMatrix(unittest.TestCase):
     def test_count_matrix(self):
         """Small test cases"""
         log=likelihood.log_likelihood(self.C1, self.T1)
-        self.assertTrue(np.allclose(log, np.log(0.8*0.2**3*0.9**3*0.1)))        
+        assert_allclose(log, np.log(0.8*0.2**3*0.9**3*0.1))        
         
         
 if __name__=="__main__":

--- a/pyemma/msm/estimation/sparse/prior_test.py
+++ b/pyemma/msm/estimation/sparse/prior_test.py
@@ -6,6 +6,7 @@ r"""Unit test for the prior module
 import unittest
 
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 
 from scipy.sparse import csr_matrix
 
@@ -42,17 +43,17 @@ class TestPrior(unittest.TestCase):
 
     def test_prior_const(self):
         Bn=prior.prior_const(self.C)
-        self.assertTrue(np.allclose(Bn, self.alpha_def*self.B_const))
+        assert_allclose(Bn, self.alpha_def*self.B_const)
 
         Bn=prior.prior_const(self.C, alpha=self.alpha)
-        self.assertTrue(np.allclose(Bn, self.alpha*self.B_const))
+        assert_allclose(Bn, self.alpha*self.B_const)
 
     def test_prior_rev(self):
         Bn=prior.prior_rev(self.C)
-        self.assertTrue(np.allclose(Bn, -1.0*self.B_rev))
+        assert_allclose(Bn, -1.0*self.B_rev)
 
         Bn=prior.prior_rev(self.C, alpha=self.alpha)
-        self.assertTrue(np.allclose(Bn, self.alpha*self.B_rev))
+        assert_allclose(Bn, self.alpha*self.B_rev)
         
 
 if __name__=="__main__":

--- a/pyemma/msm/estimation/sparse/transition_matrix_test.py
+++ b/pyemma/msm/estimation/sparse/transition_matrix_test.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 import scipy.sparse
 
 import transition_matrix
@@ -26,10 +27,10 @@ class TestTransitionMatrixNonReversible(unittest.TestCase):
     def test_count_matrix(self):
         """Small test cases"""
         T=transition_matrix.transition_matrix_non_reversible(self.C1).toarray()
-        self.assertTrue(np.allclose(T, self.T1.toarray()))
+        assert_allclose(T, self.T1.toarray())
         
         T=transition_matrix.transition_matrix_non_reversible(self.C1).toarray()
-        self.assertTrue(np.allclose(T, self.T1.toarray()))      
+        assert_allclose(T, self.T1.toarray())      
 
         
 if __name__=="__main__":

--- a/pyemma/msm/estimation/tests/test_connectivity.py
+++ b/pyemma/msm/estimation/tests/test_connectivity.py
@@ -7,6 +7,7 @@ r"""Unit tests for the connectivity API functions
 import unittest
 
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 import scipy.sparse
 
 from pyemma.msm.estimation import connected_sets, largest_connected_set, largest_connected_submatrix, is_connected
@@ -110,11 +111,11 @@ class TestConnectedCountMatrixDense(unittest.TestCase):
     def test_connected_count_matrix(self):
         """Directed"""
         C_cc=largest_connected_submatrix(self.C)
-        self.assertTrue(np.allclose(C_cc, self.C_cc_directed))
+        assert_allclose(C_cc, self.C_cc_directed)
 
         """Undirected"""
         C_cc=largest_connected_submatrix(self.C, directed=False)
-        self.assertTrue(np.allclose(C_cc, self.C_cc_undirected))
+        assert_allclose(C_cc, self.C_cc_undirected)
         
 class TestIsConnectedDense(unittest.TestCase):
         
@@ -247,19 +248,19 @@ class TestConnectedCountMatrixSparse(unittest.TestCase):
     def test_connected_count_matrix(self):
         """Directed"""
         C_cc=largest_connected_submatrix(self.C)
-        self.assertTrue(np.allclose(C_cc.toarray(), self.C_cc_directed))
+        assert_allclose(C_cc.toarray(), self.C_cc_directed)
 
         """Directed with user specified lcc"""
         C_cc=largest_connected_submatrix(self.C, lcc=np.array([0, 1]))
-        self.assertTrue(np.allclose(C_cc.toarray(), self.C_cc_directed[0:2,0:2]))
+        assert_allclose(C_cc.toarray(), self.C_cc_directed[0:2,0:2])
 
         """Undirected"""
         C_cc=largest_connected_submatrix(self.C, directed=False)
-        self.assertTrue(np.allclose(C_cc.toarray(), self.C_cc_undirected))
+        assert_allclose(C_cc.toarray(), self.C_cc_undirected)
 
         """Undirected with user specified lcc"""
         C_cc=largest_connected_submatrix(self.C, lcc=np.array([0, 1]), directed=False)
-        self.assertTrue(np.allclose(C_cc.toarray(), self.C_cc_undirected[0:2,0:2]))
+        assert_allclose(C_cc.toarray(), self.C_cc_undirected[0:2,0:2])
         
 class TestIsConnectedSparse(unittest.TestCase):
         

--- a/pyemma/msm/estimation/tests/test_count_matrix.py
+++ b/pyemma/msm/estimation/tests/test_count_matrix.py
@@ -3,6 +3,7 @@
 import unittest
 
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 import scipy.sparse
 
 from os.path import abspath, join
@@ -28,10 +29,10 @@ class TestCountMatrixMult(unittest.TestCase):
     def test_count_matrix(self):
         """Small test cases"""
         C=count_matrix([self.S1,self.S2], 1, sliding=True).toarray()
-        self.assertTrue(np.allclose(C, self.B1_sliding))
+        assert_allclose(C, self.B1_sliding)
 
         C=count_matrix([self.S1,self.S2], 2, sliding=True).toarray()
-        self.assertTrue(np.allclose(C, self.B2_sliding))
+        assert_allclose(C, self.B2_sliding)
 
     def test_nstates_keyword(self):
         C=count_matrix([self.S1,self.S2], 1, sliding=True, nstates=10)
@@ -71,41 +72,41 @@ class TestCountMatrix(unittest.TestCase):
     def test_count_matrix(self):
         """Small test cases"""
         C=count_matrix(self.S_short, 1, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.B1_lag))
+        assert_allclose(C, self.B1_lag)
 
         C=count_matrix(self.S_short, 2, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.B2_lag))
+        assert_allclose(C, self.B2_lag)
 
         C=count_matrix(self.S_short, 3, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.B3_lag))
+        assert_allclose(C, self.B3_lag)
 
         C=count_matrix(self.S_short, 1).toarray()
-        self.assertTrue(np.allclose(C, self.B1_sliding))
+        assert_allclose(C, self.B1_sliding)
 
         C=count_matrix(self.S_short, 2).toarray()
-        self.assertTrue(np.allclose(C, self.B2_sliding))
+        assert_allclose(C, self.B2_sliding)
 
         C=count_matrix(self.S_short, 3).toarray()
-        self.assertTrue(np.allclose(C, self.B3_sliding))
+        assert_allclose(C, self.B3_sliding)
 
         """Larger test cases"""
         C=count_matrix(self.S_long, 1, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.C1_lag))
+        assert_allclose(C, self.C1_lag)
 
         C=count_matrix(self.S_long, 7, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.C7_lag))
+        assert_allclose(C, self.C7_lag)
 
         C=count_matrix(self.S_long, 13, sliding=False).toarray()
-        self.assertTrue(np.allclose(C, self.C13_lag))
+        assert_allclose(C, self.C13_lag)
 
         C=count_matrix(self.S_long, 1).toarray()
-        self.assertTrue(np.allclose(C, self.C1_sliding))
+        assert_allclose(C, self.C1_sliding)
 
         C=count_matrix(self.S_long, 7).toarray()
-        self.assertTrue(np.allclose(C, self.C7_sliding))
+        assert_allclose(C, self.C7_sliding)
 
         C=count_matrix(self.S_long, 13).toarray()
-        self.assertTrue(np.allclose(C, self.C13_sliding))
+        assert_allclose(C, self.C13_sliding)
 
         """Test raising of value error if lag greater than trajectory length"""
         with self.assertRaises(ValueError):

--- a/pyemma/msm/estimation/tests/test_likelihood.py
+++ b/pyemma/msm/estimation/tests/test_likelihood.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 import scipy.sparse
 
 from pyemma.msm.estimation import log_likelihood
@@ -24,7 +25,7 @@ class TestTransitionMatrix(unittest.TestCase):
     def test_count_matrix(self):
         """Small test cases"""
         log=log_likelihood(self.C1, self.T1)
-        self.assertTrue(np.allclose(log, np.log(0.8*0.2**3*0.9**3*0.1)))        
+        assert_allclose(log, np.log(0.8*0.2**3*0.9**3*0.1))        
         
         
 if __name__=="__main__":

--- a/pyemma/msm/estimation/tests/test_mle_trev.py
+++ b/pyemma/msm/estimation/tests/test_mle_trev.py
@@ -1,5 +1,6 @@
 import unittest
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 import scipy
 import scipy.sparse
 
@@ -23,9 +24,9 @@ class Test_mle_trev(unittest.TestCase):
         T_api_dense = apicall(C,reversible=True)
         T_api_sparse = apicall(scipy.sparse.csr_matrix(C),reversible=True).toarray() 
 
-        self.assertTrue(np.allclose(T_cython_sparse,T_python))
-        self.assertTrue(np.allclose(T_api_sparse,T_python))
-        self.assertTrue(np.allclose(T_api_dense,T_python))            
+        assert_allclose(T_cython_sparse, T_python)
+        assert_allclose(T_api_sparse, T_python)
+        assert_allclose(T_api_dense, T_python)
 
 
 if __name__ == '__main__':

--- a/pyemma/msm/estimation/tests/test_mle_trev_given_pi.py
+++ b/pyemma/msm/estimation/tests/test_mle_trev_given_pi.py
@@ -1,5 +1,6 @@
 import unittest
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 import scipy
 import scipy.sparse
 
@@ -32,10 +33,10 @@ class Test_mle_trev_given_pi(unittest.TestCase):
         # print T_python
         # print T_api_sparse
 
-        self.assertTrue(np.allclose(T_cython_dense,T_python))
-        self.assertTrue(np.allclose(T_cython_sparse,T_python))
-        self.assertTrue(np.allclose(T_api_sparse,T_python))
-        self.assertTrue(np.allclose(T_api_dense,T_python))
+        assert_allclose(T_cython_dense, T_python)
+        assert_allclose(T_cython_sparse, T_python)
+        assert_allclose(T_api_sparse, T_python)
+        assert_allclose(T_api_dense, T_python)
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyemma/msm/estimation/tests/test_prior.py
+++ b/pyemma/msm/estimation/tests/test_prior.py
@@ -7,6 +7,7 @@ import unittest
 import warnings
 
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 
 from scipy.sparse import csr_matrix
 
@@ -35,24 +36,24 @@ class TestPriorDense(unittest.TestCase):
 
     def test_prior_neighbor(self):
         Bn=prior_neighbor(self.C)
-        self.assertTrue(np.allclose(Bn, self.alpha_def*self.B_neighbor))
+        assert_allclose(Bn, self.alpha_def*self.B_neighbor)
 
         Bn=prior_neighbor(self.C, alpha=self.alpha)
-        self.assertTrue(np.allclose(Bn, self.alpha*self.B_neighbor))
+        assert_allclose(Bn, self.alpha*self.B_neighbor)
 
     def test_prior_const(self):
         Bn=prior_const(self.C)
-        self.assertTrue(np.allclose(Bn, self.alpha_def*self.B_const))
+        assert_allclose(Bn, self.alpha_def*self.B_const)
 
         Bn=prior_const(self.C, alpha=self.alpha)
-        self.assertTrue(np.allclose(Bn, self.alpha*self.B_const))
+        assert_allclose(Bn, self.alpha*self.B_const)
 
     def test_prior_rev(self):
         Bn=prior_rev(self.C)
-        self.assertTrue(np.allclose(Bn, -1.0*self.B_rev))
+        assert_allclose(Bn, -1.0*self.B_rev)
 
         Bn=prior_rev(self.C, alpha=self.alpha)
-        self.assertTrue(np.allclose(Bn, self.alpha*self.B_rev))
+        assert_allclose(Bn, self.alpha*self.B_rev)
 
 class TestPriorSparse(unittest.TestCase):
     
@@ -84,20 +85,20 @@ class TestPriorSparse(unittest.TestCase):
     def test_prior_const(self):
         with warnings.catch_warnings(record=True) as w:
             Bn=prior_const(self.C)
-            self.assertTrue(np.allclose(Bn, self.alpha_def*self.B_const))
+            assert_allclose(Bn, self.alpha_def*self.B_const)
 
         with warnings.catch_warnings(record=True) as w:
             Bn=prior_const(self.C, alpha=self.alpha)
-            self.assertTrue(np.allclose(Bn, self.alpha*self.B_const))
+            assert_allclose(Bn, self.alpha*self.B_const)
 
     def test_prior_rev(self):
         with warnings.catch_warnings(record=True) as w:
             Bn=prior_rev(self.C)
-            self.assertTrue(np.allclose(Bn, -1.0*self.B_rev))
+            assert_allclose(Bn, -1.0*self.B_rev)
 
         with warnings.catch_warnings(record=True) as w:
             Bn=prior_rev(self.C, alpha=self.alpha)
-            self.assertTrue(np.allclose(Bn, self.alpha*self.B_rev))
+            assert_allclose(Bn, self.alpha*self.B_rev)
         
 
 if __name__=="__main__":

--- a/pyemma/msm/estimation/tests/test_transition_matrix.py
+++ b/pyemma/msm/estimation/tests/test_transition_matrix.py
@@ -2,6 +2,7 @@ import unittest
 import warnings
 
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 import scipy.sparse
 
 from pyemma.msm.estimation import transition_matrix, tmatrix_cov, error_perturbation
@@ -30,24 +31,24 @@ class TestTransitionMatrixNonReversibleSparse(unittest.TestCase):
     def test_transition_matrix(self):
         """Non-reversible"""
         T=transition_matrix(self.C1).toarray()
-        self.assertTrue(np.allclose(T, self.T1.toarray()))
+        assert_allclose(T, self.T1.toarray())
         
         T=transition_matrix(self.C2).toarray()
-        self.assertTrue(np.allclose(T, self.T2.toarray()))   
+        assert_allclose(T, self.T2.toarray())   
 
         """Reversible"""
         T=transition_matrix(self.C1, rversible=True).toarray()
-        self.assertTrue(np.allclose(T, self.T1.toarray()))
+        assert_allclose(T, self.T1.toarray())
 
         T=transition_matrix(self.C2, reversible=True).toarray()
-        self.assertTrue(np.allclose(T, self.T2.toarray()))   
+        assert_allclose(T, self.T2.toarray())   
 
         """Reversible with fixed pi"""
         T=transition_matrix(self.C1, rversible=True, pi=self.pi1).toarray()
-        self.assertTrue(np.allclose(T, self.T1.toarray()))
+        assert_allclose(T, self.T1.toarray())
         
         T=transition_matrix(self.C2, rversible=True, pi=self.pi2).toarray()
-        self.assertTrue(np.allclose(T, self.T2.toarray()))       
+        assert_allclose(T, self.T2.toarray())       
         
 
 class TestCovariance(unittest.TestCase):
@@ -74,10 +75,10 @@ class TestCovariance(unittest.TestCase):
 
     def test_tmatrix_cov(self):
         cov=tmatrix_cov(self.C)
-        self.assertTrue(np.allclose(cov, self.cov))
+        assert_allclose(cov, self.cov)
 
         cov=tmatrix_cov(self.C, k=1)
-        self.assertTrue(np.allclose(cov, self.cov[1, :, :]))
+        assert_allclose(cov, self.cov[1, :, :])
 
 class TestErrorPerturbation(unittest.TestCase):
     def setUp(self):
@@ -117,21 +118,21 @@ class TestErrorPerturbation(unittest.TestCase):
 
     def test_error_perturbation(self):
         xn=error_perturbation(self.C, self.S1)
-        self.assertTrue(np.allclose(xn, self.x))
+        assert_allclose(xn, self.x)
 
         Xn=error_perturbation(self.C, self.S2)
-        self.assertTrue(np.allclose(Xn, self.X))   
+        assert_allclose(Xn, self.X)   
 
     def test_error_perturbation_sparse(self):
         Csparse=scipy.sparse.csr_matrix(self.C)
 
         with warnings.catch_warnings(record=True) as w:
             xn=error_perturbation(Csparse,self.S1)
-            self.assertTrue(np.allclose(xn, self.x))
+            assert_allclose(xn, self.x)
 
         with warnings.catch_warnings(record=True) as w:
             Xn=error_perturbation(Csparse,self.S2)
-            self.assertTrue(np.allclose(Xn, self.X))
+            assert_allclose(Xn, self.X)
         
         
 if __name__=="__main__":

--- a/pyemma/msm/flux/dense/tpt_test.py
+++ b/pyemma/msm/flux/dense/tpt_test.py
@@ -6,6 +6,7 @@ r"""Unit test for the TPT-module
 
 import unittest
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 
 import tpt
 
@@ -266,19 +267,19 @@ class TestTPT(unittest.TestCase):
 
     def test_flux(self):
         flux=self.bdc.flux(self.a, self.b)        
-        self.assertTrue(np.allclose(self.fluxn, flux))
+        assert_allclose(self.fluxn, flux)
 
     def test_netflux(self):
         netflux=self.bdc.netflux(self.a, self.b)
-        self.assertTrue(np.allclose(self.netfluxn, netflux))
+        assert_allclose(self.netfluxn, netflux)
 
     def test_totalflux(self):
         F=self.bdc.totalflux(self.a, self.b)
-        self.assertTrue(np.allclose(self.Fn, F))
+        assert_allclose(self.Fn, F)
 
     def test_rate(self):
         k=self.bdc.rate(self.a, self.b)
-        self.assertTrue(np.allclose(self.kn, k))
+        assert_allclose(self.kn, k)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/msm/flux/reactive_flux_test.py
+++ b/pyemma/msm/flux/reactive_flux_test.py
@@ -6,6 +6,7 @@ Created on Aug 14, 2014
 
 import unittest
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 
 import api as msmapi
 import pyemma.msm.analysis as msmana
@@ -120,29 +121,29 @@ class TestReactiveFluxFunctions(unittest.TestCase):
         self.assertEqual(self.tpt1.B, self.B)
     
     def test_flux(self):
-        self.assertTrue(np.allclose(self.tpt1.flux, self.ref_netflux, rtol=1e-02, atol=1e-07))
+        assert_allclose(self.tpt1.flux, self.ref_netflux, rtol=1e-02, atol=1e-07)
     
     def test_netflux(self):
-        self.assertTrue(np.allclose(self.tpt1.net_flux, self.ref_netflux, rtol=1e-02, atol=1e-07))
+        assert_allclose(self.tpt1.net_flux, self.ref_netflux, rtol=1e-02, atol=1e-07)
     
     def test_grossflux(self):
-        self.assertTrue(np.allclose(self.tpt1.gross_flux, self.ref_grossflux, rtol=1e-02, atol=1e-07))
+        assert_allclose(self.tpt1.gross_flux, self.ref_grossflux, rtol=1e-02, atol=1e-07)
     
     def test_committor(self):
-        self.assertTrue(np.allclose(self.tpt1.committor, self.ref_committor, rtol=1e-02, atol=1e-07))
+        assert_allclose(self.tpt1.committor, self.ref_committor, rtol=1e-02, atol=1e-07)
     
     def test_forwardcommittor(self):
-        self.assertTrue(np.allclose(self.tpt1.forward_committor, self.ref_committor, rtol=1e-02, atol=1e-07))
+        assert_allclose(self.tpt1.forward_committor, self.ref_committor, rtol=1e-02, atol=1e-07)
     
     def test_backwardcommittor(self):
-        self.assertTrue(np.allclose(self.tpt1.backward_committor, self.ref_backwardcommittor, rtol=1e-02, atol=1e-07))
+        assert_allclose(self.tpt1.backward_committor, self.ref_backwardcommittor, rtol=1e-02, atol=1e-07)
     
     def test_total_flux(self):
-        self.assertTrue(np.allclose(self.tpt1.total_flux, self.ref_totalflux, rtol=1e-02, atol=1e-07))
+        assert_allclose(self.tpt1.total_flux, self.ref_totalflux, rtol=1e-02, atol=1e-07)
     
     def test_rate(self):
-        self.assertTrue(np.allclose(self.tpt1.rate, self.ref_kAB, rtol=1e-02, atol=1e-07))
-        self.assertTrue(np.allclose(1.0/self.tpt1.rate, self.ref_mfptAB, rtol=1e-02, atol=1e-07))
+        assert_allclose(self.tpt1.rate, self.ref_kAB, rtol=1e-02, atol=1e-07)
+        assert_allclose(1.0/self.tpt1.rate, self.ref_mfptAB, rtol=1e-02, atol=1e-07)
     
     def test_pathways(self):
         # all paths
@@ -150,19 +151,19 @@ class TestReactiveFluxFunctions(unittest.TestCase):
         self.assertEqual(len(paths), len(self.ref_paths))
         for i in range(len(paths)):
             self.assertTrue(np.all(np.array(paths[i]) == np.array(self.ref_paths[i])))
-        self.assertTrue(np.allclose(pathfluxes, self.ref_pathfluxes, rtol=1e-02, atol=1e-07))
+        assert_allclose(pathfluxes, self.ref_pathfluxes, rtol=1e-02, atol=1e-07)
         # major paths
         (paths,pathfluxes) = self.tpt1.pathways(fraction = 0.99)
         self.assertEqual(len(paths), len(self.ref_paths_99percent))
         for i in range(len(paths)):
             self.assertTrue(np.all(np.array(paths[i]) == np.array(self.ref_paths_99percent[i])))
-        self.assertTrue(np.allclose(pathfluxes, self.ref_pathfluxes_99percent, rtol=1e-02, atol=1e-07))
+        assert_allclose(pathfluxes, self.ref_pathfluxes_99percent, rtol=1e-02, atol=1e-07)
     
     def test_major_flux(self):
         # all flux
-        self.assertTrue(np.allclose(self.tpt1.major_flux(fraction=1.0), self.ref_netflux, rtol=1e-02, atol=1e-07))
+        assert_allclose(self.tpt1.major_flux(fraction=1.0), self.ref_netflux, rtol=1e-02, atol=1e-07)
         # 0.99 flux
-        self.assertTrue(np.allclose(self.tpt1.major_flux(fraction=0.99), self.ref_majorflux_99percent, rtol=1e-02, atol=1e-07))
+        assert_allclose(self.tpt1.major_flux(fraction=0.99), self.ref_majorflux_99percent, rtol=1e-02, atol=1e-07)
     
     def test_coarse_grain(self):
         (tpt_sets,cgRF) = self.tpt2.coarse_grain(self.coarsesets2)
@@ -170,13 +171,13 @@ class TestReactiveFluxFunctions(unittest.TestCase):
         self.assertEqual(cgRF.A, self.ref2_cgA)
         self.assertEqual(cgRF.I, self.ref2_cgI)
         self.assertEqual(cgRF.B, self.ref2_cgB)
-        self.assertTrue(np.allclose(cgRF.stationary_distribution, self.ref2_cgpstat))
-        self.assertTrue(np.allclose(cgRF.committor, self.ref2_cgcommittor))
-        self.assertTrue(np.allclose(cgRF.forward_committor, self.ref2_cgcommittor))
-        self.assertTrue(np.allclose(cgRF.backward_committor, self.ref2_cgbackwardcommittor))
-        self.assertTrue(np.allclose(cgRF.flux, self.ref2_cgnetflux))
-        self.assertTrue(np.allclose(cgRF.net_flux, self.ref2_cgnetflux))
-        self.assertTrue(np.allclose(cgRF.gross_flux, self.ref2_cggrossflux))
+        assert_allclose(cgRF.stationary_distribution, self.ref2_cgpstat)
+        assert_allclose(cgRF.committor, self.ref2_cgcommittor)
+        assert_allclose(cgRF.forward_committor, self.ref2_cgcommittor)
+        assert_allclose(cgRF.backward_committor, self.ref2_cgbackwardcommittor)
+        assert_allclose(cgRF.flux, self.ref2_cgnetflux)
+        assert_allclose(cgRF.net_flux, self.ref2_cgnetflux)
+        assert_allclose(cgRF.gross_flux, self.ref2_cggrossflux)
 
 
 if __name__ == "__main__":

--- a/pyemma/msm/flux/sparse/tpt_test.py
+++ b/pyemma/msm/flux/sparse/tpt_test.py
@@ -6,6 +6,7 @@ r"""Unit test for the TPT-module
 
 import unittest
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 
 from scipy.sparse import csr_matrix
 
@@ -252,7 +253,7 @@ class TestRemoveNegativeEntries(unittest.TestCase):
         Aplus = self.Aplus
 
         Aplusn = tpt.remove_negative_entries(A)
-        self.assertTrue(np.allclose(Aplusn.toarray(), Aplus))
+        assert_allclose(Aplusn.toarray(), Aplus)
 
 
 class TestTPT(unittest.TestCase):
@@ -288,19 +289,19 @@ class TestTPT(unittest.TestCase):
 
     def test_flux(self):
         flux=self.bdc.flux(self.a, self.b)        
-        self.assertTrue(np.allclose(self.fluxn.toarray(), flux))
+        assert_allclose(self.fluxn.toarray(), flux)
 
     def test_netflux(self):
         netflux=self.bdc.netflux(self.a, self.b)
-        self.assertTrue(np.allclose(self.netfluxn.toarray(), netflux))
+        assert_allclose(self.netfluxn.toarray(), netflux)
 
     #def test_totalflux(self):
     #    F=self.bdc.totalflux(self.a, self.b)
-    #    self.assertTrue(np.allclose(self.Fn, F))
+    #    assert_allclose(self.Fn, F)
 
     #def test_rate(self):
     #    k=self.bdc.rate(self.a, self.b)
-    #    self.assertTrue(np.allclose(self.kn, k))
+    #    assert_allclose(self.kn, k)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/msm/flux/tests/test_tpt.py
+++ b/pyemma/msm/flux/tests/test_tpt.py
@@ -6,6 +6,7 @@ r"""Unit test for the TPT-functions of the analysis API
 
 import unittest
 import numpy as np
+from pyemma.util.numeric import assert_allclose
 
 from scipy.sparse import csr_matrix
 
@@ -48,64 +49,64 @@ class TestTPTDense(unittest.TestCase):
         flux=self.bdc.flux(self.a, self.b)        
         
         fluxn=self.tpt.gross_flux
-        self.assertTrue(np.allclose(fluxn, flux))
+        assert_allclose(fluxn, flux)
 
         fluxn=self.tpt_fast.gross_flux
-        self.assertTrue(np.allclose(fluxn, flux))
+        assert_allclose(fluxn, flux)
 
     def test_netflux(self):
         netflux=self.bdc.netflux(self.a, self.b)
         
         netfluxn=self.tpt.net_flux
-        self.assertTrue(np.allclose(netfluxn, netflux))
+        assert_allclose(netfluxn, netflux)
 
         netfluxn=self.tpt_fast.net_flux
-        self.assertTrue(np.allclose(netfluxn, netflux))        
+        assert_allclose(netfluxn, netflux)        
 
     def test_totalflux(self):
         F=self.bdc.totalflux(self.a, self.b)
 
         Fn=self.tpt.total_flux
-        self.assertTrue(np.allclose(Fn, F))
+        assert_allclose(Fn, F)
 
         Fn=self.tpt_fast.total_flux
-        self.assertTrue(np.allclose(Fn, F))
+        assert_allclose(Fn, F)
 
     def test_rate(self):
         k=self.bdc.rate(self.a, self.b)
         
         kn=self.tpt.rate
-        self.assertTrue(np.allclose(kn, k))
+        assert_allclose(kn, k)
 
         kn=self.tpt_fast.rate
-        self.assertTrue(np.allclose(kn, k))
+        assert_allclose(kn, k)
 
     def test_backward_committor(self):
         qminus=self.qminus
 
         qminusn=self.tpt.backward_committor
-        self.assertTrue(np.allclose(qminusn, qminus))
+        assert_allclose(qminusn, qminus)
 
         qminusn=self.tpt_fast.backward_committor
-        self.assertTrue(np.allclose(qminusn, qminus))
+        assert_allclose(qminusn, qminus)
 
     def test_forward_committor(self):
         qplus=self.qplus
 
         qplusn=self.tpt.forward_committor
-        self.assertTrue(np.allclose(qplusn, qplus))
+        assert_allclose(qplusn, qplus)
 
         qplusn=self.tpt_fast.forward_committor
-        self.assertTrue(np.allclose(qplusn, qplus))
+        assert_allclose(qplusn, qplus)
 
     def test_stationary_distribution(self):
         mu=self.mu
         
         mun=self.tpt.stationary_distribution
-        self.assertTrue(np.allclose(mun, mu))
+        assert_allclose(mun, mu)
 
         mun=self.tpt_fast.stationary_distribution
-        self.assertTrue(np.allclose(mun, mu))
+        assert_allclose(mun, mu)
 
 
 class TestTptFunctionsDense(unittest.TestCase):
@@ -138,19 +139,19 @@ class TestTptFunctionsDense(unittest.TestCase):
     
     def test_tpt_flux(self):
         flux=self.bdc.flux(self.a, self.b)        
-        self.assertTrue(np.allclose(self.fluxn, flux))
+        assert_allclose(self.fluxn, flux)
 
     def test_tpt_netflux(self):
         netflux=self.bdc.netflux(self.a, self.b)
-        self.assertTrue(np.allclose(self.netfluxn, netflux))
+        assert_allclose(self.netfluxn, netflux)
 
     def test_tpt_totalflux(self):
         totalflux=self.bdc.totalflux(self.a, self.b)
-        self.assertTrue(np.allclose(self.totalfluxn, totalflux))
+        assert_allclose(self.totalfluxn, totalflux)
 
     def test_tpt_rate(self):
         rate=self.bdc.rate(self.a, self.b)
-        self.assertTrue(np.allclose(self.raten, rate))
+        assert_allclose(self.raten, rate)
 
 
 ################################################################################
@@ -192,64 +193,64 @@ class TestTPTSparse(unittest.TestCase):
         flux=self.bdc.flux(self.a, self.b)        
 
         fluxn=self.tpt.gross_flux
-        self.assertTrue(np.allclose(fluxn.toarray(), flux))
+        assert_allclose(fluxn.toarray(), flux)
 
         fluxn=self.tpt_fast.gross_flux
-        self.assertTrue(np.allclose(fluxn.toarray(), flux))
+        assert_allclose(fluxn.toarray(), flux)
 
     def test_netflux(self):
         netflux=self.bdc.netflux(self.a, self.b)
         
         netfluxn=self.tpt.net_flux
-        self.assertTrue(np.allclose(netfluxn.toarray(), netflux))
+        assert_allclose(netfluxn.toarray(), netflux)
 
         netfluxn=self.tpt_fast.net_flux
-        self.assertTrue(np.allclose(netfluxn.toarray(), netflux))        
+        assert_allclose(netfluxn.toarray(), netflux)        
 
     def test_totalflux(self):
         F=self.bdc.totalflux(self.a, self.b)
 
         Fn=self.tpt.total_flux
-        self.assertTrue(np.allclose(Fn, F))
+        assert_allclose(Fn, F)
 
         Fn=self.tpt_fast.total_flux
-        self.assertTrue(np.allclose(Fn, F))
+        assert_allclose(Fn, F)
 
     def test_rate(self):
         k=self.bdc.rate(self.a, self.b)
         
         kn=self.tpt.rate
-        self.assertTrue(np.allclose(kn, k))
+        assert_allclose(kn, k)
 
         kn=self.tpt_fast.rate
-        self.assertTrue(np.allclose(kn, k))
+        assert_allclose(kn, k)
 
     def test_backward_committor(self):
         qminus=self.qminus
 
         qminusn=self.tpt.backward_committor
-        self.assertTrue(np.allclose(qminusn, qminus))
+        assert_allclose(qminusn, qminus)
 
         qminusn=self.tpt_fast.backward_committor
-        self.assertTrue(np.allclose(qminusn, qminus))
+        assert_allclose(qminusn, qminus)
 
     def test_forward_committor(self):
         qplus=self.qplus
 
         qplusn=self.tpt.forward_committor
-        self.assertTrue(np.allclose(qplusn, qplus))
+        assert_allclose(qplusn, qplus)
 
         qplusn=self.tpt_fast.forward_committor
-        self.assertTrue(np.allclose(qplusn, qplus))
+        assert_allclose(qplusn, qplus)
 
     def test_stationary_distribution(self):
         mu=self.mu
         
         mun=self.tpt.stationary_distribution
-        self.assertTrue(np.allclose(mun, mu))
+        assert_allclose(mun, mu)
 
         mun=self.tpt_fast.stationary_distribution
-        self.assertTrue(np.allclose(mun, mu))
+        assert_allclose(mun, mu)
 
 class TestTptFunctionsSparse(unittest.TestCase):
     def setUp(self):
@@ -283,19 +284,19 @@ class TestTptFunctionsSparse(unittest.TestCase):
     
     def test_tpt_flux(self):
         flux=self.bdc.flux(self.a, self.b)
-        self.assertTrue(np.allclose(self.fluxn.toarray(), flux))
+        assert_allclose(self.fluxn.toarray(), flux)
 
     def test_tpt_netflux(self):
         netflux=self.bdc.netflux(self.a, self.b)
-        self.assertTrue(np.allclose(self.netfluxn.toarray(), netflux))
+        assert_allclose(self.netfluxn.toarray(), netflux)
 
     def test_tpt_totalflux(self):
         totalflux=self.bdc.totalflux(self.a, self.b)
-        self.assertTrue(np.allclose(self.totalfluxn, totalflux))
+        assert_allclose(self.totalfluxn, totalflux)
 
     def test_tpt_rate(self):
         rate=self.bdc.rate(self.a, self.b)
-        self.assertTrue(np.allclose(self.raten, rate))
+        assert_allclose(self.raten, rate)
 
 
 if __name__ == "__main__":

--- a/pyemma/util/numeric.py
+++ b/pyemma/util/numeric.py
@@ -8,6 +8,7 @@ import numpy as np
 from scipy.sparse import dia_matrix
 
 __all__ = ['allclose_sparse',
+           'assert_allclose',
            'diags',
            'isclose',
            'choice',
@@ -393,3 +394,11 @@ except ImportError:
             return res
 
         return a[idx]
+
+
+def assert_allclose(actual, desired, rtol=1.e-5, atol=1.e-8,
+                    err_msg='', verbose=True):
+    r"""wrapper for numpy.testing.allclose with default tolerances of
+    numpy.allclose. Needed since testing method has different values."""
+    from numpy.testing import assert_allclose
+    return assert_allclose(actual, desired, rtol, atol, err_msg, verbose)


### PR DESCRIPTION
To use default values of atol/rtol of numpy.allclose, please use wrapper provided in util.numeric