### PR TITLE
Started to unify error conditions in reversible matrix estimation

### DIFF
--- a/pyemma/coordinates/clustering/include/clustering.h
+++ b/pyemma/coordinates/clustering/include/clustering.h
@@ -89,7 +89,7 @@ float minRMSD_distance(float *SKP_restrict a, float *SKP_restrict b, size_t n, f
 // assignment to cluster centers from python
 PyObject *assign(PyObject *self, PyObject *args);
 // assignment to cluster centers from c
-int c_assign(float *chunk, float *centers, npy_int64 *dtraj, char* metric, Py_ssize_t N_frames, Py_ssize_t N_centers, Py_ssize_t dim);
+int c_assign(float *chunk, float *centers, npy_int32 *dtraj, char* metric, Py_ssize_t N_frames, Py_ssize_t N_centers, Py_ssize_t dim);
 
 #ifdef __cplusplus
 }

--- a/pyemma/coordinates/clustering/interface.py
+++ b/pyemma/coordinates/clustering/interface.py
@@ -67,7 +67,7 @@ class AbstractClustering(Transformer):
         return 1
 
     def output_type(self):
-        return np.int64
+        return np.int32
 
     def assign(self, X=None, stride=1):
         """

--- a/pyemma/coordinates/clustering/src/clustering.c
+++ b/pyemma/coordinates/clustering/src/clustering.c
@@ -52,7 +52,7 @@ float minRMSD_distance(float *SKP_restrict a, float *SKP_restrict b, size_t n, f
     return sqrt(msd);
 }
 
-int c_assign(float *chunk, float *centers, npy_int64 *dtraj, char* metric, Py_ssize_t N_frames, Py_ssize_t N_centers, Py_ssize_t dim) {
+int c_assign(float *chunk, float *centers, npy_int32 *dtraj, char* metric, Py_ssize_t N_frames, Py_ssize_t N_centers, Py_ssize_t dim) {
     int ret;
     float d, mindist;
     size_t argmin;
@@ -105,7 +105,7 @@ PyObject *assign(PyObject *self, PyObject *args) {
     Py_ssize_t N_centers, N_frames, dim;
     float *chunk;
     float *centers;
-    npy_int64 *dtraj;
+    npy_int32 *dtraj;
     char *metric;
 
     py_centers = NULL; py_res = NULL;
@@ -127,14 +127,14 @@ PyObject *assign(PyObject *self, PyObject *args) {
     chunk = PyArray_DATA(np_chunk);
 
     /* import dtraj */
-    if(PyArray_TYPE(np_dtraj)!=NPY_INT64) { PyErr_SetString(PyExc_ValueError, "dtype of \"dtraj\" isn\'t int (64)."); goto error; };
+    if(PyArray_TYPE(np_dtraj)!=NPY_INT32) { PyErr_SetString(PyExc_ValueError, "dtype of \"dtraj\" isn\'t int (32)."); goto error; };
     if(!PyArray_ISBEHAVED_RO(np_dtraj) ) { PyErr_SetString(PyExc_ValueError, "\"dtraj\" isn\'t behaved."); goto error; };
     if(PyArray_NDIM(np_dtraj)!=1) { PyErr_SetString(PyExc_ValueError, "Number of dimensions of \"dtraj\" isn\'t 1."); goto error; };
     if(np_chunk->dimensions[0]!=N_frames) {
         PyErr_SetString(PyExc_ValueError, "Size of \"dtraj\" differs from number of frames in \"chunk\".");
         goto error;
     }
-    dtraj = (npy_int64*)PyArray_DATA(np_dtraj);
+    dtraj = (npy_int32*)PyArray_DATA(np_dtraj);
 
     /* import list of cluster centers */
     np_centers = (PyArrayObject*)PyArray_ContiguousFromAny(py_centers, NPY_FLOAT32, 2, 2);

--- a/pyemma/coordinates/tests/test_assign.py
+++ b/pyemma/coordinates/tests/test_assign.py
@@ -145,7 +145,7 @@ class TestCluster(unittest.TestCase):
 
     def test_output_type(self):
         c = self.ass
-        assert c.output_type() == np.int64
+        assert c.output_type() == np.int32
 
     def test_parametrize(self):
         c = self.ass

--- a/pyemma/coordinates/tests/test_cluster.py
+++ b/pyemma/coordinates/tests/test_cluster.py
@@ -139,7 +139,7 @@ class TestCluster(unittest.TestCase):
 
     def test_output_type(self):
         for c in self.cl:
-            assert c.output_type() == np.int64
+            assert c.output_type() == np.int32
 
     def test_parametrize(self):
         for c in self.cl:

--- a/pyemma/msm/estimation/dense/mle_trev_given_pi.pyx
+++ b/pyemma/msm/estimation/dense/mle_trev_given_pi.pyx
@@ -7,6 +7,9 @@ r"""Cython implementation of iterative likelihood maximization.
 import numpy
 cimport numpy
 import pyemma.msm.estimation
