### PR TITLE
[msm.api.its] gets a new property "fraction_of_frames" (for every lagtime)

### DIFF
--- a/pyemma/msm/tests/test_its.py
+++ b/pyemma/msm/tests/test_its.py
@@ -133,6 +133,21 @@ class ImpliedTimescalesTest(unittest.TestCase):
         assert (np.alltrue(est < t4 + 20.0))
         assert (np.alltrue(est > t4 - 20.0))
 
+    def test_fraction_of_frames(self):
+        dtrajs = [
+            [0, 1, 0], # These two will fail for lag >2
+            [1, 0, 1], # These two will fail for lag >2
+            [0, 1, 1, 1],
+            [1, 0, 0, 0],
+            [0, 1, 0, 1, 0],
+            [1, 0, 1, 0, 1],
+            ]
+        lags = [1, 2, 3]
+        its = ImpliedTimescales(dtrajs, lags=lags)
+        all_frames = its.lengths.sum()
+        longer_than_3 = its.lengths[2:].sum()
+        test_frac = longer_than_3/all_frames
+        assert np.allclose(its.fraction_of_frames, np.array([1, 1, test_frac]))
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/msm/ui/timescales.py
+++ b/pyemma/msm/ui/timescales.py
@@ -427,3 +427,32 @@ class ImpliedTimescales(object):
                 L[i] = conf[1]
                 R[i] = conf[2]
             return (L, R)
+
+    @property
+    def fraction_of_frames(self):
+        r"""Returns the fraction of frames used to compute the count matrix at each lagtime.
+
+        Notes
+        -------
+        In a list of discrete trajectories with varying lengths, the estimation at longer lagtimes will mean
+        discarding some trajectories for which not even one count can be computed. This function returns the fraction
+        of frames that was actually used in computing the count matrix.
+
+        **Be aware**: this fraction refers to the **full count matrix**, and not that of the largest connected
+        set. Hence, the output is not necessarily the **active** fraction. For that, use the
+        :py:func:`EstimatedMSM.active_count_fraction` function of the :py:class:`EstimatedMSM` class object.
+        """
+
+        # TODO : implement fraction_of_active_frames
+
+        # Are we computing this for the first time?
+        if not hasattr(self,'_fraction'):
+            self._fraction = np.zeros_like(self.lagtimes, dtype='float32')
+            self._nframes = self.lengths.sum()
+
+            # Iterate over lagtimes and find trajectories that contributed with at least one count
+            for ii, lag in enumerate(self.lagtimes):
+                long_enough = np.argwhere(self.lengths-lag >= 1).squeeze()
+                self._fraction[ii] = self.lengths[long_enough].sum()/self._nframes
+
+        return self._fraction


### PR DESCRIPTION
I think it is useful to have this when dealing with dtrajs of significantly different lenghts.

TODO: I would also want to add sth like fraction_active_frames. 

I updated the docs, and also the ./doc/source/api/generated/pyemma.msm.ui.ImpliedTimescales.rst file, but it is not tracked. Do we want to add them? 
