### PR TITLE
[util/config] do not fail, if configuration directory (.pyemma) can not be created.

### DIFF
--- a/pyemma/util/config.py
+++ b/pyemma/util/config.py
@@ -119,8 +119,8 @@ def create_cfg_dir(default_config):
         try:
             mkdir_p(pyemma_cfg_dir)
         except EnvironmentError:
-            warnings.warn("could not create configuration directory '%s'" %
-                          pyemma_cfg_dir)
+            raise RuntimeError("could not create configuration directory '%s'" %
+                               pyemma_cfg_dir)
 
     def touch(fname, times=None):
         with open(fname, 'a'):
@@ -153,7 +153,11 @@ def readConfiguration():
     default_pyemma_conf = pkg_resources.resource_filename('pyemma', cfg)
 
     # create .pyemma dir in home
-    pyemma_cfg_dir = create_cfg_dir(default_pyemma_conf)
+    pyemma_cfg_dir = ''
+    try:
+        pyemma_cfg_dir = create_cfg_dir(default_pyemma_conf)
+    except RuntimeError as re:
+        warnings.warn(str(re))
 
     # use these files to extend/overwrite the conf_values.
     # Last red file always overwrites existing values!

--- a/pyemma/util/files.py
+++ b/pyemma/util/files.py
@@ -29,6 +29,8 @@ Created on 17.02.2014
 '''
 import os
 import errno
+import tempfile
+import shutil
 
 
 def mkdir_p(path):
@@ -39,3 +41,32 @@ def mkdir_p(path):
             pass
         else:
             raise
+
+
+class TemporaryDirectory(object):
+    """ use this class in context (with keyword)
+
+    Examples
+    --------
+    >>> import os
+    >>> with TemporaryDirectory() as tmp:
+    ...    path = os.path.join(tmp, "myfile.dat")
+    ...    fh = open(path, 'w)
+    ...    fh.write('hello world')
+    ...    fh.close()
+
+    """
+
+    def __init__(self, prefix='', suffix='', dir=None):
+        self.prefix = prefix
+        self.suffix = suffix
+        self.dir = dir
+        self.tmpdir = None
+
+    def __enter__(self):
+        self.tmpdir = tempfile.mkdtemp(suffix=self.suffix, prefix=self.prefix,
+                                       dir=self.dir)
+        return self.tmpdir
+
+    def __exit__(self, *args):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)

--- a/pyemma/util/tests/test_config.py
+++ b/pyemma/util/tests/test_config.py
@@ -6,6 +6,7 @@ Created on 11.06.2015
 import warnings
 import unittest
 import os
+import sys
 
 from pyemma.util.config import readConfiguration
 from pyemma.util.files import TemporaryDirectory
@@ -13,6 +14,7 @@ from pyemma.util.files import TemporaryDirectory
 
 class TestConfig(unittest.TestCase):
 
+    @unittest.skipIf(sys.platform == 'win32', 'unix based test')
     def test_can_not_create_cfg_dir(self):
         os.environ['HOME'] = '/dev/null'
 
@@ -28,6 +30,7 @@ class TestConfig(unittest.TestCase):
             assert issubclass(w[-1].category, UserWarning)
             assert "could not create" in str(w[-1].message)
 
+    @unittest.skipIf(sys.platform == 'win32', 'unix based test')
     def test_non_writeable_cfg_dir(self):
 
         with TemporaryDirectory() as tmp:

--- a/pyemma/util/tests/test_config.py
+++ b/pyemma/util/tests/test_config.py
@@ -1,0 +1,53 @@
+'''
+Created on 11.06.2015
+
+@author: marscher
+'''
+import warnings
+import unittest
+import os
+
+from pyemma.util.config import readConfiguration
+from pyemma.util.files import TemporaryDirectory
+
+
+class TestConfig(unittest.TestCase):
+
+    def test_can_not_create_cfg_dir(self):
+        os.environ['HOME'] = '/dev/null'
+
+        exp_homedir = os.path.expanduser('~')
+        assert exp_homedir == '/dev/null'
+
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always")
+            # Trigger a warning.
+            readConfiguration()
+            assert len(w) == 1
+            assert issubclass(w[-1].category, UserWarning)
+            assert "could not create" in str(w[-1].message)
+
+    def test_non_writeable_cfg_dir(self):
+
+        with TemporaryDirectory() as tmp:
+            cfg_dir = os.path.join(tmp, '.pyemma')
+            os.mkdir(cfg_dir)
+            os.environ['HOME'] = tmp
+            # make cfg dir non-writeable
+            os.chmod(cfg_dir, 444)
+
+            exp_homedir = os.path.expanduser('~')
+            assert exp_homedir == tmp
+
+            with warnings.catch_warnings(record=True) as w:
+                # Cause all warnings to always be triggered.
+                warnings.simplefilter("always")
+                # Trigger a warning.
+                readConfiguration()
+                assert len(w) == 1
+                assert issubclass(w[-1].category, UserWarning)
+                assert "is not writeable" in str(w[-1].message)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Triggers a UserWarning instead. Fixes #350
