### PR TITLE
Add stride for save trajs

### DIFF
--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -52,6 +52,9 @@ from pyemma.coordinates.clustering.uniform_time import UniformTimeClustering as 
 from pyemma.coordinates.clustering.regspace import RegularSpaceClustering as _RegularSpaceClustering
 from pyemma.coordinates.clustering.assign import AssignCenters as _AssignCenters
 
+import numpy as _np
+import itertools as _itertools
+
 _logger = _getLogger('coordinates.api')
 
 __author__ = "Frank Noe, Martin Scherer"
@@ -234,16 +237,14 @@ def source(inp, features=None, top=None):
         to analyze big data in streaming mode.
 
     """
-    from numpy import ndarray
-
     # CASE 1: input is a string or list of strings
     # check: if single string create a one-element list
     if isinstance(inp, basestring) or (isinstance(inp, (list, tuple))
                                        and (any(isinstance(item, basestring) for item in inp) or len(inp) is 0)):
         reader = _create_file_reader(inp, top, features)
 
-    elif isinstance(inp, ndarray) or (isinstance(inp, (list, tuple))
-                                      and (any(isinstance(item, ndarray) for item in inp) or len(inp) is 0)):
+    elif isinstance(inp, _np.ndarray) or (isinstance(inp, (list, tuple))
+                                      and (any(isinstance(item, _np.ndarray) for item in inp) or len(inp) is 0)):
         # CASE 2: input is a (T, N, 3) array or list of (T_i, N, 3) arrays
         # check: if single array, create a one-element list
         # check: do all arrays have compatible dimensions (*, N, 3)? If not: raise ValueError.
@@ -432,7 +433,7 @@ def memory_reader(data):
     return _DataInMemory(data)
 
 
-def save_traj(traj_inp, indexes, outfile, verbose=False):
+def save_traj(traj_inp, indexes, outfile, verbose=False, stride=1):
     r""" Saves a sequence of frames as a single trajectory.
 
     Extracts the specified sequence of time/trajectory indexes from the input loader
@@ -457,27 +458,23 @@ def save_traj(traj_inp, indexes, outfile, verbose=False):
     verbose : boolean, default is False
         Verbose output while looking for "indexes" in the "traj_inp.trajfiles"
     """
-
-    from itertools import islice
-    from numpy import vstack, unique
-
     # Convert to index (T,2) array if parsed a list or a list of arrays
-    indexes = vstack(indexes)
+    indexes = _np.vstack(indexes)
     # Instantiate  a list of iterables that will contain mdtraj trajectory objects
     trajectory_iterator_list = []
 
     # Cycle only over files that are actually mentioned in "indexes"
-    file_idxs, file_pos = unique(indexes[:, 0], return_inverse=True)
+    file_idxs, file_pos = _np.unique(indexes[:, 0], return_inverse=True)
     for ii, ff in enumerate(file_idxs):
         # Slice the indexes array (frame column) where file ff was mentioned
         frames = indexes[file_pos == ii, 1]
         # Store the trajectory object that comes out of _frames_from_file
         # directly as an iterator in trajectory_iterator_list
-        trajectory_iterator_list.append(islice(_frames_from_file(traj_inp.trajfiles[ff],
-                                                                 traj_inp.topfile,
-                                                                 frames, chunksize=traj_inp.chunksize,
-                                                                 verbose=verbose), None
-                                               )
+        trajectory_iterator_list.append(_itertools.islice(_frames_from_file(
+                                                traj_inp.trajfiles[ff],
+                                                traj_inp.topfile,
+                                                frames, chunksize=traj_inp.chunksize,
+                                                verbose=verbose), None)
                                         )
 
     # Iterate directly over the index of files and pick the trajectory that you need from the iterator list
@@ -490,7 +487,7 @@ def save_traj(traj_inp, indexes, outfile, verbose=False):
         else:
             traj = traj.join(trajectory_iterator_list[traj_idx].next())
 
-    # Return to memory as an mdtraj trajectory object 
+    # Return to memory as an mdtraj trajectory object
     if outfile is None:
         return traj
     # or to disk as a molecular trajectory file
@@ -500,7 +497,8 @@ def save_traj(traj_inp, indexes, outfile, verbose=False):
     _logger.info("Created file %s" % outfile)
 
 
-def save_trajs(traj_inp, indexes, prefix='set_', fmt=None, outfiles=None, inmemory=False, verbose=False):
+def save_trajs(traj_inp, indexes, prefix='set_', fmt=None, outfiles=None,
+               inmemory=False, verbose=False, stride=1):
     r""" Saves sequences of frames as multiple trajectories.
 
     Extracts a number of specified sequences of time/trajectory indexes from the input loader
