### PR TITLE
transposes the returned eigenvectors if right=False

### DIFF
--- a/pyemma/msm/analysis/api.py
+++ b/pyemma/msm/analysis/api.py
@@ -503,6 +503,9 @@ def eigenvectors(T, k=None, right=True, ncv=None):
         the corresponding eigenvalue. If k is None then n=d, if k is
         int then n=k.
 
+        If right = True, the right eigenvectors are returned as column vectors.
+        If right = False, the left eigenvectors are returned as row vectors
+
     See also
     --------
     rdl_decomposition    
@@ -541,9 +544,16 @@ def eigenvectors(T, k=None, right=True, ncv=None):
            
     """
     if _issparse(T):
-        return sparse.decomposition.eigenvectors(T, k=k, right=right, ncv=ncv)
+        if right:
+            return sparse.decomposition.eigenvectors(T, k=k, right=right, ncv=ncv)
+        else:
+            return sparse.decomposition.eigenvectors(T, k=k, right=right, ncv=ncv).T
+
     elif _isdense(T):
-        return dense.decomposition.eigenvectors(T, k=k, right=right)
+        if right:
+            return dense.decomposition.eigenvectors(T, k=k, right=right)
+        else:
+            return dense.decomposition.eigenvectors(T, k=k, right=right).T
     else:
         raise _type_not_supported
 

--- a/pyemma/msm/analysis/tests/test_decomposition.py
+++ b/pyemma/msm/analysis/tests/test_decomposition.py
@@ -97,7 +97,7 @@ class TestDecompositionDense(unittest.TestCase):
         Rn = eigenvectors(P)
         assert_allclose(np.dot(P,Rn),np.dot(Rn,Dn))
         # left eigenvectors
-        Ln = eigenvectors(P, right=False)
+        Ln = eigenvectors(P, right=False).T
         assert_allclose(np.dot(Ln.T,P),np.dot(Dn,Ln.T))
         # orthogonality
         Xn = np.dot(Ln.T, Rn)
@@ -111,7 +111,7 @@ class TestDecompositionDense(unittest.TestCase):
         Rn = eigenvectors(P, k=self.k)
         assert_allclose(np.dot(P,Rn),np.dot(Rn,Dnk))
         # left eigenvectors
-        Ln = eigenvectors(P, right=False, k=self.k)
+        Ln = eigenvectors(P, right=False, k=self.k).T
         assert_allclose(np.dot(Ln.T,P),np.dot(Dnk,Ln.T))
         # orthogonality
         Xn = np.dot(Ln.T, Rn)
@@ -302,14 +302,14 @@ class TestDecompositionSparse(unittest.TestCase):
         Rn = eigenvectors(P, k=self.k)
         assert_allclose(vals[np.newaxis, :] * Rn, P.dot(Rn))
 
-        Ln = eigenvectors(P, right=False, k=self.k)
+        Ln = eigenvectors(P, right=False, k=self.k).T
         assert_allclose(P.transpose().dot(Ln), vals[np.newaxis, :] * Ln)
 
         """k is not None and ncv is not None"""
         Rn = eigenvectors(P, k=self.k, ncv=self.ncv)
         assert_allclose(vals[np.newaxis, :] * Rn, P.dot(Rn))
 
-        Ln = eigenvectors(P, right=False, k=self.k, ncv=self.ncv)
+        Ln = eigenvectors(P, right=False, k=self.k, ncv=self.ncv).T
         assert_allclose(P.transpose().dot(Ln), vals[np.newaxis, :] * Ln)
 
     def test_rdl_decomposition(self):


### PR DESCRIPTION
This should close #249 The tests have been updated accordingly. Pycharm reports no other usages except for the declaration in the api, so nothing else should be broken (please @trendelkampschroer , can you confirm?) 

Do we include this in the changelog? 
