### PR TITLE
[TICA] variable self._skipped_trajs stores skipped trajs and 'skipped traje…

### DIFF
--- a/pyemma/coordinates/tests/test_tica.py
+++ b/pyemma/coordinates/tests/test_tica.py
@@ -306,5 +306,16 @@ class TestTICAExtensive(unittest.TestCase):
 
         assert np.isclose(test_corr, true_corr).all()
 
+    def test_skipped_trajs(self):
+
+        feature_trajs = [np.arange(10),
+                         np.arange(11),
+                         np.arange(12),
+                         np.arange(13)]
+
+        tica_obj = tica(data=feature_trajs, lag=11)
+        assert (len(tica_obj._skipped_trajs)==2)
+        assert np.allclose(tica_obj._skipped_trajs, [0,1])
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/transform/tica.py
+++ b/pyemma/coordinates/transform/tica.py
@@ -134,7 +134,8 @@ class TICA(Transformer):
         self._progress_mean = None
         self._progress_cov = None
 
-
+        # skipped trajectories
+        self._skipped_trajs = []
     @property
     def lag(self):
         """ lag time of correlation matrix :math:`C_{\tau}` """
@@ -285,7 +286,7 @@ class TICA(Transformer):
                 show_progressbar(self._progress_cov)
 
             else:
-                self._logger.warning("trajectory nr %i too short, skipping it" % itraj)
+                self._skipped_trajs.append(itraj)
 
             if last_chunk:
                 return True  # finished!
@@ -316,6 +317,12 @@ class TICA(Transformer):
         # compute cumulative variance
         self.cumvar = np.cumsum(self.eigenvalues ** 2)
         self.cumvar /= self.cumvar[-1]
+
+
+        if len(self._skipped_trajs) >= 1:
+            self._skipped_trajs = np.asarray(self._skipped_trajs)
+            self._logger.warn("Had to skip %u trajectories for being too short. "
+                              "Their indexes are in self._skipped_trajs."%len(self._skipped_trajs))
 
     def _map_array(self, X):
         r"""Projects the data onto the dominant independent components.


### PR DESCRIPTION
…ctory' warnings stop after 100 warnings

Otherwise the notebook might get too cluttered (or even crash) when thousands of warnings are issued.
