### PR TITLE
Fast timescale calculation

### DIFF
--- a/pyemma/msm/analysis/api.py
+++ b/pyemma/msm/analysis/api.py
@@ -390,7 +390,7 @@ def stationary_distribution(T):
 
 
 # DONE: Martin, Ben
-def eigenvalues(T, k=None, ncv=None):
+def eigenvalues(T, k=None, ncv=None, reversible=False, mu=None):
     r"""Find eigenvalues of the transition matrix.
 
     Parameters
@@ -402,6 +402,12 @@ def eigenvalues(T, k=None, ncv=None):
     ncv : int (optional)
         The number of Lanczos vectors generated, `ncv` must be greater than k;
         it is recommended that ncv > 2*k
+    reversible : bool (optional)
+        Indicate that transition matrix is reversible. Will compute its stationary distribution `\mu` (unless given)
+        and then compute the eigenvalues of the symmetric matrix `\sqrt(\mu_i / \mu_j)` which is equivalent but
+        much faster
+    mu : numpy.ndarray, shape=(d)
+        Stationary distribution of T. Will only be used if reversible=True in order to symmetrize T.
 
     Returns
     -------
@@ -427,13 +433,13 @@ def eigenvalues(T, k=None, ncv=None):
     if _issparse(T):
         return sparse.decomposition.eigenvalues(T, k, ncv=ncv)
     elif _isdense(T):
-        return dense.decomposition.eigenvalues(T, k)
+        return dense.decomposition.eigenvalues(T, k, reversible=reversible, mu=mu)
     else:
         raise _type_not_supported
 
 
 # DONE: Ben
-def timescales(T, tau=1, k=None, ncv=None):
+def timescales(T, tau=1, k=None, ncv=None, reversible=False, mu=None):
     r"""Compute implied time scales of given transition matrix.
 
     Parameters
@@ -449,6 +455,12 @@ def timescales(T, tau=1, k=None, ncv=None):
     ncv : int (optional, for sparse T only)
         The number of Lanczos vectors generated, `ncv` must be greater than k;
         it is recommended that ncv > 2*k
+    reversible : bool (optional)
+        Indicate that transition matrix is reversible. Will compute its stationary distribution `\mu` (unless given)
+        and then compute the eigenvalues of the symmetric matrix `\sqrt(\mu_i / \mu_j)` which is equivalent but
+        much faster
+    mu : numpy.ndarray, shape=(d)
+        Stationary distribution of T. Will only be used if reversible=True in order to symmetrize T.
 
     Returns
     -------
@@ -476,7 +488,7 @@ def timescales(T, tau=1, k=None, ncv=None):
     if _issparse(T):
         return sparse.decomposition.timescales(T, tau=tau, k=k, ncv=ncv)
     elif _isdense(T):
-        return dense.decomposition.timescales(T, tau=tau, k=k)
+        return dense.decomposition.timescales(T, tau=tau, k=k, reversible=reversible, mu=mu)
     else:
         raise _type_not_supported
 

--- a/pyemma/msm/analysis/dense/decomposition_test.py
+++ b/pyemma/msm/analysis/dense/decomposition_test.py
@@ -89,6 +89,21 @@ class TestDecomposition(unittest.TestCase):
         evn = eigenvalues(P, k=self.k)
         assert_allclose(ev[0:self.k], evn)
 
+    def test_eigenvalues_reversible(self):
+        P = self.bdc.transition_matrix()
+        ev = eigvals(P)
+        """Sort with decreasing magnitude"""
+        ev = ev[np.argsort(np.abs(ev))[::-1]]
+
+
+        """reversible without given mu"""
+        evn = eigenvalues(P, reversible=True)
+        assert_allclose(ev, evn)
+
+        """reversible with given mu"""
+        evn = eigenvalues(P, reversible=True, mu=self.bdc.stationary_distribution())
+        assert_allclose(ev, evn)
+
     def test_eigenvectors(self):
         P = self.bdc.transition_matrix()
 

--- a/pyemma/msm/ui/timescales.py
+++ b/pyemma/msm/ui/timescales.py
@@ -127,10 +127,12 @@ class ImpliedTimescales(object):
         
         """
         # connected set
-        C = (connected_cmatrix(C)).toarray()
-        if (len(C) > 1):
+        C = connected_cmatrix(C)
+        if (np.shape(C)[0] > 1):
             # estimate transition matrix
             T = tmatrix(C, reversible=self._reversible)
+            # make it dense
+            T = T.toarray()
             # timescales
             ts = timescales(T, tau, k=min(self._nits, len(T)) + 1, reversible=self._reversible)[1:]
             return ts

--- a/pyemma/msm/ui/timescales.py
+++ b/pyemma/msm/ui/timescales.py
@@ -132,7 +132,7 @@ class ImpliedTimescales(object):
             # estimate transition matrix
             T = tmatrix(C, reversible=self._reversible)
             # timescales
-            ts = timescales(T, tau, k=min(self._nits, len(T)) + 1)[1:]
+            ts = timescales(T, tau, k=min(self._nits, len(T)) + 1, reversible=self._reversible)[1:]
             return ts
         else:
             return None  # no timescales available


### PR DESCRIPTION
The timescale calculation is sped up a lot due to two changes:
- Now converting to a dense matrix just before calculating the timescales. This way we do the reversible estimation on a sparse matrix which is for some reason much faster, although I don't understand why because the sparsity pattern is the same and should be exploited also in the dense implementation ( @fabian-paul , you said that for the dense T-matrix estimation a C-extension would not speed it up, but this seems to contradict my observation. )
- Added fast eigenvalue and timescale calculation for reversible T-matrices to msm.analysis. There is an option reversible=False and an option mu=None for the stationary distribution. If reversible=True, then the stationary distribution is used or computed to symmetrise the T-matrix as s_ij = sqrt(mu_i/mu_j) T_ij. Then eigenvalsh is used to compute the eigenvalues (identical problem, but much faster).

I would like @trendelkampschroer to check this PR. @trendelkampschroer , if you agree with these changes please do a corresponding enhancement for the eigenvectors (which are the eigenvectors of S, scaled by 1/sqrt(mu)) and rdl decomposition and also for the sparse case.
