### PR TITLE
Update mapping.py

### DIFF
--- a/pyemma/msm/ui/mapping.py
+++ b/pyemma/msm/ui/mapping.py
@@ -190,26 +190,38 @@ def regroup_DISK(trajs, topology_file, disctrajs, path, stride=1):
 
     states = np.unique(np.hstack(([np.unique(disctraj) for disctraj in disctrajs])))
     states = np.setdiff1d(states, [-1])  # exclude invalid states
+    states_length = len(states)
     writer = [None] * (max(states) + 1)
     cluster = [None] * (max(states) + 1)
-
-    for i in states:
-        cluster[i] = path + os.sep + ('%d.xtc' % i)
-        writer[i] = XTCTrajectoryFile(cluster[i], 'w', force_overwrite=True)
-
-    for disctraj, traj in zip(disctrajs, trajs):
-        reader = md.iterload(traj, top=topology_file, stride=stride)
-        start = 0
-        for chunk in reader:
-            chunk_length = chunk.xyz.shape[0]
-            for i in xrange(chunk_length):
-                cl = disctraj[i + start]
-                if cl != -1:
-                    writer[cl].write(chunk.xyz[i, :, :])  # np.newaxis?
-            start += chunk_length
-            # TODO: check that whole disctrajs was used
-    for i in states:
-        writer[i].close()
+    cl_list_writer_chunck = []
+    counter = 0
+    for j in states:
+	
+			#create a chunck of writers (of 100 writers) in order to avoid limits in the number of simultanious opened files
+			cluster[j] = path + os.sep + ('%d.xtc' % j)
+			writer[j] = XTCTrajectoryFile(cluster[j], 'w', force_overwrite=True)
+			cl_list_writer_chunck.append(j)
+			if counter % 100 == 99 or counter == states_length:
+		
+				for disctraj, traj in zip(disctrajs, trajs):
+						      
+					reader = md.iterload(traj, top=topology_file, stride=stride)
+					start = 0
+					for chunk in reader:
+						chunk_length = chunk.xyz.shape[0]
+						for i in xrange(chunk_length):
+							cl = disctraj[i + start]
+							if cl != -1 and cl in cl_list_writer_chunck:
+								writer[cl].write(chunk.xyz[i, :, :])  # np.newaxis?
+						start += chunk_length
+						# TODO: check that whole disctrajs was used
+							
+				for i in cl_list_writer_chunck:
+					writer[i].close()
+	      
+	  		cl_list_writer_chunck = []
+	  
+			counter += 1
 
     return cluster
 


### PR DESCRIPTION
Create a chunck of writers (of 100 writers) in order to avoid limits in the number of simultanious opened files.
Workarround for error produced when using function regroup_DISK in more than 100 clusters:

IOError                                   Traceback (most recent call last)
<ipython-input-8-91c84707b844> in <module>()
     13 except:
     14     pass
---> 15 cluster_DISK_apo_1B = regroup_DISK(trajsdcd[:apo_1B_len - 1],top_file_apo_1B,dtraj_list[:apo_1B_len - 1], path_apo_1B)
     16 #cluster_DISK_clz_1B = regroup_DISK(trajsdcd[apo_1B_len:],top_file_clz_1B,D.dtrajs[apo_1B_len:], path_clz_1B)

/home/ismael/anaconda/lib/python2.7/site-packages/pyEMMA-1.1.1-py2.7-linux-x86_64.egg/pyemma/msm/ui/mapping.pyc in regroup_DISK(trajs, topology_file, disctrajs, path, stride)
    169     for i in states:
    170         cluster[i] = path+os.sep+('%d.xtc'%i)
--> 171         writer[i] = XTCTrajectoryFile(cluster[i],'w',force_overwrite=True)
    172 
    173     for disctraj,traj in zip(disctrajs,trajs):

/home/ismael/anaconda/lib/python2.7/site-packages/mdtraj/formats/xtc.so in xtc.XTCTrajectoryFile.**cinit** (MDTraj/formats/xtc/xtc.c:3137)()

IOError: Unable to open file "./clustered_structures_tica/apo_1B/0.xtc"
