### PR TITLE
[coor/transformer|regspace] introduced exception type for early parametrization termination 

### DIFF
--- a/pyemma/coordinates/clustering/regspace.py
+++ b/pyemma/coordinates/clustering/regspace.py
@@ -21,6 +21,7 @@
 # ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from pyemma.util.exceptions import NotConvergedWarning
 
 '''
 Created on 26.01.2015
@@ -128,8 +129,6 @@ class RegularSpaceClustering(AbstractClustering):
                                self.metric, self._max_centers)
             # finished regularly
             if last_chunk:
-                self.clustercenters = np.array(self._clustercenters)
-                self.n_clusters = self.clustercenters.shape[0]
                 return True  # finished!
         except RuntimeError:
             msg = 'Maximum number of cluster centers reached.' \
@@ -140,12 +139,15 @@ class RegularSpaceClustering(AbstractClustering):
             # finished anyway, because we have no more space for clusters. Rest of trajectory has no effect
             self.clustercenters = np.array(self._clustercenters)
             self.n_clusters = self.clustercenters.shape[0]
-
-            return True
+            # TODO: pass amount of processed data
+            raise NotConvergedWarning
 
         return False
 
     def _param_finish(self):
+        self.clustercenters = np.array(self._clustercenters)
+        self.n_clusters = self.clustercenters.shape[0]
+
         if len(self._clustercenters) == 1:
             self._logger.warning('Have found only one center according to '
                                  'minimum distance requirement of %f' % self.dmin)

--- a/pyemma/coordinates/data/feature_reader.py
+++ b/pyemma/coordinates/data/feature_reader.py
@@ -143,6 +143,15 @@ class FeatureReader(ReaderInterface):
         return patches.iterload(filename, chunk=self.chunksize,
                                 top=self.topfile, skip=skip, stride=stride)
 
+    def _close(self):
+        try:
+            if self._mditer:
+                self._mditer.close()
+            if self._mditer2:
+                self._mditer2.close()
+        except:
+            self._logger.exception("something went wrong closing file handles")
+
     def _reset(self, stride=1):
         """
         resets the chunk reader
@@ -185,9 +194,8 @@ class FeatureReader(ReaderInterface):
             if __debug__:
                 self._logger.debug('closing current trajectory "%s"'
                                    % self.trajfiles[self._itraj])
-            self._mditer.close()
-            if self._curr_lag != 0:
-                self._mditer2.close()
+            self._close()
+
             self._t = 0
             self._itraj += 1
             self._mditer = self._create_iter(self.trajfiles[self._itraj], stride=stride)

--- a/pyemma/coordinates/data/numpy_filereader.py
+++ b/pyemma/coordinates/data/numpy_filereader.py
@@ -73,7 +73,7 @@ class NumPyFileReader(ReaderInterface):
     def _reset(self, stride=1):
         self._t = 0
         self._itraj = 0
-        self._close_file()
+        self._close()
 
     def describe(self):
         return "[NumpyFileReader arrays with shape %s]" % [np.shape(x)
@@ -98,7 +98,7 @@ class NumPyFileReader(ReaderInterface):
         return array
 
     def __load_file(self, filename):
-        self._close_file()
+        self._close()
         self._logger.debug("opening file %s" % filename)
 
         if filename.endswith('.npy'):
@@ -110,7 +110,7 @@ class NumPyFileReader(ReaderInterface):
         self._array = arr
         return arr
 
-    def _close_file(self):
+    def _close(self):
         if self._array is None:
             return
 
@@ -129,7 +129,7 @@ class NumPyFileReader(ReaderInterface):
             array = self.__load_file(f)
             self._lengths.append(np.shape(array)[0])
             ndims.append(np.shape(array)[1])
-            self._close_file()
+            self._close()
             pg.numerator += 1
             show_progressbar(pg)
 

--- a/pyemma/coordinates/data/py_csv_reader.py
+++ b/pyemma/coordinates/data/py_csv_reader.py
@@ -64,12 +64,18 @@ class _csv_chunked_numpy_iterator:
     def __iter__(self):
         return self
 
+    def close(self):
+        self.fh.close()
+
     def _convert_to_np_chunk(self, list_of_strings):
         stack_of_strings = np.vstack(list_of_strings)
         result = stack_of_strings.astype(float)
         return result
 
     def next(self):
+        if not self.fh:
+            raise StopIteration
+
         lines = []
 
         for row in self.reader:
@@ -237,6 +243,11 @@ class PyCSVReader(ReaderInterface):
             self._iter = reader
         else:
             self._iter_lagged = reader
+
+    def _close(self):
+        # invalidate iterator
+        if self._iter:
+            self._iter.close()
 
     def _next_chunk(self, lag=0, stride=1):
         if self._iter is None:

--- a/pyemma/coordinates/tests/test_regspace.py
+++ b/pyemma/coordinates/tests/test_regspace.py
@@ -123,7 +123,8 @@ class TestRegSpaceClustering(unittest.TestCase):
 
     def test_too_small_dmin_should_warn(self):
         self.clustering.dmin = 1e-8
-        self.clustering.max_centers = 50
+        max_centers = 50
+        self.clustering.max_centers = max_centers
         import warnings
         with warnings.catch_warnings(record=True) as w:
             # Cause all warnings to always be triggered.
@@ -131,6 +132,14 @@ class TestRegSpaceClustering(unittest.TestCase):
             # Trigger a warning.
             self.clustering.parametrize()
             assert w
+            assert len(w) == 1
+
+            assert len(self.clustering.clustercenters) == max_centers
+
+            # assign data
+            out = self.clustering.get_output()
+            assert len(out) == self.clustering.number_of_trajectories()
+            assert len(out[0]) == self.clustering.trajectory_lengths()[0]
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The only usecase for this is currently regspace clustering, which terminates when max_centers has been reached before seeing all data.

At first stance I tried to add the add_data_finished variable to the outer loops, which caused strange side effects in kmeans (cluster centers were not being converted). This is due to some algorithms expect to be called with last_chunk=True once. So raising an exception to terminate all loops seems to be the simplest and robust solution.

Superseeds #381 
