### PR TITLE
Fix chunksize datainmemory

### DIFF
--- a/pyemma/coordinates/data/data_in_memory.py
+++ b/pyemma/coordinates/data/data_in_memory.py
@@ -133,22 +133,19 @@ class DataInMemory(ReaderInterface):
 
             X = traj[slice_x]
 
-            if lag == 0:
-                self._t = upper_bound
+            if lag!=0:
+                 upper_bound_Y = min(
+                     self._t + (lag + self._chunksize) * stride, traj_len)
+                 slice_y = slice(self._t + lag*stride, upper_bound_Y, stride)
+                 Y = traj[slice_y]
 
-                if upper_bound >= traj_len:
-                    self._itraj += 1
-                    self._t = 0
+            self._t = upper_bound
+
+            if upper_bound >= traj_len:
+                 self._itraj += 1
+                 self._t = 0
+                 
+            if lag==0:
                 return X
-            else:
-                # its okay to return empty chunks
-                upper_bound = min(
-                    self._t + stride * (lag + self._chunksize), traj_len)
-                slice_y = slice(self._t + lag, upper_bound, stride)
-                self._t = upper_bound
-
-                if self._t >= traj_len:
-                    self._itraj += 1
-                    self._t = 0
-                Y = traj[slice_y]
-                return X, Y
+            else: 
+                return (X, Y)

--- a/pyemma/coordinates/data/data_in_memory.py
+++ b/pyemma/coordinates/data/data_in_memory.py
@@ -128,7 +128,7 @@ class DataInMemory(ReaderInterface):
         # chunked mode
         else:
             upper_bound = min(
-                self._t + (self._chunksize + 1) * stride, traj_len)
+                self._t + self._chunksize * stride, traj_len)
             slice_x = slice(self._t, upper_bound, stride)
 
             X = traj[slice_x]
@@ -143,7 +143,7 @@ class DataInMemory(ReaderInterface):
             else:
                 # its okay to return empty chunks
                 upper_bound = min(
-                    self._t + (lag + self._chunksize + 1) * stride, traj_len)
+                    self._t + stride * (lag + self._chunksize), traj_len)
                 slice_y = slice(self._t + lag, upper_bound, stride)
                 self._t += X.shape[0]
 

--- a/pyemma/coordinates/data/data_in_memory.py
+++ b/pyemma/coordinates/data/data_in_memory.py
@@ -145,7 +145,7 @@ class DataInMemory(ReaderInterface):
                 upper_bound = min(
                     self._t + stride * (lag + self._chunksize), traj_len)
                 slice_y = slice(self._t + lag, upper_bound, stride)
-                self._t += X.shape[0]
+                self._t = upper_bound
 
                 if self._t >= traj_len:
                     self._itraj += 1

--- a/pyemma/coordinates/tests/test_datainmemory.py
+++ b/pyemma/coordinates/tests/test_datainmemory.py
@@ -21,6 +21,7 @@
 # ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import pyemma
 
 '''
 Created on 04.02.2015
@@ -158,6 +159,14 @@ class TestDataInMemory(unittest.TestCase):
             expected = self.d[::s]
             np.testing.assert_allclose(output, expected,
                                        err_msg="not equal for stride=%i" % s)
+
+    def test_chunksize(self):
+        data = np.random.randn(200,2)
+        cs = 100
+        source = pyemma.coordinates.source(data,chunk_size=cs)
+        source.chunksize = 100
+        for i,ch in source.iterator():
+            assert ch.shape[0] <=cs, ch.shape
 
     def test_lagged_iterator_1d(self):
         n = 57


### PR DESCRIPTION
Your fix isn't working. I changed it.
Now the following works:

``` Python
import pyemma
import numpy as np
data1 = np.random.randn(12345,10)
data2 = np.random.randn(54321,10)
source = pyemma.coordinates.source([data1,data2])
stride = 123
lag = 45
source.chunksize = 678
c = 0
c_lag = 0
for i,X,Y in source.iterator(stride=stride,lag=lag):
    c+=X.shape[0]
    c_lag+=Y.shape[0]
print 'got', c, 'expected', ((data1.shape[0]-1)//stride+1) + ((data2.shape[0]-1)//stride+1)
print 'got', c_lag, 'expected', ((data1.shape[0]-1)//stride+1 - lag) +  ((data2.shape[0]-1)//stride+1 - lag) # old convention

```
