### PR TITLE
[coordinates/clustering/kmeans] Added progress bars for initialization

### DIFF
--- a/pyemma/util/progressbar/gui.py
+++ b/pyemma/util/progressbar/gui.py
@@ -57,6 +57,12 @@ def show_progressbar(bar, show_eta=True):
 
             # make it visible once
             display(box)
+
+            # update css for a more compact view
+            progress_widget._css = [
+                ("div", "margin-top", "0px")
+            ]
+            progress_widget.height = "8px"
         else:
             widget = bar.widget
 


### PR DESCRIPTION
As the title says, added progress bars for initialization of cluster centers as well as for the iterations (which might end early and therefore only gives an upper bound). Additionally this PR contains a modification of the progress-bars css such that it appears more compact:

![screenshot 2015-05-27 14 37 54](https://cloud.githubusercontent.com/assets/1685266/7836720/afdeaf7c-0482-11e5-8705-07700f8c3e83.png)

This should improve #326.