@@ -549,20 +547,16 @@ def save_trajs(traj_inp, indexes, prefix='set_', fmt=None, outfiles=None, inmemo
         The list of absolute paths that the output files have been written to.
 
     """
-
-    from itertools import izip
-    from numpy import ndarray
-
     # Make sure indexes is iterable
     assert _types.is_iterable(indexes), "Indexes must be an iterable of matrices."
     # only if 2d-array, convert into a list
-    if isinstance(indexes, ndarray):
+    if isinstance(indexes, _np.ndarray):
         if indexes.ndim == 2:
             indexes = [indexes]
 
     # Make sure the elements of that lists are arrays, and that they are shaped properly
     for i_indexes in indexes:
-        assert isinstance(i_indexes, ndarray), "The elements in the 'indexes' variable must be numpy.ndarrays"
+        assert isinstance(i_indexes, _np.ndarray), "The elements in the 'indexes' variable must be numpy.ndarrays"
         assert i_indexes.ndim == 2, \
             "The elements in the 'indexes' variable are must have ndim = 2, and not %u" % i_indexes.ndim
         assert i_indexes.shape[1] == 2, \
@@ -589,14 +583,14 @@ def save_trajs(traj_inp, indexes, prefix='set_', fmt=None, outfiles=None, inmemo
     # This implementation looks for "i_indexes" separately, and thus one traj_inp.trajfile 
     # might be accessed more than once (less memory intensive)
     if not inmemory:
-        for i_indexes, outfile in izip(indexes, outfiles):
+        for i_indexes, outfile in _itertools.izip(indexes, outfiles):
             # TODO: use kwargs** to parse to save_traj
             save_traj(traj_inp, i_indexes, outfile, verbose=verbose)
     # This implementation is "one file - one pass" but might temporally create huge memory objects 
     else:
         traj = save_traj(traj_inp, indexes, outfile=None, verbose=verbose)
         i_idx = 0
-        for i_indexes, outfile in izip(indexes, outfiles):
+        for i_indexes, outfile in _itertools.izip(indexes, outfiles):
             # Create indices for slicing the mdtraj trajectory object
             f_idx = i_idx + len(i_indexes)
             # print i_idx, f_idx

--- a/pyemma/coordinates/tests/test_frames_from_file.py
+++ b/pyemma/coordinates/tests/test_frames_from_file.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2015, 2014 Computational Molecular Biology Group, Free University
+# Berlin, 14195 Berlin, Germany.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+'''
+Test the get_frames_from_file by comparing
+the direct, sequential retrieval of frames via mdtraj.load_frame() vs
+the retrival via save_trajs
+@author: gph82, clonker
+'''
+
+import unittest
+import os
+import shutil
+import tempfile
+
+from numpy.random import randint
+from numpy import floor
+import mdtraj as md
+from pyemma.coordinates.data.frames_from_file import frames_from_file as _frames_from_file
+from pyemma.coordinates.data.util.reader_utils import compare_coords_md_trajectory_objects
+
+class TestFramesFromFile(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestFramesFromFile, cls).setUpClass()
+
+    def setUp(self):
+        self.eps = 1e-10
+        path = os.path.join(os.path.split(__file__)[0], 'data')
+        self.pdbfile = os.path.join(path, 'bpti_ca.pdb')
+        self.trajfiles = os.path.join(path, 'bpti_mini.xtc')
+        self.subdir = tempfile.mkdtemp(suffix='get_frames_from_file/')
+
+        # Create of frames to be retrieved from trajfiles
+        self.n_frames = 50
+        self.frames = randint(0, high = 100, size = self.n_frames)
+        self.chunksize = 30
+
+    def tearDown(self):
+        shutil.rmtree(self.subdir, ignore_errors=True)
+
+    def test_returns_trajectory(self):
+        assert isinstance(_frames_from_file(self.trajfiles, self.pdbfile, self.frames),
+                          md.Trajectory)
+
+    def test_gets_the_right_frames_no_stride_no_chunk(self):
+        # I am calling this "no_chunk" because chunksize = int(1e3) will force frames_from_file to load one single chunk
+
+        traj_test = _frames_from_file(self.trajfiles, self.pdbfile, self.frames, chunksize = int(1e3), verbose=False)
+        traj_ref = md.load(self.trajfiles, top = self.pdbfile)[self.frames]
+
+        (found_diff, errmsg) = compare_coords_md_trajectory_objects(traj_test, traj_ref, atom=0, mess=False)
+        self.assertFalse(found_diff, errmsg)
+
+    def test_gets_the_right_frames_no_stride_with_chunk(self):
+
+        traj_test = _frames_from_file(self.trajfiles, self.pdbfile, self.frames, chunksize=self.chunksize, verbose = False)
+        traj_ref = md.load(self.trajfiles, top=self.pdbfile)[self.frames]
+
+        (found_diff, errmsg) = compare_coords_md_trajectory_objects(traj_test, traj_ref, atom = 0, mess = False)
+        self.assertFalse(found_diff, errmsg)
+
+    def test_gets_the_right_frames_with_stride_no_chunk(self):
+        # I am calling this "no_chunk" because chunksize = int(1e3) will force frames_from_file to load one single chunk
+
+        for stride in [2, 5, 10]:
+            # Make sure we don't overshoot the number of available frames (100)
+            frames = randint(0, high=floor(100 / stride), size=self.n_frames)
+
+            traj_test = _frames_from_file(self.trajfiles, self.pdbfile, frames, stride = stride, verbose=False)
+            traj_ref = md.load(self.trajfiles, top=self.pdbfile, stride = stride)[frames]
+
+            (found_diff, errmsg) = compare_coords_md_trajectory_objects(traj_test, traj_ref, atom=0, mess=False)
+            self.assertFalse(found_diff, errmsg)
+
+    def test_gets_the_right_frames_with_stride_with_chunk(self):
+
+        for stride in [2, 3, 5, 6, 10, 15]:
+            # Make sure we don't overshoot the number of available frames (100)
+            frames = randint(0, high = floor(100/stride), size = self.n_frames)
+
+            traj_test = _frames_from_file(self.trajfiles, self.pdbfile, frames,
+                                          chunksize=self.chunksize,
+                                          stride = stride,
+                                          verbose=False)
+            traj_ref = md.load(self.trajfiles, top=self.pdbfile, stride = stride)[frames]
+
+            (found_diff, errmsg) = compare_coords_md_trajectory_objects(traj_test, traj_ref, atom=0, mess=False)
+            self.assertFalse(found_diff, errmsg)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyemma/coordinates/tests/test_save_trajs.py
+++ b/pyemma/coordinates/tests/test_save_trajs.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2015, 2014 Computational Molecular Biology Group, Free University
 # Berlin, 14195 Berlin, Germany.
 # All rights reserved.
@@ -134,6 +133,17 @@ class TestSaveTrajs(unittest.TestCase):
                 break
 
         self.assertFalse(found_diff, errmsg)
+
+    def test_with_stride(self):
+        strides = [1, 2, 3, 5]
+
+        for stride in strides:
+            # Test that we're saving to disk alright
+            flist = save_trajs(self.reader, self.sets, prefix=self.subdir, stride=stride)
+            exist = True
+            for f in flist:
+                exist = exist and os.stat(f)
+            self.assertTrue(exist, "Could not write to disk")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This  closes #309 i'm trying to merge to the same branch as @marscher was doing in #309 , but now there are some conflicts. Not sure how to handle this best.

Now frames_from_file gets its own test (tests for save_trajs have also been extended to test the stride functionality). 

I think we should anyways take save_traj out of the api and give save_trajs a "flatten" option. Otherwise it's a bit confusing. I'll do that next.
