### PR TITLE
[transformer] method trajectory_lengths returns numpy int array now. 

### DIFF
--- a/pyemma/coordinates/data/interface.py
+++ b/pyemma/coordinates/data/interface.py
@@ -94,9 +94,9 @@ class ReaderInterface(Transformer):
             running through them with a step size of `stride`
 
         :return:
-            list containing length of each trajectory
+            numpy array containing length of each trajectory
         """
-        return [(l - 1) // stride + 1 for l in self._lengths]
+        return np.array([(l - 1) // stride + 1 for l in self._lengths], dtype=int)
 
     def n_frames_total(self, stride=1):
         """

--- a/pyemma/coordinates/tests/test_datainmemory.py
+++ b/pyemma/coordinates/tests/test_datainmemory.py
@@ -61,8 +61,8 @@ class TestDataInMemory(unittest.TestCase):
 
         self.assertEqual(d.dimension(), dim)
 
-        self.assertEqual(
-            d.trajectory_lengths(), [frames_per_traj for _ in xrange(3)])
+        np.testing.assert_equal(
+            d.trajectory_lengths(), np.array([frames_per_traj for _ in xrange(3)]))
 
     def testDataArray(self):
         frames_per_traj = 100
@@ -71,15 +71,15 @@ class TestDataInMemory(unittest.TestCase):
         data = np.random.random((frames_per_traj, dim))
         d = DataInMemory(data)
 
-        self.assertEqual(
-            d.trajectory_lengths(), [frames_per_traj for _ in xrange(1)])
+        np.testing.assert_equal(
+            d.trajectory_lengths(), np.array([frames_per_traj for _ in xrange(1)]))
 
     def test1dData(self):
         n = 3
         data = np.arange(n)
         reader = DataInMemory(data)
 
-        self.assertEqual(reader.trajectory_lengths(), [n])
+        self.assertEqual(reader.trajectory_lengths(), np.array([n]))
         self.assertEqual(reader.dimension(), 1)
         self.assertEqual(reader.number_of_trajectories(), 1)
         self.assertEqual(reader.n_frames_total(), n)
@@ -89,7 +89,7 @@ class TestDataInMemory(unittest.TestCase):
         data = [np.arange(n), np.arange(n)]
         reader = DataInMemory(data)
 
-        self.assertEqual(reader.trajectory_lengths(), [n, n])
+        np.testing.assert_equal(reader.trajectory_lengths(), np.array([n, n]))
         self.assertEqual(reader.dimension(), 1)
         self.assertEqual(reader.number_of_trajectories(), 2)
         self.assertEqual(reader.n_frames_total(), 2 * n)
@@ -109,8 +109,8 @@ class TestDataInMemory(unittest.TestCase):
         self.assertEqual(reader.dimension(), 2 * 2 * 2)
         self.assertEqual(reader.number_of_trajectories(), 1)
         self.assertEqual(reader.n_frames_total(), 4)
-        self.assertEqual(
-            reader.trajectory_lengths(), [reader.n_frames_total()])
+        np.testing.assert_equal(
+            reader.trajectory_lengths(), np.array([reader.n_frames_total()]))
 
     def test_time_lagged_chunked_access(self):
         n = 100

--- a/pyemma/coordinates/tests/test_stride.py
+++ b/pyemma/coordinates/tests/test_stride.py
@@ -78,7 +78,7 @@ class TestStride(unittest.TestCase):
             # print 'len_ref', len_ref
 
             # compare length
-            self.assertTrue(len_ref == len_trajs)
+            np.testing.assert_equal(len_trajs, len_ref)
             self.assertTrue(len_ref == len_tica)
             self.assertTrue(len_ref == len_reader)
 

--- a/pyemma/coordinates/transform/transformer.py
+++ b/pyemma/coordinates/transform/transformer.py
@@ -196,7 +196,7 @@ class Transformer(object):
 
         Returns
         -------
-        int : length of each trajectory
+        array(dtype=int) : containing length of each trajectory
         """
         return self.data_producer.trajectory_lengths(stride=stride)
 


### PR DESCRIPTION
This implements feature requested in #340
