### PR TITLE
[coor/feature_reader|config] cache trajectory lengths in (optional) cache.

### DIFF
--- a/pyemma/coordinates/data/traj_info_cache.py
+++ b/pyemma/coordinates/data/traj_info_cache.py
@@ -1,0 +1,75 @@
+'''
+Created on 30.04.2015
+
+@author: marscher
+'''
+import anydbm
+import os
+import mdtraj
+from threading import Semaphore
+
+__all__ = ('TrajectoryInfoCache')
+
+
+class TrajectoryInfoCache(object):
+
+    """ stores trajectory lengths associated to a file based hash (mtime, name, 1mb of data)
+
+    Parameters
+    ----------
+    database_filename : str (optional)
+        if given the cache is being made persistent to this file. Otherwise the
+        cache is lost after the process has finished.
+
+    """
+
+    def __init__(self, database_filename=None):
+        if database_filename is not None:
+            self._database = anydbm.open(database_filename, flag="c")
+        else:
+            self._database = {}
+        self._write_protector = Semaphore()
+
+    def __getitem__(self, filename):
+        key = self.__get_file_hash(filename)
+        result = None
+        try:
+            result = self._database[key]
+        except KeyError:
+            result = self.__determine_len(filename)
+            self.__setitem__(filename, result, key=key)
+        return int(result)
+
+    def __determine_len(self, filename):
+        with mdtraj.open(filename) as fh:
+            return len(fh)
+
+    def __format_value(self, filename, length):
+        return str(length)
+
+    def __get_file_hash(self, filename):
+        statinfo = os.stat(filename)
+
+        # only remember file name without path, to re-identify it when its
+        # moved
+        hash_value = hash(os.path.basename(filename))
+        hash_value ^= hash(statinfo.st_mtime)
+        hash_value ^= hash(statinfo.st_size)
+
+        # now read the first megabyte and hash it
+        with open(filename, mode='rb') as fh:
+            data = fh.read(1024)
+
+        hash_value ^= hash(data)
+        return str(hash_value)
+
+    def __setitem__(self, filename, n_frames, key=None):
+        if not key:
+            key = self.__get_file_hash(filename)
+        self._write_protector.acquire()
+        self._database[key] = self.__format_value(filename, n_frames)
+        self._write_protector.release()
+
+    def __del__(self):
+        if not isinstance(self._database, dict):
+            self._database.close()

--- a/pyemma/coordinates/tests/__init__.py
+++ b/pyemma/coordinates/tests/__init__.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2015, 2014 Computational Molecular Biology Group, Free University
 # Berlin, 14195 Berlin, Germany.
 # All rights reserved.
@@ -23,3 +22,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+
+def setup_package():
+    # setup function for nose tests (for this package only)
+    from pyemma.util.config import conf_values
+    # do not cache trajectory info in user directory (temp traj files)
+    conf_values['pyemma']['traj_len_cache_file'] = None

