### PR TITLE
Refactor clustering

### DIFF
--- a/pyemma/coordinates/clustering/interface.py
+++ b/pyemma/coordinates/clustering/interface.py
@@ -30,7 +30,8 @@ class AbstractClustering(Transformer):
         dtraj = np.empty(X.shape[0], np.int64)
         regspatial.assign(X.astype(np.float32, order='C', copy=False),
                           self.clustercenters, dtraj, self.metric)
-        return dtraj
+        res = dtraj[:,None] # always return a column vector in this function
+        return res
 
     def dimension(self):
         """output dimension of clustering algorithm (always 1)."""

--- a/pyemma/coordinates/clustering/interface.py
+++ b/pyemma/coordinates/clustering/interface.py
@@ -32,21 +32,28 @@ class AbstractClustering(Transformer):
                           self.clustercenters, dtraj, self.metric)
         return dtraj
 
-    @doc_inherit
     def dimension(self):
+        """output dimension of clustering algorithm (always 1)."""
         return 1
 
-    def assign(self, X):
+    def assign(self, X=None, stride=1):
         """
         Assigns the given trajectory or list of trajectories to cluster centers by using the discretization defined
         by this clustering method (usually a Voronoi tesselation)
 
         Parameters
         ----------
-        X : ndarray(T, n) or list of ndarray(T_i, n)
-            The input data, where T is the number of time steps and n is the number of dimensions.
+        X : ndarray(T, n) or list of ndarray(T_i, n), optional, default = None
+            Optional input data to map, where T is the number of time steps and n is the number of dimensions.
             When a list is provided they can have differently many time steps, but the number of dimensions need
-            to be consistent.
+            to be consistent. When X is not provided, the result of assign is identical to get_output(), i.e. the
+            data used for clustering will be assigned.
+
+        stride : int, optional, default = 1
+            If set to 1, all frames of the input data will be assigned. Note that this could cause this calculation
+            to be very slow for large data sets. Since molecular dynamics data is usually
+            correlated at short timescales, it is often sufficient to obtain the discretization at a longer stride.
+            Note that the stride option used to conduct the clustering is independent of the assign stride.
 
         Returns
         -------

--- a/pyemma/coordinates/clustering/kmeans.py
+++ b/pyemma/coordinates/clustering/kmeans.py
@@ -100,4 +100,4 @@ class KmeansClustering(AbstractClustering):
         if X.ndim == 1:
             X = self._ensure2d(X)
         d = self._algo.predict(X)
-        return d
+        return d[:,None] # always return a column vector in this function

--- a/pyemma/coordinates/clustering/kmeans.py
+++ b/pyemma/coordinates/clustering/kmeans.py
@@ -77,21 +77,22 @@ class KmeansClustering(AbstractClustering):
                 self._logger.info("Pass 1: Accumulated all data, running kmeans on "+str(alldata.shape))
                 self._algo.fit(alldata)
 
-        # second pass: assign states
-        if ipass == 1:
-            if first_chunk:
-                self._logger.info("Pass 2: Assigning data")
-            # discretize all
-            if t == 0:
-                n = self.data_producer.trajectory_length(itraj, stride=stride)
-                self.dtrajs.append(np.empty(n, dtype=int))
-
-            assignment = self._algo.predict(X)
-            self.dtrajs[itraj][t: t + assignment.shape[0]] = assignment
-
             # done
             if last_chunk:
                 return True
+        # # second pass: assign states
+        # if ipass == 1:
+        #     if first_chunk:
+        #         self._logger.info("Pass 2: Assigning data")
+        #     # discretize all
+        #     if t == 0:
+        #         n = self.data_producer.trajectory_length(itraj, stride=stride)
+        #         self.dtrajs.append(np.empty(n, dtype=int))
+        #
+        #     assignment = self._algo.predict(X)
+        #     self.dtrajs[itraj][t: t + assignment.shape[0]] = assignment
+
+
 
     def _param_finish(self):
         self.clustercenters = self._algo.cluster_centers_
@@ -100,4 +101,6 @@ class KmeansClustering(AbstractClustering):
         if X.ndim == 1:
             X = self._ensure2d(X)
         d = self._algo.predict(X)
-        return d[:,None] # always return a column vector in this function
+        if d.dtype != self.output_type():
+            d = d.astype(self.output_type())  # convert type if necessary
+        return d[:,None]  # always return a column vector in this function

--- a/pyemma/coordinates/clustering/regspace.py
+++ b/pyemma/coordinates/clustering/regspace.py
@@ -84,30 +84,19 @@ class RegularSpaceClustering(AbstractClustering):
                 regspatial.cluster(X.astype(np.float32, order='C', copy=False),
                                    self._clustercenters, self._dmin,
                                    self.metric, self.max_clusters)
+                # finished regularly
+                if last_chunk:
+                    self.clustercenters = np.array(self._clustercenters)
+                    return True  # finished!
             except RuntimeError:
                 msg = 'Maximum number of cluster centers reached.' \
                       ' Consider increasing max_clusters or choose' \
                       ' a larger minimum distance, dmin.'
                 self._logger.warning(msg)
                 warnings.warn(msg)
-                return False
-
-        elif ipass == 1:
-            # discretize all
-            if t == 0:
-                if itraj == 0:
-                    assert len(self._clustercenters) >= 1
-                    # create numpy array from clustercenters list
-                    self.clustercenters = np.array(self._clustercenters)
-                    self._logger.info("number of clustercenters: %i" %
-                                      len(self.clustercenters))
-                n = self.data_producer.trajectory_length(itraj, stride=stride)
-                self.dtrajs.append(np.empty(n, dtype=np.int64))
-            L = np.shape(X)[0]
-
-            self.dtrajs[itraj][t:t+L] = self.map(X)
-            if last_chunk:
-                return True  # finished!
+                # finished anyway, because we have no more space for clusters. Rest of trajectory has no effect
+                self.clustercenters = np.array(self._clustercenters)
+                return True
 
         return False
 

--- a/pyemma/coordinates/clustering/uniform_time.py
+++ b/pyemma/coordinates/clustering/uniform_time.py
@@ -102,12 +102,6 @@ class UniformTimeClustering(AbstractClustering):
                 self._nextt += self._dt
             if last_chunk_in_traj:
                 self._tprev += self.data_producer.trajectory_length(itraj, stride=stride)
-        if ipass == 1:
-            # discretize all
-            if t == 0:
-                n = self.data_producer.trajectory_length(itraj, stride=stride)
-                self.dtrajs.append(np.zeros(n, dtype=int))
-            self.dtrajs[itraj][t:t+L] = self.map(X)
             if last_chunk:
                 return True  # done!
 

--- a/pyemma/coordinates/tests/test_kmeans.py
+++ b/pyemma/coordinates/tests/test_kmeans.py
@@ -28,8 +28,8 @@ class TestKmeans(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.dtraj_dir, ignore_errors=True)
 
-    def testDtraj(self):
-        assert self.kmeans.dtrajs[0].dtype == int
+    def testDtrajType(self):
+        assert self.kmeans.dtrajs[0].dtype == self.kmeans.output_type()
 
     def test_3gaussian_1d_singletraj(self):
         # generate 1D data from three gaussians

--- a/pyemma/coordinates/tests/test_regspace.py
+++ b/pyemma/coordinates/tests/test_regspace.py
@@ -8,6 +8,7 @@ import unittest
 
 from pyemma.coordinates.clustering.regspace import RegularSpaceClustering
 import numpy as np
+import pyemma.util.types as types
 import warnings
 from pyemma.coordinates.api import cluster_regspace
 
@@ -34,6 +35,11 @@ class RandomDataSource:
     def trajectory_length(self, itraj, stride=1):
         assert stride == 1, 'stride !=1 not implemented'
         return self.data[itraj].shape[0]
+
+    def trajectory_lengths(self, stride=1):
+        assert stride == 1, 'stride !=1 not implemented'
+        lengths = [traj.shape[0] for traj in self.data]
+        return lengths
 
     def number_of_trajectories(self):
         return self.data.shape[0]
@@ -62,7 +68,8 @@ class TestRegSpaceClustering(unittest.TestCase):
     def testAlgo(self):
         self.clustering.parametrize()
 
-        assert self.clustering.dtrajs[0].dtype == int
+        # correct type of dtrajs
+        assert types.is_int_array(self.clustering.dtrajs[0])
 
         # assert distance for each centroid is at least dmin
         for c in itertools.combinations(self.clustering.clustercenters, 2):

--- a/pyemma/coordinates/transform/tica.py
+++ b/pyemma/coordinates/transform/tica.py
@@ -216,7 +216,7 @@ class TICA(Transformer):
                     self.N_cov += 2.0*np.shape(X)[0]
 
             else:
-                self._logger.error("trajectory nr %i too short, skipping it" % itraj)
+                self._logger.info("trajectory nr %i too short, skipping it" % itraj)
 
             if last_chunk:
                 self._logger.info("finished calculation of Cov and Cov_tau.")

--- a/pyemma/coordinates/transform/tica.py
+++ b/pyemma/coordinates/transform/tica.py
@@ -216,7 +216,7 @@ class TICA(Transformer):
                     self.N_cov += 2.0*np.shape(X)[0]
 
             else:
-                self._logger.info("trajectory nr %i too short, skipping it" % itraj)
+                self._logger.warning("trajectory nr %i too short, skipping it" % itraj)
 
             if last_chunk:
                 self._logger.info("finished calculation of Cov and Cov_tau.")

--- a/pyemma/coordinates/transform/transformer.py
+++ b/pyemma/coordinates/transform/transformer.py
@@ -176,6 +176,12 @@ class Transformer(object):
         """ get a representation of this Transformer"""
         return self.__str__()
 
+    def dimension(self):
+        return 0  # default
+
+    def output_type(self):
+        return np.float32
+
     def parametrize(self, stride=1):
         r""" parametrize this Transformer
         """
@@ -504,7 +510,7 @@ class Transformer(object):
         assert ndim > 0, "ndim was zero in %s" % self.__class__.__name__
 
         # allocate memory
-        trajs = [np.empty((l, ndim)) for l in self.trajectory_lengths(stride=stride)]
+        trajs = [np.empty((l, ndim), dtype=self.output_type()) for l in self.trajectory_lengths(stride=stride)]
 
         if __debug__:
             self._logger.debug("get_output(): created output trajs with shapes: %s"

--- a/pyemma/coordinates/transform/transformer.py
+++ b/pyemma/coordinates/transform/transformer.py
@@ -263,14 +263,16 @@ class Transformer(object):
         # TODO: This is a very naive implementation of case switching. Please check and make more robust if needed.
         if isinstance(X, np.ndarray):
             if X.ndim == 2:
-                return self._map_array(X)
+                mapped = self._map_array(X)
+                return mapped
             else:
                 raise TypeError('Input has the wrong shape: '+str(X.shape)+' with '+str(X.ndim)
                                 +' dimensions. Expecting a matrix (2 dimensions)')
         elif isinstance(X, list):
             out = []
             for x in X:
-                out.append(self._map_array(x))
+                mapped = self._map_array(x)
+                out.append(mapped)
         else:
             raise TypeError('Input has the wrong type: '+str(type(X))
                             +'. Either accepting numpy arrays of dimension 2 or lists of such arrays')
@@ -386,7 +388,7 @@ class Transformer(object):
                 self._t += X.shape[0]
                 if self._t >= self.trajectory_length(self._itraj, stride=stride):
                     self._itraj += 1
-                    self._t = 0                
+                    self._t = 0
                 return self.map(X)
             else:
                 (X0, Xtau) = self.data_producer._next_chunk(lag=lag, stride=stride)
@@ -515,8 +517,9 @@ class Transformer(object):
             if itraj != last_itraj:
                 last_itraj = itraj
                 t = 0  # reset time to 0 for new trajectory
-            trajs[itraj][t:t+chunk.shape[0], :] = chunk[:, dimensions]
-            t += chunk.shape[0]
+            L = chunk.shape[0]
+            trajs[itraj][t:t + L, :] = chunk[:, dimensions]
+            t += L
 
         return trajs
 


### PR DESCRIPTION
* Refactored clustering such that parametrization only does the clustering and not the assign. Assign is done upon request by assign(), get_output(), or dtrajs (which is now a property)
* map function always returns a column matrix or array. That means with get_output() on a clustering algorithm you get a list of Tx1 arrays. assign() and dtrajs reshape this into the usual list of flat int-arrays.
* Minor bugfixes
* Some logging cosmetics
* Fixes  #227
* Four tests are failing, but these are due to numpy and csv readers. cluster-related unit-tests and practical ipython tests with real data look good.