### PR TITLE
Update api.py

### DIFF
--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -572,7 +572,9 @@ def save_trajs(traj_inp, indexes, prefix='set_', fmt=None, outfiles=None, inmemo
         import os
 
         _, fmt = os.path.splitext(traj_inp.trajfiles[0])
-
+    else:
+      fmt = '.' + fmt
+      
     # Prepare the list of outfiles before the loop
     if outfiles is None:
         outfiles = []


### PR DESCRIPTION
'fmt' option in pyemma.coordinates.save_trajs(), missing dot in output filenames when 'fmt' is not by default.