--- a/pyemma/coordinates/tests/test_traj_info_cache.py
+++ b/pyemma/coordinates/tests/test_traj_info_cache.py
@@ -1,0 +1,40 @@
+'''
+Created on 30.04.2015
+
+@author: marscher
+'''
+import unittest
+import os
+import tempfile
+from glob import glob
+
+from pyemma.coordinates.data.traj_info_cache import TrajectoryInfoCache
+import mdtraj
+
+path = os.path.join(os.path.split(__file__)[0], 'data')
+# os.path.join(path, 'bpti_mini.xtc')
+xtcfiles = glob(path + os.path.sep + "*.xtc")
+pdbfile = os.path.join(path, 'bpti_ca.pdb')
+
+
+class TestTrajectoryInfoCache(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpfile = tempfile.mktemp()
+        self.db = TrajectoryInfoCache(self.tmpfile)
+
+    def testCacheResults(self):
+        # cause cache failures
+        results = {}
+        for f in xtcfiles:
+            results[f] = self.db[f]
+
+        desired = {}
+        for f in xtcfiles:
+            with mdtraj.open(f) as fh:
+                desired[f] = len(fh)
+
+        self.assertEqual(results, desired)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyemma/pyemma.cfg
+++ b/pyemma/pyemma.cfg
@@ -17,3 +17,4 @@ format = %%(asctime)s %%(name)-12s %%(levelname)-8s %%(message)s
 # pyemma configuration section
 [pyemma]
 show_progress_bars = True
+traj_len_cache_file = 'traj_len.db'

--- a/pyemma/util/config.py
+++ b/pyemma/util/config.py
@@ -21,7 +21,6 @@
 # ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 r'''
 Runtime Configuration
 =====================
@@ -31,9 +30,9 @@ its final set of settings. It searches for the file 'pyemma.cfg' in several
 locations with different priorities:
 
 1. $CWD/pyemma.cfg
-2. /etc/pyemma.cfg
-3. ~/pyemma.cfg
-4. $PYTHONPATH/pyemma/pyemma.cfg (always taken as default configuration file)
+2. $HOME/.pyemma/pyemma.cfg
+4. ~/pyemma.cfg
+5. $PYTHONPATH/pyemma/pyemma.cfg (always taken as default configuration file)
 
 The same applies for the filename ".pyemma.cfg" (hidden file).
 
@@ -82,6 +81,9 @@ __docformat__ = "restructuredtext en"
 
 import ConfigParser
 import os
+import warnings
+
+from pyemma.util.files import mkdir_p
 
 __all__ = ['configParser', 'used_filenames', 'AttribStore']
 
@@ -110,6 +112,35 @@ class AttribStore(dict):
         self[name] = value
 
 
+def create_cfg_dir(default_config):
+    home = os.path.expanduser("~")
+    pyemma_cfg_dir = os.path.join(home, ".pyemma")
+    if not os.path.exists(pyemma_cfg_dir):
+        try:
+            mkdir_p(pyemma_cfg_dir)
+        except EnvironmentError:
+            warnings.warn("could not create configuration directory '%s'" %
+                          pyemma_cfg_dir)
+
+    def touch(fname, times=None):
+        with open(fname, 'a'):
+            os.utime(fname, times)
+
+    test_fn = os.path.join(pyemma_cfg_dir, "dummy")
+    try:
+        touch(test_fn)
+        os.unlink(test_fn)
+    except:
+        raise RuntimeError("%s is not writeable" % pyemma_cfg_dir)
+
+    # give user the default cfg file, if its not there
+    import shutil
+    if not os.path.exists(os.path.join(pyemma_cfg_dir, os.path.basename(default_config))):
+        shutil.copy(default_config, pyemma_cfg_dir)
+
+    return pyemma_cfg_dir
+
+
 def readConfiguration():
     """
     TODO: consider using json to support arbitray python objects in ini file (if this getting more complex)
@@ -118,26 +149,32 @@ def readConfiguration():
 
     global configParser, conf_values, used_filenames
 
+    cfg = 'pyemma.cfg'
+    default_pyemma_conf = pkg_resources.resource_filename('pyemma', cfg)
+
+    # create .pyemma dir in home
+    pyemma_cfg_dir = create_cfg_dir(default_pyemma_conf)
+
     # use these files to extend/overwrite the conf_values.
     # Last red file always overwrites existing values!
-    cfg = 'pyemma.cfg'
-    cfg_hidden = '.pyemma.cfg'
     filenames = [
         cfg,  # conf_values in current dir
-        '/etc/' + cfg,  # conf_values in global installation
+        os.path.join(pyemma_cfg_dir, cfg),
         os.path.join(os.path.expanduser(
                      '~' + os.path.sep), cfg)  # config in user dir
     ]
+
+    cfg_hidden = '.pyemma.cfg'
     filenames += [
         cfg_hidden,
-        '/etc/' + cfg_hidden,
+        os.path.join(pyemma_cfg_dir, cfg),
         os.path.join(os.path.expanduser(
                      '~' + os.path.sep), cfg_hidden)
     ]
 
     # read defaults from default_pyemma_conf first.
     defParser = ConfigParser.RawConfigParser()
-    default_pyemma_conf = pkg_resources.resource_filename('pyemma', cfg)
+
     try:
         with open(default_pyemma_conf) as f:
             defParser.readfp(f, default_pyemma_conf)
@@ -161,5 +198,8 @@ def readConfiguration():
         conf_values[section] = AttribStore()
         for item in configParser.items(section):
             conf_values[section][item[0]] = item[1]
+
+    # remember cfg dir
+    conf_values['pyemma']['cfg_dir'] = pyemma_cfg_dir
 
 readConfiguration()


### PR DESCRIPTION
Can be turned of via config. A default config is now created in ~/.pyemma/

Fixes #279 
