### PR TITLE
Fix timescale tolerances

### DIFF
--- a/pyemma/msm/analysis/dense/decomposition.py
+++ b/pyemma/msm/analysis/dense/decomposition.py
@@ -366,7 +366,7 @@ def timescales_from_eigenvalues(evals, tau=1):
         warnings.warn('Using eigenvalues with non-zero imaginary part', ImaginaryEigenValueWarning)
 
     """Check for multiple eigenvalues of magnitude one"""
-    ind_abs_one = np.isclose(np.abs(evals), 1.0)
+    ind_abs_one = np.isclose(np.abs(evals), 1.0, rtol=0.0, atol=1e-14)
     if sum(ind_abs_one) > 1:
         warnings.warn('Multiple eigenvalues with magnitude one.', SpectralWarning)
 

--- a/pyemma/msm/analysis/sparse/decomposition.py
+++ b/pyemma/msm/analysis/sparse/decomposition.py
@@ -375,7 +375,7 @@ def timescales_from_eigenvalues(ev, tau=1):
                       'for implied time scale computation', ImaginaryEigenValueWarning)
 
     """Check for multiple eigenvalues of magnitude one"""
-    ind_abs_one = np.isclose(np.abs(ev), 1.0)
+    ind_abs_one = np.isclose(np.abs(ev), 1.0, rtol=0.0, atol=1e-14)
     if sum(ind_abs_one) > 1:
         warnings.warn('Multiple eigenvalues with magnitude one.', SpectralWarning)
 


### PR DESCRIPTION
[msm/analysis] Set floating point tolerance to distinguish unit eigenvalues from eigenvalues<1 in timescales computation to tol=1e-14
