### PR TITLE
Modified Ben's cool MSM object to include LEVs and REVs if wanted

### DIFF
--- a/pyemma/msm/ui/msm.py
+++ b/pyemma/msm/ui/msm.py
@@ -102,8 +102,9 @@ class MSM(object):
         self.mu = statdist(self.T)
 
         """ First left and right EVs"""
-        self.LEVs = eigenvectors(self.T, k = np.min([10, self.T.shape[0]-1]), right=False )          
-        self.REVs = eigenvectors(self.T, k = np.min([10, self.T.shape[0]-1]), right=True )
+        k = np.min([10, self.T.shape[0]-2])
+        self.LEVs = eigenvectors(self.T, k = k, right=False )          
+        self.REVs = eigenvectors(self.T, k = k, right=True )
 
         self.computed = True
 

--- a/pyemma/msm/ui/msm.py
+++ b/pyemma/msm/ui/msm.py
@@ -102,8 +102,8 @@ class MSM(object):
         self.mu = statdist(self.T)
 
         """ First left and right EVs"""
-        self.LEVs = eigenvectors(self.T, k = 10, right=False )          
-        self.REVs = eigenvectors(self.T, k = 10, right=True  )          
+        self.LEVs = eigenvectors(self.T, k = np.min([10, self.T.shape[0]-1]), right=False )          
+        self.REVs = eigenvectors(self.T, k = np.min([10, self.T.shape[0]-1]), right=True )
 
         self.computed = True
 

--- a/pyemma/msm/ui/msm.py
+++ b/pyemma/msm/ui/msm.py
@@ -11,7 +11,7 @@ __docformat__ = "restructuredtext en"
 import numpy as np
 
 from pyemma.msm.estimation import cmatrix, largest_connected_set, connected_cmatrix, tmatrix
-from pyemma.msm.analysis import statdist, timescales
+from pyemma.msm.analysis import statdist, timescales, eigenvectors
 
 __all__ = ['MSM']
 
@@ -67,11 +67,17 @@ class MSM(object):
         self.T = None
 
         """Stationary distribution"""
-        self.mu = None
+        self.mu = []
 
         self.computed = False
 
         self.estimate_on_lcc = estimate_on_lcc
+
+        """Left eigenvectors"""
+        self.LEVs = []
+
+        """Right eigenvectors"""
+        self.REVs = []
 
         if compute:
             self.compute()
@@ -128,10 +134,26 @@ class MSM(object):
     @property
     def stationary_distribution(self):
         self._assert_computed()
-        if self.mu is None:
+        if np.size(self.mu) == 0:
             self.mu = statdist(self.T)
         return self.mu
 
-    def get_timescales(self, k):
+    def get_timescales(self, k = 10):
         ts = timescales(self.T, k=k, tau=self.tau)
         return ts
+
+    def get_LEVs(self, k = 10):
+        self._assert_computed()
+        
+        if np.size(self.LEVs) == 0:
+           self.LEVs = eigenvectors(self.T.toarray(), k = k, right=False )
+        else:
+           print "LEVs already computed. Use MSM.LEVs"
+
+    def get_REVs(self, k = 10):
+        self._assert_computed()
+        
+        if np.size(self.REVs) == 0:
+           self.REVs = eigenvectors(self.T.toarray(), k = k, right=True  )
+        else:
+           print "REVs already computed. Use MSM.REVs"

--- a/pyemma/msm/ui/msm.py
+++ b/pyemma/msm/ui/msm.py
@@ -98,6 +98,13 @@ class MSM(object):
         else:
             self.T = tmatrix(self.C, reversible=self.reversible)
 
+        """Stationary distribution"""
+        self.mu = statdist(self.T)
+
+        """ First left and right EVs"""
+        self.LEVs = eigenvectors(self.T, k = 10, right=False )          
+        self.REVs = eigenvectors(self.T, k = 10, right=True  )          
+
         self.computed = True
 
     def _assert_computed(self):
@@ -134,8 +141,6 @@ class MSM(object):
     @property
     def stationary_distribution(self):
         self._assert_computed()
-        if self.mu is None:
-            self.mu = statdist(self.T)
         return self.mu
 
     def get_timescales(self, k = 10):
@@ -150,18 +155,12 @@ class MSM(object):
         else:
            k = np.min([self.T.shape[0], k])
 
-        if self.LEVs is None: 
-           if k < self.T.shape[0]:
-              self.LEVs = eigenvectors(self.T, k, right=False )           # "some" eigenvectors: sparse diagonalization 
-           elif k == self.T.shape[0]:
-              self.LEVs = eigenvectors(self.T.toarray(), k, right=False ) # all eigenvectors: no point in sparse diagonalization
+        if self.LEVs.shape[1] < k and k < self.T.shape[0]:
+           self.LEVs = eigenvectors(self.T, k, right=False )           # "some" eigenvectors: sparse diagonalization 
+        elif self.LEVs.shape[1] < k and k == self.T.shape[0]:
+           self.LEVs = eigenvectors(self.T.toarray(), k, right=False ) # all eigenvectors: no point in sparse diagonalization
         else:
-           if self.LEVs.shape[1] < k and k < self.T.shape[0]:
-              self.LEVs = eigenvectors(self.T, k, right=False )           # "some" eigenvectors: sparse diagonalization 
-           elif self.LEVs.shape[1] < k and k == self.T.shape[0]:
-              self.LEVs = eigenvectors(self.T.toarray(), k, right=False ) # all eigenvectors: no point in sparse diagonalization
-           else:
-              self.LEVs = self.LEVs[:,:k]
+           self.LEVs = self.LEVs[:,:k]
 
     def get_REVs(self, k = None):
         self._assert_computed()
@@ -171,15 +170,9 @@ class MSM(object):
         else:
            k = np.min([self.T.shape[0], k])
 
-        if self.REVs is None: 
-           if k < self.T.shape[0]:
-              self.REVs = eigenvectors(self.T, k, right = True )           # "some" eigenvectors: sparse diagonalization 
-           elif k == self.T.shape[0]:
-              self.REVs = eigenvectors(self.T.toarray(), k, right = True ) # all eigenvectors: no point in sparse diagonalization
+        if self.REVs.shape[1] < k and k < self.T.shape[0]:
+           self.REVs = eigenvectors(self.T, k, right=False )           # "some" eigenvectors: sparse diagonalization 
+        elif self.REVs.shape[1] < k and k == self.T.shape[0]:
+           self.REVs = eigenvectors(self.T.toarray(), k, right = True ) # all eigenvectors: no point in sparse diagonalization
         else:
-           if self.REVs.shape[1] < k and k < self.T.shape[0]:
-              self.REVs = eigenvectors(self.T, k, right=False )           # "some" eigenvectors: sparse diagonalization 
-           elif self.REVs.shape[1] < k and k == self.T.shape[0]:
-              self.REVs = eigenvectors(self.T.toarray(), k, right = True ) # all eigenvectors: no point in sparse diagonalization
-           else:
-              self.REVs = self.REVs[:,:k]
+           self.REVs = self.REVs[:,:k]


### PR DESCRIPTION
Extended the MSM object a bit so that LEVs and REVs of a given MSM object do not live "outside" the object itself. Once you have an MSM object containing T, C, LargeConSet etc...it seems artificial not to have them there.

@trendelkampschroer: I used the "get_LEVs" convention for the first time they're computed. Perhaps there's a better way? Or perhaps we should calculate them directly? That might be very time consuming, since it might involve diagonalization of large matrices