+import warnings
+import pyemma.util.exceptions
+
 
 cdef extern from "_mle_trev_given_pi.h":
   int _mle_trev_given_pi_dense(double * const T, const long long * const C, const double * const mu, const int n, double maxerr, const int maxiter, const double eps)
@@ -51,7 +54,7 @@ def mle_trev_given_pi(
   elif err == -4:
     raise Exception('Some element of pi is zero.')
   elif err == -5:
-    raise Exception('Didn\'t converge.')
+    warnings.warn('Reversible transition matrix estimation with fixed stationary distribution didn\'t converge.', pyemma.util.exceptions.NotConvergedWarning)
   elif err == -6:
     raise Exception('Count matrix has zero diagonal elements. Can\'t guarantee convergence of algorithm. '+
                     'Suggestion: set regularization parameter eps to some small value e.g. 1E-6.')

--- a/pyemma/msm/estimation/dense/transition_matrix.py
+++ b/pyemma/msm/estimation/dense/transition_matrix.py
@@ -30,6 +30,8 @@ Created on Jan 13, 2014
 '''
 
 import numpy as np
+import warnings
+import pyemma.util.exceptions
 
 
 def transition_matrix_non_reversible(C):
@@ -189,6 +191,8 @@ def estimate_transition_matrix_reversible(C, Xinit=None, maxiter=1000000, maxerr
         i += 1
     # finalize and return
     T = X / xsum[:, np.newaxis]
+    if not converged:
+        warnings.warn("Reversible transition matrix estimation didn't converge.", pyemma.util.exceptions.NotConvergedWarning)
     if (return_statdist and return_conv):
         return (T, xsum, lhist[0:i], diffs[0:i])
     if (return_statdist):
@@ -262,9 +266,10 @@ def transition_matrix_reversible_fixpi(Z, mu, maxerr=1e-10, maxiter=10000, retur
         l[:] = lnew[:]
         it += 1
     if (not converged) and (it >= maxiter):
-        raise ValueError('NOT CONVERGED: 2-norm of Langrange multiplier vector is still '
-                         + str(err) + ' > ' + str(maxerr) + ' after ' + str(
-            it) + ' iterations. Increase maxiter or decrease maxerr')
+        warnings.warn('NOT CONVERGED: 2-norm of Langrange multiplier vector is still ' +
+                         str(err) + ' > ' + str(maxerr) + ' after ' + str(it) +
+                         ' iterations. Increase maxiter or decrease maxerr', 
+                      pyemma.util.exceptions.NotConvergedWarning)
     # compute T from Langrangian multipliers
     T = np.divide(A, l[:, np.newaxis])
     # return

--- a/pyemma/msm/estimation/sparse/mle_trev.pyx
+++ b/pyemma/msm/estimation/sparse/mle_trev.pyx
@@ -3,11 +3,14 @@ r"""Cython implementation of iterative likelihood maximization.
 .. moduleauthor:: F. Paul <fabian DOT paul AT fu-berlin DOT de>
 
 """
+
 import numpy
 import scipy
 import scipy.sparse
 cimport numpy
 import pyemma.msm.estimation
+import warnings
+import pyemma.util.exceptions
 
 cdef extern from "_mle_trev.h":
   int _mle_trev_sparse(double * const T_data, const long long * const CCt_data, const long long * const i_indices, const long long * const j_indices, const int len_CCt, const long long * const sum_C, const int dim, const double maxerr, const int maxiter)
@@ -51,7 +54,7 @@ def mle_trev(C, double maxerr = 1.0E-12, int maxiter = 1000000):
   elif err == -3:
     raise Exception('Some row and corresponding column of C have zero counts.')
   elif err == -5:
-    raise Exception('Didn\'t converge.')
+    warnings.warn('Reversible transition matrix estimation didn\'t converge.', pyemma.util.exceptions.NotConvergedWarning)
 
   # T matrix has the same shape and positions of nonzero elements as CCt
   return scipy.sparse.csr_matrix((T_data,(i_indices,j_indices)),shape=CCt.shape)

--- a/pyemma/msm/estimation/sparse/mle_trev_given_pi.pyx
+++ b/pyemma/msm/estimation/sparse/mle_trev_given_pi.pyx
@@ -8,6 +8,8 @@ import scipy
 import scipy.sparse
 cimport numpy
 import pyemma.msm.estimation
+import warnings
+import pyemma.util.exceptions
 
 cdef extern from "_mle_trev_given_pi.h":
     int _mle_trev_given_pi_sparse(double * const T_data,
@@ -108,7 +110,7 @@ def mle_trev_given_pi(
   elif err == -4:
     raise Exception('Some element of pi is zero.')
   elif err == -5:
-    raise Exception('Didn\'t converge.')
+    warnings.warn('Reversible transition matrix estimation with fixed stationary distribution didn\'t converge.', pyemma.util.exceptions.NotConvergedWarning)
   elif err == -6:
     raise Exception('Count matrix has zero diagonal elements. Can\'t guarantee convergence of algorithm. '+
                     'Suggestion: set regularization parameter eps to some small value e.g. 1E-6.')

--- a/pyemma/msm/estimation/tests/test_mle_trev.py
+++ b/pyemma/msm/estimation/tests/test_mle_trev.py
@@ -28,6 +28,8 @@ import numpy as np
 from pyemma.util.numeric import assert_allclose
 import scipy
 import scipy.sparse
+import warnings
+import pyemma.util.exceptions
 
 from os.path import abspath, join
 from os import pardir
@@ -53,6 +55,20 @@ class Test_mle_trev(unittest.TestCase):
         assert_allclose(T_api_sparse, T_python)
         assert_allclose(T_api_dense, T_python)
 
+    def test_warnings(self):
+        C = np.loadtxt(testpath + 'C_1_lag.dat')
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            mtrs(scipy.sparse.csr_matrix(C), maxiter=1)
+            assert len(w) == 1
+            assert issubclass(w[-1].category, pyemma.util.exceptions.NotConvergedWarning)
+            
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            etmr(C, maxiter=1)
+            assert len(w) == 1
+            assert issubclass(w[-1].category, pyemma.util.exceptions.NotConvergedWarning)
+            
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyemma/msm/estimation/tests/test_mle_trev_given_pi.py
+++ b/pyemma/msm/estimation/tests/test_mle_trev_given_pi.py
@@ -28,6 +28,8 @@ import numpy as np
 from pyemma.util.numeric import assert_allclose
 import scipy
 import scipy.sparse
+import warnings
+import pyemma.util.exceptions
 
 from os.path import abspath, join
 from os import pardir
@@ -61,6 +63,22 @@ class Test_mle_trev_given_pi(unittest.TestCase):
         assert_allclose(T_cython_sparse, T_python)
         assert_allclose(T_api_sparse, T_python)
         assert_allclose(T_api_dense, T_python)
+        
+    def test_warnings(self):
+        C = np.loadtxt(testpath + 'C_1_lag.dat')
+        pi = np.loadtxt(testpath + 'pi.dat')
+        
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            mtrgps(scipy.sparse.csr_matrix(C), pi, eps=self.eps, maxiter=1)
+            assert len(w) == 1
+            assert issubclass(w[-1].category, pyemma.util.exceptions.NotConvergedWarning)
+            
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            mtrgpd(C, pi, eps=self.eps, maxiter=1)
+            assert len(w) == 1
+            assert issubclass(w[-1].category, pyemma.util.exceptions.NotConvergedWarning)        
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
solves issue #183
When no convergence is reached, a NotConvergedWarning is emited via the Python warning mechanism.
