### PR TITLE
Feature auto sparse

### DIFF
--- a/pyemma/msm/estimation/dense/_mle_trev_given_pi.h
+++ b/pyemma/msm/estimation/dense/_mle_trev_given_pi.h
@@ -23,4 +23,5 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-int _mle_trev_given_pi_dense(double * const T, const long long * const C, const double * const mu, const int n, double maxerr, const int maxiter, const double eps);
+int _mle_trev_given_pi_dense(double * const T, const double * const C, const double * const mu, const int n, const double maxerr, const int maxiter);
+

--- a/pyemma/msm/estimation/dense/mle_trev_given_pi.pyx
+++ b/pyemma/msm/estimation/dense/mle_trev_given_pi.pyx
@@ -12,7 +12,7 @@ import pyemma.util.exceptions
 
 
 cdef extern from "_mle_trev_given_pi.h":
-  int _mle_trev_given_pi_dense(double * const T, const long long * const C, const double * const mu, const int n, double maxerr, const int maxiter, const double eps)
+  int _mle_trev_given_pi_dense(double * const T, const double * const C, const double * const mu, const int n, const double maxerr, const int maxiter)
 
 def mle_trev_given_pi(
   C,
@@ -25,40 +25,35 @@ def mle_trev_given_pi(
   assert maxerr > 0, 'maxerr must be positive'
   assert maxiter > 0, 'maxiter must be positive'
   assert eps >= 0, 'eps must be non-negative'
+  if eps>0:
+     warnings.warn('A regularization parameter value eps!=0 is not necessary for convergence. The parameter will be removed in future versions.', DeprecationWarning)
   assert pyemma.msm.estimation.is_connected(C, directed=False), 'C must be (weakly) connected'
 
-  cdef numpy.ndarray[long long, ndim=2, mode="c"] c_C = C.astype(numpy.int64, order='C', copy=False)
-  cdef numpy.ndarray[double, ndim=1, mode="c"] c_mu = mu.astype(numpy.double, order='C', copy=False)
+  cdef numpy.ndarray[double, ndim=2, mode="c"] c_C = C.astype(numpy.float64, order='C', copy=False)
+  cdef numpy.ndarray[double, ndim=1, mode="c"] c_mu = mu.astype(numpy.float64, order='C', copy=False)
 
   assert c_C.shape[0]==c_C.shape[1]==c_mu.shape[0], 'Dimensions of C and mu don\'t agree.'
 
-  cdef numpy.ndarray[double, ndim=2, mode="c"] T = numpy.zeros_like(c_C, dtype=numpy.double, order='C')
+  cdef numpy.ndarray[double, ndim=2, mode="c"] T = numpy.zeros_like(c_C, dtype=numpy.float64, order='C')
   
   err = _mle_trev_given_pi_dense(
         <double*> numpy.PyArray_DATA(T),
-        <long long*> numpy.PyArray_DATA(c_C),
+        <double*> numpy.PyArray_DATA(c_C),
         <double*> numpy.PyArray_DATA(c_mu),
         c_C.shape[0],
         maxerr,
-        maxiter,
-        eps)
-        
-  # TODO: add self test: check if stationary distribution is ok
+        maxiter)
 
   if err == -1:
     raise Exception('Out of memory.')
   elif err == -2:
-    raise Exception('The update of the Lagrange multipliers produced zero or NaN.')
+    raise Exception('The update of the Lagrange multipliers produced NaN.')
   elif err == -3:
     raise Exception('Some row and corresponding column of C have zero counts.')
   elif err == -4:
     raise Exception('Some element of pi is zero.')
   elif err == -5:
     warnings.warn('Reversible transition matrix estimation with fixed stationary distribution didn\'t converge.', pyemma.util.exceptions.NotConvergedWarning)
-  elif err == -6:
-    raise Exception('Count matrix has zero diagonal elements. Can\'t guarantee convergence of algorithm. '+
-                    'Suggestion: set regularization parameter eps to some small value e.g. 1E-6.')
-    
-     
+
   return T
 

--- a/pyemma/msm/estimation/sparse/_mle_trev_given_pi.h
+++ b/pyemma/msm/estimation/sparse/_mle_trev_given_pi.h
@@ -23,4 +23,4 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-int _mle_trev_given_pi_sparse(double * const T_data, const double * const CCt_data, const long long * const i_indices, const long long * const j_indices, const int len_CCt,  const double * const mu, const int len_mu, double maxerr, const int maxiter);
+int _mle_trev_given_pi_sparse(double * const T_unnormalized_data, const double * const CCt_data, const int * const i_indices, const int * const j_indices, const int len_CCt,  const double * const mu, const int len_mu, const double maxerr, const int maxiter);

--- a/pyemma/msm/estimation/sparse/mle_trev_given_pi.pyx
+++ b/pyemma/msm/estimation/sparse/mle_trev_given_pi.pyx
@@ -33,6 +33,8 @@ def mle_trev_given_pi(
   assert maxerr > 0, 'maxerr must be positive'
   assert maxiter > 0, 'maxiter must be positive'
   assert eps >= 0, 'eps must be non-negative'
+  if eps>0:
+     warnings.warn('A regularization parameter value eps!=0 is not necessary for convergence. The parameter will be removed in future versions.', DeprecationWarning)
   assert pyemma.msm.estimation.is_connected(C,directed=False), 'C must be (weakly) connected'
 
   cdef numpy.ndarray[double, ndim=1, mode="c"] c_mu = mu.astype(numpy.float64, order='C', copy=False)

--- a/pyemma/msm/estimation/sparse/mle_trev_given_pi.pyx
+++ b/pyemma/msm/estimation/sparse/mle_trev_given_pi.pyx
@@ -12,26 +12,15 @@ import warnings
 import pyemma.util.exceptions
 
 cdef extern from "_mle_trev_given_pi.h":
-    int _mle_trev_given_pi_sparse(double * const T_data,
+    int _mle_trev_given_pi_sparse(double * const T_unnormalized_data,
                                   const double * const CCt_data,
-                                  const long long * const i_indices,
-                                  const long long * const j_indices,
+                                  const int * const i_indices,
+                                  const int * const j_indices,
                                   const int len_CCt,
                                   const double * const mu,
                                   const int len_mu,
-                                  double maxerr,
+                                  const double maxerr,
                                   const int maxiter)
-def check_diagonal(A):
-  r"""Check matrix with non-negative entries for zero elements on diagonal.
-
-  Parameters
-  ----------
-  A : (M, M) scipy.sparse matrix
-      Input matrix
-      
-  """
-  a_ii = A.diagonal()
-  return numpy.all(a_ii > 0.0)
 
 def mle_trev_given_pi(
   C,
@@ -46,74 +35,46 @@ def mle_trev_given_pi(
   assert eps >= 0, 'eps must be non-negative'
   assert pyemma.msm.estimation.is_connected(C,directed=False), 'C must be (weakly) connected'
 
-  CCt_csr = C+C.T
-  """Convert to csr-format"""
-  CCt_csr = CCt_csr.tocsr()
-  """Ensure that entries are of type double"""
-  CCT_csr = CCt_csr.astype(numpy.double)
+  cdef numpy.ndarray[double, ndim=1, mode="c"] c_mu = mu.astype(numpy.float64, order='C', copy=False)
 
-  cdef numpy.ndarray[double, ndim=1, mode="c"] c_mu = mu.astype(numpy.double, order='C', copy=False)
+  CCt_coo = (C+C.T).tocoo()
 
-  assert CCt_csr.shape[0] == CCt_csr.shape[1] == c_mu.shape[0], 'Dimensions of C and mu don\'t agree.'
-  # """add regularization"""
-  # CCt_ii=CCt_csr.diagonal()
-  # """Check for zero elements"""
+  assert CCt_coo.shape[0] == CCt_coo.shape[1] == c_mu.shape[0], 'Dimensions of C and mu don\'t agree.'
 
-  if not check_diagonal(CCt_csr) and eps == 0.0:
-    raise Exception('Count matrix has zero diagonal elements. Can\'t guarantee convergence of algorithm. '+
-                    'Suggestion: set regularization parameter eps to some small value e.g. 1E-6.')
-
-  """Add regularization"""
-  c_ii = CCt_csr.diagonal()
-  ind = (c_ii == 0.0)
-  prior = numpy.zeros(len(c_ii))
-  prior[ind] = eps
-
-  CCt_csr = CCt_csr+scipy.sparse.diags(prior, 0)
-
-  # for i in xrange(CCt_csr.shape[0]):
-  #   if CCt_csr[i,i] == 0:
-  #     if eps==0:
-  #       raise Exception('Count matrix has zero diagonal elements. Can\'t guarantee convergence of algorithm. Suggestion: set regularization parameter eps to some small value e.g. 1E-6.')
-  #     else:
-  #       CCt_csr[i,i] = eps
-
-  # convert to coo format
-  CCt_coo = CCt_csr.tocoo()
   n_data = CCt_coo.nnz
-  cdef numpy.ndarray[double, ndim=1, mode="c"] CCt_data =  CCt_coo.data.astype(numpy.double, order='C', copy=False)
-  cdef numpy.ndarray[long long, ndim=1, mode="c"] i_indices = CCt_coo.row.astype(numpy.int64, order='C', copy=True)
-  cdef numpy.ndarray[long long, ndim=1, mode="c"] j_indices = CCt_coo.col.astype(numpy.int64, order='C', copy=True)
+  cdef numpy.ndarray[double, ndim=1, mode="c"] CCt_data =  CCt_coo.data.astype(numpy.float64, order='C', copy=False)
+  cdef numpy.ndarray[int, ndim=1, mode="c"] i_indices = CCt_coo.row.astype(numpy.intc, order='C', copy=False)
+  cdef numpy.ndarray[int, ndim=1, mode="c"] j_indices = CCt_coo.col.astype(numpy.intc, order='C', copy=False)
 
   # prepare data array of T in coo format
-  cdef numpy.ndarray[double, ndim=1, mode="c"] T_data = numpy.zeros(n_data, dtype=numpy.double, order='C')
+  cdef numpy.ndarray[double, ndim=1, mode="c"] T_unnormalized_data = numpy.zeros(n_data, dtype=numpy.float64, order='C')
 
   err = _mle_trev_given_pi_sparse(
-        <double*> numpy.PyArray_DATA(T_data),
+        <double*> numpy.PyArray_DATA(T_unnormalized_data),
         <double*> numpy.PyArray_DATA(CCt_data),
-        <long long*> numpy.PyArray_DATA(i_indices),
-        <long long*> numpy.PyArray_DATA(j_indices),
+        <int*> numpy.PyArray_DATA(i_indices),
+        <int*> numpy.PyArray_DATA(j_indices),
         n_data,
         <double*> numpy.PyArray_DATA(c_mu),
-        CCt_csr.shape[0],
+        CCt_coo.shape[0],
         maxerr,
         maxiter)
-
-  # TODO: add self test: check if stationary distribution is ok
 
   if err == -1:
     raise Exception('Out of memory.')
   elif err == -2:
-    raise Exception('The update of the Lagrange multipliers produced zero or NaN.')
+    raise Exception('The update of the Lagrange multipliers produced NaN.')
   elif err == -3:
     raise Exception('Some row and corresponding column of C have zero counts.')
   elif err == -4:
     raise Exception('Some element of pi is zero.')
   elif err == -5:
     warnings.warn('Reversible transition matrix estimation with fixed stationary distribution didn\'t converge.', pyemma.util.exceptions.NotConvergedWarning)
-  elif err == -6:
-    raise Exception('Count matrix has zero diagonal elements. Can\'t guarantee convergence of algorithm. '+
-                    'Suggestion: set regularization parameter eps to some small value e.g. 1E-6.')
 
-  # T matrix has the same shape and positions of nonzero elements as the regularized C matrix
-  return scipy.sparse.csr_matrix((T_data, (i_indices, j_indices)), shape=CCt_csr.shape)
+  # unnormalized T matrix has the same shape and positions of nonzero elements as the C matrix
+  T_unnormalized = scipy.sparse.csr_matrix((T_unnormalized_data, (i_indices.copy(), j_indices.copy())), shape=CCt_coo.shape)
+  # finish T by setting the diagonal elements according to the normalization constraint
+  rowsum = T_unnormalized.sum(axis=1).A1
+  T_diagonal = scipy.sparse.diags(numpy.maximum(1.0-rowsum,0.0), 0)
+  
+  return T_unnormalized + T_diagonal

--- a/pyemma/msm/estimation/tests/test_mle_trev.py
+++ b/pyemma/msm/estimation/tests/test_mle_trev.py
@@ -34,8 +34,8 @@ import pyemma.util.exceptions
 from os.path import abspath, join
 from os import pardir
 
-from pyemma.msm.estimation.sparse.mle_trev import mle_trev as mtrs
-from pyemma.msm.estimation.dense.transition_matrix import estimate_transition_matrix_reversible as etmr
+from pyemma.msm.estimation.sparse.mle_trev import mle_trev as impl_sparse
+from pyemma.msm.estimation.dense.transition_matrix import estimate_transition_matrix_reversible as impl_dense
 from pyemma.msm.estimation import tmatrix as apicall
 
 testpath = abspath(join(abspath(__file__), pardir)) + '/testfiles/'
@@ -45,43 +45,51 @@ class Test_mle_trev(unittest.TestCase):
     def test_mle_trev(self):
         C = np.loadtxt(testpath + 'C_1_lag.dat')
 
-        T_cython_sparse = mtrs(scipy.sparse.csr_matrix(C)).toarray()
+        T_impl_algo_sparse_type_sparse = impl_sparse(scipy.sparse.csr_matrix(C)).toarray()
+        T_impl_algo_dense_type_dense = impl_dense(C)
 
-        T_python = etmr(C)
-        T_api_dense = apicall(C, reversible=True)
-        T_api_sparse = apicall(scipy.sparse.csr_matrix(C), reversible=True).toarray()
+        T_api_algo_dense_type_dense = apicall(C, reversible=True, method='dense')
+        T_api_algo_sparse_type_dense = apicall(C, reversible=True, method='sparse')
+        T_api_algo_dense_type_sparse = apicall(scipy.sparse.csr_matrix(C), reversible=True, method='dense').toarray()
+        T_api_algo_sparse_type_sparse = apicall(scipy.sparse.csr_matrix(C), reversible=True, method='sparse').toarray()
+        T_api_algo_auto_type_dense = apicall(C, reversible=True, method='auto')
+        T_api_algo_auto_type_sparse = apicall(scipy.sparse.csr_matrix(C), reversible=True, method='auto').toarray()
 
-        assert_allclose(T_cython_sparse, T_python)
-        assert_allclose(T_api_sparse, T_python)
-        assert_allclose(T_api_dense, T_python)
+        assert_allclose(T_impl_algo_sparse_type_sparse, T_impl_algo_dense_type_dense)
+        assert_allclose(T_api_algo_dense_type_dense, T_impl_algo_dense_type_dense)
+        assert_allclose(T_api_algo_sparse_type_dense, T_impl_algo_dense_type_dense)
+        assert_allclose(T_api_algo_dense_type_sparse, T_impl_algo_dense_type_dense)
+        assert_allclose(T_api_algo_sparse_type_sparse, T_impl_algo_dense_type_dense)
+        assert_allclose(T_api_algo_auto_type_dense, T_impl_algo_dense_type_dense)
+        assert_allclose(T_api_algo_auto_type_sparse, T_impl_algo_dense_type_dense)
 
     def test_warnings(self):
         C = np.loadtxt(testpath + 'C_1_lag.dat')
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            mtrs(scipy.sparse.csr_matrix(C), maxiter=1)
+            impl_sparse(scipy.sparse.csr_matrix(C), maxiter=1)
             assert len(w) == 1
             assert issubclass(w[-1].category, pyemma.util.exceptions.NotConvergedWarning)
             
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            etmr(C, maxiter=1)
+            impl_dense(C, maxiter=1)
             assert len(w) == 1
             assert issubclass(w[-1].category, pyemma.util.exceptions.NotConvergedWarning)
             
     def test_noninteger_counts_sparse(self):
         C = np.loadtxt(testpath + 'C_1_lag.dat')
-        T_sparse_reference = mtrs(scipy.sparse.csr_matrix(C)).toarray()
-        T_sparse_scaled_1 = mtrs(scipy.sparse.csr_matrix(C*10.0)).toarray()
-        T_sparse_scaled_2 = mtrs(scipy.sparse.csr_matrix(C*0.1)).toarray()
+        T_sparse_reference = impl_sparse(scipy.sparse.csr_matrix(C)).toarray()
+        T_sparse_scaled_1 = impl_sparse(scipy.sparse.csr_matrix(C*10.0)).toarray()
+        T_sparse_scaled_2 = impl_sparse(scipy.sparse.csr_matrix(C*0.1)).toarray()
         assert_allclose(T_sparse_reference, T_sparse_scaled_1)
         assert_allclose(T_sparse_reference, T_sparse_scaled_2)
 
     def test_noninteger_counts_dense(self):
         C = np.loadtxt(testpath + 'C_1_lag.dat')
-        T_dense_reference = etmr(C)
-        T_dense_scaled_1 = etmr(C*10.0)
-        T_dense_scaled_2 = etmr(C*0.1)
+        T_dense_reference = impl_dense(C)
+        T_dense_scaled_1 = impl_dense(C*10.0)
+        T_dense_scaled_2 = impl_dense(C*0.1)
         assert_allclose(T_dense_reference, T_dense_scaled_1)
         assert_allclose(T_dense_reference, T_dense_scaled_2)
 

--- a/pyemma/msm/estimation/tests/test_mle_trev_given_pi.py
+++ b/pyemma/msm/estimation/tests/test_mle_trev_given_pi.py
@@ -38,7 +38,7 @@ from pyemma.msm.estimation.dense.mle_trev_given_pi import mle_trev_given_pi as m
 from pyemma.msm.estimation.sparse.mle_trev_given_pi import mle_trev_given_pi as mtrgps
 from pyemma.msm.estimation.dense.transition_matrix import transition_matrix_reversible_fixpi as tmrfp
 from pyemma.msm.estimation import tmatrix as apicall
-from pyemma.msm.analysis import statdist
+from pyemma.msm.analysis import statdist, is_transition_matrix
 
 testpath = abspath(join(abspath(__file__), pardir)) + '/testfiles/'
 
@@ -61,10 +61,14 @@ class Test_mle_trev_given_pi(unittest.TestCase):
         assert_allclose(T_cython_sparse, T_python)
         assert_allclose(T_api_sparse, T_python)
         assert_allclose(T_api_dense, T_python)
-        
+
+        assert is_transition_matrix(T_cython_dense)
+        assert is_transition_matrix(T_cython_sparse)
+        assert is_transition_matrix(T_python)
         assert_allclose(statdist(T_cython_dense), pi)
         assert_allclose(statdist(T_cython_sparse), pi)
-        
+        assert_allclose(statdist(T_python), pi)
+
     def test_warnings(self):
         C = np.loadtxt(testpath + 'C_1_lag.dat')
         pi = np.loadtxt(testpath + 'pi.dat')

--- a/pyemma/msm/estimation/tests/test_mle_trev_given_pi.py
+++ b/pyemma/msm/estimation/tests/test_mle_trev_given_pi.py
@@ -34,9 +34,9 @@ import pyemma.util.exceptions
 from os.path import abspath, join
 from os import pardir
 
-from pyemma.msm.estimation.dense.mle_trev_given_pi import mle_trev_given_pi as mtrgpd
-from pyemma.msm.estimation.sparse.mle_trev_given_pi import mle_trev_given_pi as mtrgps
-from pyemma.msm.estimation.dense.transition_matrix import transition_matrix_reversible_fixpi as tmrfp
+from pyemma.msm.estimation.dense.mle_trev_given_pi import mle_trev_given_pi as impl_dense
+from pyemma.msm.estimation.sparse.mle_trev_given_pi import mle_trev_given_pi as impl_sparse
+from pyemma.msm.estimation.dense.transition_matrix import transition_matrix_reversible_fixpi as impl_dense_Frank
 from pyemma.msm.estimation import tmatrix as apicall
 from pyemma.msm.analysis import statdist, is_transition_matrix
 
@@ -45,29 +45,50 @@ testpath = abspath(join(abspath(__file__), pardir)) + '/testfiles/'
 
 class Test_mle_trev_given_pi(unittest.TestCase):
     def setUp(self):
-        self.eps = 0
+        pass
 
     def test_mle_trev_given_pi(self):
         C = np.loadtxt(testpath + 'C_1_lag.dat')
         pi = np.loadtxt(testpath + 'pi.dat')
 
-        T_cython_dense = mtrgpd(C, pi, eps=self.eps)
-        T_cython_sparse = mtrgps(scipy.sparse.csr_matrix(C), pi, eps=self.eps).toarray()
-        T_python = tmrfp(C, pi)
-        T_api_dense = apicall(C, reversible=True, mu=pi, eps=self.eps)
-        T_api_sparse = apicall(scipy.sparse.csr_matrix(C), reversible=True, mu=pi, eps=self.eps).toarray()
+        T_impl_algo_dense_type_dense = impl_dense(C, pi)
+        T_impl_algo_sparse_type_sparse = impl_sparse(scipy.sparse.csr_matrix(C), pi).toarray()
+        T_Frank = impl_dense_Frank(C, pi)
+        T_api_algo_dense_type_dense = apicall(C, reversible=True, mu=pi, method='dense')
+        T_api_algo_sparse_type_dense = apicall(C, reversible=True, mu=pi, method='sparse')
+        T_api_algo_dense_type_sparse = apicall(scipy.sparse.csr_matrix(C), reversible=True, mu=pi, method='dense').toarray()
+        T_api_algo_sparse_type_sparse = apicall(scipy.sparse.csr_matrix(C), reversible=True, mu=pi, method='sparse').toarray()
+        T_api_algo_auto_type_dense = apicall(C, reversible=True, mu=pi, method='auto')
+        T_api_algo_auto_type_sparse = apicall(scipy.sparse.csr_matrix(C), reversible=True, mu=pi, method='auto').toarray()
 
-        assert_allclose(T_cython_dense, T_python)
-        assert_allclose(T_cython_sparse, T_python)
-        assert_allclose(T_api_sparse, T_python)
-        assert_allclose(T_api_dense, T_python)
+        assert_allclose(T_impl_algo_dense_type_dense, T_Frank)
+        assert_allclose(T_impl_algo_sparse_type_sparse, T_Frank)
+        assert_allclose(T_api_algo_dense_type_dense, T_Frank)
+        assert_allclose(T_api_algo_sparse_type_dense, T_Frank)
+        assert_allclose(T_api_algo_dense_type_sparse, T_Frank)
+        assert_allclose(T_api_algo_sparse_type_sparse, T_Frank)
+        assert_allclose(T_api_algo_auto_type_dense, T_Frank)
+        assert_allclose(T_api_algo_auto_type_sparse, T_Frank)
 
-        assert is_transition_matrix(T_cython_dense)
-        assert is_transition_matrix(T_cython_sparse)
-        assert is_transition_matrix(T_python)
-        assert_allclose(statdist(T_cython_dense), pi)
-        assert_allclose(statdist(T_cython_sparse), pi)
-        assert_allclose(statdist(T_python), pi)
+        assert is_transition_matrix(T_Frank)
+        assert is_transition_matrix(T_impl_algo_dense_type_dense)
+        assert is_transition_matrix(T_impl_algo_sparse_type_sparse)
+        assert is_transition_matrix(T_api_algo_dense_type_dense)
+        assert is_transition_matrix(T_api_algo_sparse_type_dense)
+        assert is_transition_matrix(T_api_algo_dense_type_sparse)
+        assert is_transition_matrix(T_api_algo_sparse_type_sparse)
+        assert is_transition_matrix(T_api_algo_auto_type_dense)
+        assert is_transition_matrix(T_api_algo_auto_type_sparse)
+
+        assert_allclose(statdist(T_Frank), pi)
+        assert_allclose(statdist(T_impl_algo_dense_type_dense), pi)
+        assert_allclose(statdist(T_impl_algo_sparse_type_sparse), pi)
+        assert_allclose(statdist(T_api_algo_dense_type_dense), pi)
+        assert_allclose(statdist(T_api_algo_sparse_type_dense), pi)
+        assert_allclose(statdist(T_api_algo_dense_type_sparse), pi)
+        assert_allclose(statdist(T_api_algo_sparse_type_sparse), pi)
+        assert_allclose(statdist(T_api_algo_auto_type_dense), pi)
+        assert_allclose(statdist(T_api_algo_auto_type_sparse), pi)
 
     def test_warnings(self):
         C = np.loadtxt(testpath + 'C_1_lag.dat')
@@ -75,13 +96,13 @@ class Test_mle_trev_given_pi(unittest.TestCase):
         
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            mtrgps(scipy.sparse.csr_matrix(C), pi, eps=self.eps, maxiter=1)
+            impl_sparse(scipy.sparse.csr_matrix(C), pi, maxiter=1)
             assert len(w) == 1
             assert issubclass(w[-1].category, pyemma.util.exceptions.NotConvergedWarning)
             
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            mtrgpd(C, pi, eps=self.eps, maxiter=1)
+            impl_dense(C, pi, maxiter=1)
             assert len(w) == 1
             assert issubclass(w[-1].category, pyemma.util.exceptions.NotConvergedWarning)        
 

--- a/pyemma/msm/estimation/tests/test_mle_trev_given_pi.py
+++ b/pyemma/msm/estimation/tests/test_mle_trev_given_pi.py
@@ -38,6 +38,7 @@ from pyemma.msm.estimation.dense.mle_trev_given_pi import mle_trev_given_pi as m
 from pyemma.msm.estimation.sparse.mle_trev_given_pi import mle_trev_given_pi as mtrgps
 from pyemma.msm.estimation.dense.transition_matrix import transition_matrix_reversible_fixpi as tmrfp
 from pyemma.msm.estimation import tmatrix as apicall
+from pyemma.msm.analysis import statdist
 
 testpath = abspath(join(abspath(__file__), pardir)) + '/testfiles/'
 
@@ -56,13 +57,13 @@ class Test_mle_trev_given_pi(unittest.TestCase):
         T_api_dense = apicall(C, reversible=True, mu=pi, eps=self.eps)
         T_api_sparse = apicall(scipy.sparse.csr_matrix(C), reversible=True, mu=pi, eps=self.eps).toarray()
 
-        # print T_python
-        # print T_api_sparse
-
         assert_allclose(T_cython_dense, T_python)
         assert_allclose(T_cython_sparse, T_python)
         assert_allclose(T_api_sparse, T_python)
         assert_allclose(T_api_dense, T_python)
+        
+        assert_allclose(statdist(T_cython_dense), pi)
+        assert_allclose(statdist(T_cython_sparse), pi)
         
     def test_warnings(self):
         C = np.loadtxt(testpath + 'C_1_lag.dat')

--- a/pyemma/msm/estimation/tests/test_mle_trev_given_pi.py
+++ b/pyemma/msm/estimation/tests/test_mle_trev_given_pi.py
@@ -45,7 +45,7 @@ testpath = abspath(join(abspath(__file__), pardir)) + '/testfiles/'
 
 class Test_mle_trev_given_pi(unittest.TestCase):
     def setUp(self):
-        self.eps = 1.0E-6
+        self.eps = 0
 
     def test_mle_trev_given_pi(self):
         C = np.loadtxt(testpath + 'C_1_lag.dat')


### PR DESCRIPTION
This implements a feature I discussed with Frank last week: automatic choice of sparse or dense algorithm for ML T matrix estimation. Whichever algorithm is more efficient, is selected.
The criterion is a simple heuristic that compares the potential memory usage of the sparse and the dense representations of the C (or T) matrix. If 3*n_dof < dim the sparse algorithm is used. (n_dof is the number non-zero elements in the C matrix and dim is its dimension). 3*n_dof > dim, dense is used.
The idea behind the heuristic is that in many cases, the speed of computation is limited by the access to the data. Therefore the more compact data representation should yield a faster algorithm.
The new behavior can be controlled by the auto_sparse parameter of pyemma.msm.estimation.tmatrix and is on by default.
