### PR TITLE
[coor/clustering] regspace naming max_centers (same as api, fixes #307)

### DIFF
--- a/pyemma/coordinates/clustering/interface.py
+++ b/pyemma/coordinates/clustering/interface.py
@@ -28,6 +28,7 @@ Created on 18.02.2015
 @author: marscher
 '''
 from pyemma.coordinates.transform.transformer import Transformer
+from pyemma.util.annotators import doc_inherit
 from pyemma.util.files import mkdir_p
 
 import numpy as np
@@ -63,6 +64,7 @@ class AbstractClustering(Transformer):
 
     @property
     def dtrajs(self):
+        """Discrete trajectories (assigned data to cluster centers)."""
         if len(self._dtrajs) == 0:  # nothing assigned yet, doing that now
             self._dtrajs = self.assign(stride=1)
 
@@ -80,6 +82,7 @@ class AbstractClustering(Transformer):
         """output dimension of clustering algorithm (always 1)."""
         return 1
 
+    @doc_inherit
     def output_type(self):
         return np.int32
 

--- a/pyemma/coordinates/clustering/interface.py
+++ b/pyemma/coordinates/clustering/interface.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2015, 2014 Computational Molecular Biology Group, Free University
 # Berlin, 14195 Berlin, Germany.
 # All rights reserved.
@@ -28,7 +27,6 @@ Created on 18.02.2015
 @author: marscher
 '''
 from pyemma.coordinates.transform.transformer import Transformer
-from pyemma.util.annotators import doc_inherit
 from pyemma.util.files import mkdir_p
 
 import numpy as np
@@ -82,7 +80,8 @@ class AbstractClustering(Transformer):
         """output dimension of clustering algorithm (always 1)."""
         return 1
 
-    @doc_inherit
+    #@doc_inherit
+    # TODO: inheritance of docstring should work
     def output_type(self):
         return np.int32
 

--- a/pyemma/coordinates/clustering/kmeans.py
+++ b/pyemma/coordinates/clustering/kmeans.py
@@ -108,10 +108,6 @@ class KmeansClustering(AbstractClustering):
     def _get_constant_memory(self):
         return 1
 
-    @doc_inherit
-    def describe(self):
-        return "[Kmeans, k=%i]" % self.n_clusters
-
     def _param_finish(self):
         self.clustercenters = np.array(self._cluster_centers)
         del self._cluster_centers
@@ -132,14 +128,14 @@ class KmeansClustering(AbstractClustering):
         if ipass == 0:
             # beginning - compute
             if first_chunk:
-                mem_req = 1e-6 * 2 * X[0, :].nbytes * self.n_frames_total(stride=stride)
-                self._logger.warn('K-means implementation is currently memory inefficient.'
-                                  ' This calculation needs %i megabytes of main memory.'
-                                  ' If you get a memory error, try using a larger stride.'
-                                  % mem_req)
+                mem_req = int(1.0/1024**2 * X[0, :].nbytes * self.n_frames_total(stride))
+                if mem_req > 10:
+                    self._logger.warn('K-means implementation is currently memory inefficient.'
+                                      ' This calculation needs %i megabytes of main memory.'
+                                      ' If you get a memory error, try using a larger stride.'
+                                      % mem_req)
 
             # appends a true copy
-            # self._in_memory_chunks.append(X[:, :])
             self._in_memory_chunks[self._t_total:self._t_total + len(X)] = X[:]
             self._t_total += len(X)
             # initialize uniform cluster centers

--- a/pyemma/coordinates/clustering/kmeans.py
+++ b/pyemma/coordinates/clustering/kmeans.py
@@ -108,10 +108,6 @@ class KmeansClustering(AbstractClustering):
     def _get_constant_memory(self):
         return 1
 
-    def _map_to_memory(self):
-        # results mapped to memory during parametrize
-        pass
-
     @doc_inherit
     def describe(self):
         return "[Kmeans, k=%i]" % self.n_clusters

--- a/pyemma/coordinates/clustering/kmeans.py
+++ b/pyemma/coordinates/clustering/kmeans.py
@@ -27,13 +27,13 @@ Created on 22.01.2015
 
 @author: marscher, noe
 """
-
-import kmeans_clustering
 import math
 import os
 import random
 import tempfile
 import numpy as np
+
+from . import kmeans_clustering
 
 from pyemma.util.annotators import doc_inherit
 from pyemma.coordinates.clustering.interface import AbstractClustering

--- a/pyemma/coordinates/clustering/uniform_time.py
+++ b/pyemma/coordinates/clustering/uniform_time.py
@@ -137,8 +137,3 @@ class UniformTimeClustering(AbstractClustering):
                 return True  # done!
 
         return False  # not done yet.
-
-    def _map_to_memory(self):
-        # nothing to do, because memory-mapping of the discrete trajectories is
-        # done in parametrize
-        pass


### PR DESCRIPTION
- moved _map_to_memory to interface
- added some docstrings
