### PR TITLE
Lag before stride

### DIFF
--- a/pyemma/coordinates/data/data_in_memory.py
+++ b/pyemma/coordinates/data/data_in_memory.py
@@ -123,29 +123,28 @@ class DataInMemory(ReaderInterface):
             if lag == 0:
                 return X
             else:
-                Y = traj[lag * stride:traj_len:stride]
-                return (X, Y)
+                Y = traj[lag::stride]
+                return X, Y
         # chunked mode
         else:
-            upper_bound = min(
-                self._t + self._chunksize * stride, traj_len)
+            upper_bound = min(self._t + self._chunksize * stride, traj_len)
             slice_x = slice(self._t, upper_bound, stride)
 
             X = traj[slice_x]
 
-            if lag!=0:
-                 upper_bound_Y = min(
-                     self._t + (lag + self._chunksize) * stride, traj_len)
-                 slice_y = slice(self._t + lag*stride, upper_bound_Y, stride)
-                 Y = traj[slice_y]
+            if lag != 0:
+                upper_bound_Y = min(
+                     self._t + lag + self._chunksize * stride, traj_len)
+                slice_y = slice(self._t + lag, upper_bound_Y, stride)
+                Y = traj[slice_y]
 
             self._t = upper_bound
 
             if upper_bound >= traj_len:
-                 self._itraj += 1
-                 self._t = 0
-                 
-            if lag==0:
+                self._itraj += 1
+                self._t = 0
+
+            if lag == 0:
                 return X
-            else: 
-                return (X, Y)
+            else:
+                return X, Y

--- a/pyemma/coordinates/data/feature_reader.py
+++ b/pyemma/coordinates/data/feature_reader.py
@@ -171,7 +171,7 @@ class FeatureReader(ReaderInterface):
                                        % (self._itraj, lag))
                 self._curr_lag = lag
                 self._mditer2 = self._create_iter(self.trajfiles[self._itraj],
-                                                  skip=self._curr_lag*stride, stride=stride) 
+                                                  skip=self._curr_lag, stride=stride)
             try:
                 adv_chunk = self._mditer2.next()
             except StopIteration:

--- a/pyemma/coordinates/data/numpy_filereader.py
+++ b/pyemma/coordinates/data/numpy_filereader.py
@@ -159,17 +159,21 @@ class NumPyFileReader(ReaderInterface):
             if lag == 0:
                 return X
             else:
-                Y = traj[lag * stride:traj_len:stride]
-                return (X, Y)
+                Y = traj[lag::stride]
+                return X, Y
         # chunked mode
         else:
-            upper_bound = min(
-                self._t + (self._chunksize + 1) * stride, traj_len)
+            upper_bound = min(self._t + self._chunksize * stride, traj_len)
             slice_x = slice(self._t, upper_bound, stride)
-
             X = traj[slice_x]
 
-            last_t = self._t
+            if lag != 0:
+                upper_bound_Y = min(
+                     self._t + lag + self._chunksize * stride, traj_len)
+                slice_y = slice(self._t + lag, upper_bound_Y, stride)
+                Y = traj[slice_y]
+
+            # set new time position
             self._t = upper_bound
 
             if self._t >= traj_len:
@@ -180,16 +184,8 @@ class NumPyFileReader(ReaderInterface):
                 # if time index scope ran out of len of current trajectory, open next file.
                 if self._itraj <= self.number_of_trajectories() - 1:
                     self.__load_file(self._filenames[self._itraj])
-                # we open self._mditer2 only if requested due lag parameter!
-                self._curr_lag = 0
 
             if lag == 0:
                 return X
             else:
-                # its okay to return empty chunks
-                upper_bound = min(
-                    last_t + (lag + self._chunksize + 1) * stride, traj_len)
-                slice_y = slice(last_t + lag, upper_bound, stride)
-
-                Y = traj[slice_y]
                 return X, Y

--- a/pyemma/coordinates/tests/test_datainmemory.py
+++ b/pyemma/coordinates/tests/test_datainmemory.py
@@ -239,5 +239,18 @@ class TestDataInMemory(unittest.TestCase):
         for traj, input_traj in zip(lagged_trajs, lagged_0):
             np.testing.assert_equal(traj.reshape(input_traj.shape), input_traj)
 
+    def test_lagged_stridden_access(self):
+        data = np.random.random((1000, 2))
+        reader = DataInMemory(data)
+        strides = [2, 3, 5, 7, 15]
+        lags = [1, 3, 7, 10, 30]
+        for stride in strides:
+            for lag in lags:
+                chunks = []
+                for _, _, Y in reader.iterator(stride, lag):
+                    chunks.append(Y)
+                chunks = np.vstack(chunks)
+                np.testing.assert_equal(chunks, data[lag::stride])
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/tests/test_featurereader.py
+++ b/pyemma/coordinates/tests/test_featurereader.py
@@ -42,6 +42,20 @@ from pyemma.coordinates.api import feature_reader, discretizer, tica
 log = getLogger('TestFeatureReader')
 
 
+def create_traj(top):
+    trajfile = tempfile.mktemp('.dcd')
+    n_frames = np.random.randint(500, 1500)
+    log.debug("create traj with %i frames" % n_frames)
+    xyz = np.arange(n_frames * 3 * 3).reshape((n_frames, 3, 3))
+
+    t = mdtraj.load(top)
+    t.xyz = xyz
+    t.time = np.arange(n_frames)
+    t.save(trajfile)
+
+    return trajfile, xyz, n_frames
+
+
 class TestFeatureReader(unittest.TestCase):
 
     @classmethod
@@ -49,17 +63,11 @@ class TestFeatureReader(unittest.TestCase):
         c = super(TestFeatureReader, cls).setUpClass()
         # create a fake trajectory which has 3 atoms and coordinates are just a range
         # over all frames.
-        cls.trajfile = tempfile.mktemp('.xtc')
-        cls.n_frames = 1000
-        cls.xyz = np.random.random(
-            cls.n_frames * 3 * 3).reshape((cls.n_frames, 3, 3))
-        log.debug("shape traj: %s" % str(cls.xyz.shape))
         cls.topfile = pkg_resources.resource_filename(
             'pyemma.coordinates.tests.test_featurereader', 'data/test.pdb')
-        t = mdtraj.load(cls.topfile)
-        t.xyz = cls.xyz
-        t.time = np.arange(cls.n_frames)
-        t.save(cls.trajfile)
+        cls.trajfile, cls.xyz, cls.n_frames = create_traj(cls.topfile)
+        cls.trajfile2, cls.xyz2, cls.n_frames2 = create_traj(cls.topfile)
+
         return c
 
     @classmethod
@@ -75,30 +83,32 @@ class TestFeatureReader(unittest.TestCase):
         frames = 0
         data = []
         for i, X in reader:
+            assert isinstance(X, np.ndarray)
             frames += X.shape[0]
             data.append(X)
-
-        # restore shape of input
-        data = np.array(data).reshape(self.xyz.shape)
 
         self.assertEqual(frames, reader.trajectory_lengths()[0])
-        self.assertTrue(np.allclose(data, self.xyz))
+        data = np.vstack(data)
+        # restore shape of input
+        data.reshape(self.xyz.shape)
+
+        self.assertTrue(np.allclose(data, self.xyz.reshape(-1, 9)))
 
     def testIteratorAccess2(self):
-        reader = FeatureReader([self.trajfile, self.trajfile], self.topfile)
+        reader = FeatureReader([self.trajfile, self.trajfile2], self.topfile)
         reader.chunksize = 100
 
-        frames = 0
-        data = []
-        for i, X in reader:
-            frames += X.shape[0]
-            data.append(X)
-        self.assertEqual(frames, reader.trajectory_lengths()[0] * 2)
-        # restore shape of input
-        data = np.array(
-            data[0:reader.trajectory_lengths()[0] / reader.chunksize]).reshape(self.xyz.shape)
+        data = {itraj: [] for itraj in xrange(reader.number_of_trajectories())}
 
-        self.assertTrue(np.allclose(data, self.xyz))
+        for i, X in reader:
+            data[i].append(X)
+
+        # restore shape of input
+        data[0] = np.vstack(data[0]).reshape(-1, 9)
+        data[1] = np.vstack(data[1]).reshape(-1, 9)
+
+        np.testing.assert_equal(data[0], self.xyz.reshape(-1, 9))
+        np.testing.assert_equal(data[1], self.xyz2.reshape(-1, 9))
 
     def testTimeLaggedIterator(self):
         lag = 10
@@ -117,20 +127,18 @@ class TestFeatureReader(unittest.TestCase):
 
         # reproduce outcome
         xyz_s = self.xyz.shape
-        fake_lagged = np.empty((xyz_s[0] - lag, xyz_s[1] * xyz_s[2]))
         fake_lagged = self.xyz.reshape((xyz_s[0], -1))[lag:]
 
         self.assertTrue(np.allclose(merged_lagged, fake_lagged))
 
         # restore shape of input
-        data = np.array(data).reshape(self.xyz.shape)
+        data = np.vstack(data).reshape(self.xyz.shape)
 
         self.assertEqual(frames, reader.trajectory_lengths()[0])
         self.assertTrue(np.allclose(data, self.xyz))
 
     def test_with_pipeline_time_lagged(self):
         reader = feature_reader(self.trajfile, self.topfile)
-        #reader.featurizer.distances([[0, 1], [0, 2]])
         t = tica(dim=2, lag=1)
         d = discretizer(reader, t)
         d.parametrize()
@@ -140,9 +148,6 @@ class TestFeatureReader(unittest.TestCase):
         out1 = reader.get_output()
         # now map stuff to memory
         reader.in_memory = True
-
-        print len(reader._Y)
-        print reader._Y[0].shape
 
         reader2 = api.source(self.trajfile, top=self.topfile)
         out = reader2.get_output()
@@ -170,30 +175,36 @@ class TestFeatureReader(unittest.TestCase):
 
     def test_in_memory_switch_stride_dim(self):
         reader = api.source(self.trajfile, top=self.topfile)
-        reader.chunksize = 360
+        reader.chunksize = 100
         reader.in_memory = True
 
         # now get output with different strides
         strides = [1, 2, 3, 4, 5, 10, 20]
         for s in strides:
-            if reader.chunksize % s != 0:
-                continue
             out = reader.get_output(stride=s)
             shape = (reader.trajectory_length(0, stride=s), reader.dimension())
-            self.assertEqual(out[0].shape, shape, "not equal for stride=%i" % s)
+            self.assertEqual(
+                out[0].shape, shape, "not equal for stride=%i" % s)
 
     def test_lagged_stridden_access(self):
-        reader = api.source(self.trajfile, top=self.topfile)
+        reader = api.source([self.trajfile, self.trajfile2], top=self.topfile)
         reader.chunksize = 210
         strides = [2, 3, 5, 7, 15]
         lags = [1, 3, 7, 10, 30]
+        err_msg = "not equal for stride=%i, lag=%i"
         for stride in strides:
             for lag in lags:
-                chunks = []
-                for _, _, Y in reader.iterator(stride, lag):
-                    chunks.append(Y)
-                chunks = np.vstack(chunks)
-                np.testing.assert_almost_equal(chunks, self.xyz.reshape(-1, 9)[lag::stride])
+                chunks = {itraj: []
+                          for itraj in xrange(reader.number_of_trajectories())}
+                for itraj, _, Y in reader.iterator(stride, lag):
+                    chunks[itraj].append(Y)
+                chunks[0] = np.vstack(chunks[0])
+                np.testing.assert_almost_equal(
+                    chunks[0], self.xyz.reshape(-1, 9)[lag::stride], err_msg=err_msg % (stride, lag))
+
+                chunks[1] = np.vstack(chunks[1])
+                np.testing.assert_almost_equal(
+                    chunks[1], self.xyz2.reshape(-1, 9)[lag::stride], err_msg=err_msg % (stride, lag))
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/tests/test_stride.py
+++ b/pyemma/coordinates/tests/test_stride.py
@@ -107,7 +107,7 @@ class TestStride(unittest.TestCase):
         for stride in xrange(1, 100, 23):
             r = coor.source(self.trajnames, top=self.temppdb)
             tau = 5
-            t = coor.tica(r, lag=tau, dim=2, force_eigenvalues_le_one=True)
+            t = coor.tica(r, lag=tau, dim=2, force_eigenvalues_le_one=False)
             # force_eigenvalues_le_one=True enables an internal consitency check in TICA
             t.parametrize(stride=stride)
             self.assertTrue(np.all(t.eigenvalues <= 1.0+1.E-12))

--- a/pyemma/coordinates/tests/test_stride.py
+++ b/pyemma/coordinates/tests/test_stride.py
@@ -107,10 +107,13 @@ class TestStride(unittest.TestCase):
         for stride in xrange(1, 100, 23):
             r = coor.source(self.trajnames, top=self.temppdb)
             tau = 5
-            t = coor.tica(r, lag=tau, dim=2, force_eigenvalues_le_one=False)
-            # force_eigenvalues_le_one=True enables an internal consitency check in TICA
-            t.parametrize(stride=stride)
-            self.assertTrue(np.all(t.eigenvalues <= 1.0+1.E-12))
+            try:
+                t = coor.tica(r, lag=tau, stride=stride, dim=2, force_eigenvalues_le_one=True)
+                # force_eigenvalues_le_one=True enables an internal consistency check in TICA
+                t.parametrize(stride=stride)
+                self.assertTrue(np.all(t.eigenvalues <= 1.0+1.E-12))
+            except RuntimeError:
+                assert tau % stride != 0
 
     @classmethod
     def tearDownClass(cls):

--- a/pyemma/coordinates/transform/tica.py
+++ b/pyemma/coordinates/transform/tica.py
@@ -38,6 +38,10 @@ import numpy as np
 __all__ = ['TICA']
 
 
+class MeaningOfLagWithStrideWarning(UserWarning):
+    pass
+
+
 class TICA(Transformer):
     r""" Time-lagged independent component analysis (TICA) [1]_, [2]_, [3]_.
 
@@ -179,6 +183,15 @@ class TICA(Transformer):
         assert indim > 0, "zero dimension from data producer"
         assert self._dim <= indim, ("requested more output dimensions (%i) than dimension"
                                     " of input data (%i)" % (self._dim, indim))
+        if self._force_eigenvalues_le_one and self._lag % self._param_with_stride != 0:
+            raise RuntimeError("When using TICA with force_eigenvalues_le_one, lag must be a multiple of stride.")
+
+        if self._param_with_stride > 1:
+            import warnings
+            warnings.simplefilter('once', MeaningOfLagWithStrideWarning, append=True)
+            warnings.warn("Since version 1.3 lag is measured in time steps of your"
+                          " trajectory, no matter what value of stride is used.",
+                          MeaningOfLagWithStrideWarning)
 
         self._N_mean = 0
         self._N_cov = 0
@@ -241,7 +254,7 @@ class TICA(Transformer):
 
         elif ipass == 1:
 
-            if self.trajectory_length(itraj, stride=stride) - self._lag > 0:
+            if self.trajectory_length(itraj, stride=1) - self._lag > 0:
                 self._N_cov_tau += 2.0 * np.shape(Y)[0]
                 X_meanfree = X - self.mu
                 Y_meanfree = Y - self.mu
@@ -253,8 +266,8 @@ class TICA(Transformer):
                 # update the instantaneous covariance matrix
                 if self._force_eigenvalues_le_one:
                     # MSM-like counting
-                    Zptau = self._lag-t  # zero plus tau
-                    Nmtau = self.trajectory_length(itraj, stride=stride)-t-self._lag  # N minus tau
+                    Zptau = self._lag/stride-t  # zero plus tau
+                    Nmtau = self.trajectory_length(itraj, stride=stride)-t-self._lag/stride  # N minus tau
 
                     # restrict to valid block indices
                     size = X_meanfree.shape[0]

--- a/pyemma/coordinates/transform/tica.py
+++ b/pyemma/coordinates/transform/tica.py
@@ -241,7 +241,7 @@ class TICA(Transformer):
 
         elif ipass == 1:
 
-            if self.trajectory_length(itraj, stride=stride) > self._lag:
+            if self.trajectory_length(itraj, stride=stride) - self._lag > 0:
                 self._N_cov_tau += 2.0 * np.shape(Y)[0]
                 X_meanfree = X - self.mu
                 Y_meanfree = Y - self.mu

--- a/pyemma/coordinates/util/patches.py
+++ b/pyemma/coordinates/util/patches.py
@@ -87,8 +87,9 @@ def iterload(filename, chunk=100, **kwargs):
         topology = _parse_topology(top)
 
     if chunk % stride != 0:
-        raise ValueError('Stride must be a divisor of chunk. stride=%d does not go '
-                         'evenly into chunk=%d' % (stride, chunk))
+        pass
+        #raise ValueError('Stride must be a divisor of chunk. stride=%d does not go '
+        #                 'evenly into chunk=%d' % (stride, chunk))
     if chunk == 0:
         # If chunk was 0 then we want to avoid filetype-specific code
         # in case of undefined behavior in various file parsers.

--- a/pyemma/coordinates/util/patches.py
+++ b/pyemma/coordinates/util/patches.py
@@ -28,20 +28,8 @@ Created on 13.03.2015
 
 @author: marscher
 '''
-import numpy as np
-import warnings
-
 from mdtraj.utils.validation import cast_indices
-from mdtraj.core.trajectory import load, Trajectory, _parse_topology
-from mdtraj.formats.hdf5 import HDF5TrajectoryFile
-from mdtraj.utils.unit import in_units_of
-from mdtraj.formats.lh5 import LH5TrajectoryFile
-from mdtraj.formats import DCDTrajectoryFile
-from mdtraj.formats import XTCTrajectoryFile
-
-from pyemma.util.log import getLogger
-
-log = getLogger('patches')
+from mdtraj.core.trajectory import load, _parse_topology, _TOPOLOGY_EXTS, _get_extension
 
 
 def iterload(filename, chunk=100, **kwargs):
@@ -89,103 +77,45 @@ def iterload(filename, chunk=100, **kwargs):
     <mdtraj.Trajectory with 100 frames, 423 atoms at 0x110740a90>
 
     """
-    stride = kwargs.get('stride', 1)
-    atom_indices = cast_indices(kwargs.get('atom_indices', None))
-    if chunk % stride != 0 and filename.endswith('.dcd'):
+    stride = kwargs.pop('stride', 1)
+    atom_indices = cast_indices(kwargs.pop('atom_indices', None))
+    top = kwargs.pop('top', None)
+    skip = kwargs.pop('skip', 0)
+
+    extension = _get_extension(filename)
+    if extension not in _TOPOLOGY_EXTS:
+        topology = _parse_topology(top)
+
+    if chunk % stride != 0:
         raise ValueError('Stride must be a divisor of chunk. stride=%d does not go '
                          'evenly into chunk=%d' % (stride, chunk))
     if chunk == 0:
-        yield load(filename, **kwargs)
-    # If chunk was 0 then we want to avoid filetype-specific code in case of undefined behavior in various file parsers.
+        # If chunk was 0 then we want to avoid filetype-specific code
+        # in case of undefined behavior in various file parsers.
+        # TODO: this will first apply stride, then skip!
+        if extension not in _TOPOLOGY_EXTS:
+            kwargs['top'] = top
+        yield load(filename, **kwargs)[skip:]
+    elif extension in ('.pdb', '.pdb.gz'):
+        # the PDBTrajectortFile class doesn't follow the standard API. Fixing it
+        # to support iterload could be worthwhile, but requires a deep refactor.
+        t = load(filename, stride=stride, atom_indices=atom_indices)
+        for i in range(0, len(t), chunk):
+            yield t[i:i+chunk]
+
     else:
-        skip = kwargs.pop('skip', 0)
-        if filename.endswith('.h5'):
-            if 'top' in kwargs:
-                warnings.warn('top= kwarg ignored since file contains topology information')
-
-            with HDF5TrajectoryFile(filename) as f:
-                if skip > 0:
-                    xyz, _, _, _ = f.read(skip, atom_indices=atom_indices)
-                    if len(xyz) == 0:
-                        raise StopIteration()
-                if atom_indices is None:
-                    topology = f.topology
+        with (lambda x: open(x, n_atoms=topology.n_atoms)
+              if extension in ('.crd', '.mdcrd')
+              else open(filename))(filename) as f:
+            if skip > 0:
+                f.seek(skip)
+            while True:
+                if extension not in _TOPOLOGY_EXTS:
+                    traj = f.read_as_traj(topology, n_frames=chunk*stride, stride=stride, atom_indices=atom_indices, **kwargs)
                 else:
-                    topology = f.topology.subset(atom_indices)
+                    traj = f.read_as_traj(n_frames=chunk*stride, stride=stride, atom_indices=atom_indices, **kwargs)
 
-                while True:
-                    data = f.read(chunk*stride, stride=stride, atom_indices=atom_indices)
-                    if data == []:
-                        raise StopIteration()
-                    in_units_of(data.coordinates, f.distance_unit, Trajectory._distance_unit, inplace=True)
-                    in_units_of(data.cell_lengths, f.distance_unit, Trajectory._distance_unit, inplace=True)
-                    yield Trajectory(xyz=data.coordinates, topology=topology,
-                                     time=data.time, unitcell_lengths=data.cell_lengths,
-                                     unitcell_angles=data.cell_angles)
+                if len(traj) == 0:
+                    raise StopIteration()
 
-        if filename.endswith('.lh5'):
-            if 'top' in kwargs:
-                warnings.warn('top= kwarg ignored since file contains topology information')
-            with LH5TrajectoryFile(filename) as f:
-                if atom_indices is None:
-                    topology = f.topology
-                else:
-                    topology = f.topology.subset(atom_indices)
-
-                ptr = 0
-                if skip > 0:
-                    xyz, _, _, _ = f.read(skip, atom_indices=atom_indices)
-                    if len(xyz) == 0:
-                        raise StopIteration()
-                while True:
-                    xyz = f.read(chunk*stride, stride=stride, atom_indices=atom_indices)
-                    if len(xyz) == 0:
-                        raise StopIteration()
-                    in_units_of(xyz, f.distance_unit, Trajectory._distance_unit, inplace=True)
-                    time = np.arange(ptr, ptr+len(xyz)*stride, stride)
-                    ptr += len(xyz)*stride
-                    yield Trajectory(xyz=xyz, topology=topology, time=time)
-
-        elif filename.endswith('.xtc'):
-            topology = _parse_topology(kwargs.get('top', None))
-            with XTCTrajectoryFile(filename) as f:
-                if skip > 0:
-                    xyz, _, _, _ = f.read(skip)
-                    if len(xyz) == 0:
-                        raise StopIteration()
-                while True:
-                    xyz, time, step, box = f.read(chunk*stride, stride=stride, atom_indices=atom_indices)
-                    if len(xyz) == 0:
-                        raise StopIteration()
-                    in_units_of(xyz, f.distance_unit, Trajectory._distance_unit, inplace=True)
-                    in_units_of(box, f.distance_unit, Trajectory._distance_unit, inplace=True)
-                    trajectory = Trajectory(xyz=xyz, topology=topology, time=time)
-                    trajectory.unitcell_vectors = box
-                    yield trajectory
-
-        elif filename.endswith('.dcd'):
-            topology = _parse_topology(kwargs.get('top', None))
-            with DCDTrajectoryFile(filename) as f:
-                ptr = 0
-                if skip > 0:
-                    xyz, _, _ = f.read(skip, atom_indices=atom_indices)
-                    if len(xyz) == 0:
-                        raise StopIteration()
-                while True:
-                    # for reasons that I have not investigated, dcdtrajectory file chunk and stride
-                    # together work like this method, but HDF5/XTC do not.
-                    xyz, box_length, box_angle = f.read(chunk, stride=stride, atom_indices=atom_indices)
-                    if len(xyz) == 0:
-                        raise StopIteration()
-                    in_units_of(xyz, f.distance_unit, Trajectory._distance_unit, inplace=True)
-                    in_units_of(box_length, f.distance_unit, Trajectory._distance_unit, inplace=True)
-                    time = np.arange(ptr, ptr+len(xyz)*stride, stride)
-                    ptr += len(xyz)*stride
-                    yield Trajectory(xyz=xyz, topology=topology, time=time, unitcell_lengths=box_length,
-                                     unitcell_angles=box_angle)
-
-        else:
-            log.critical("loading complete traj into mem! This might no be desired.")
-            t = load(filename, **kwargs)
-            for i in range(skip, len(t), chunk):
-                yield t[i:i+chunk]
+                yield traj

--- a/pyemma/coordinates/util/patches.py
+++ b/pyemma/coordinates/util/patches.py
@@ -29,7 +29,7 @@ Created on 13.03.2015
 @author: marscher
 '''
 from mdtraj.utils.validation import cast_indices
-from mdtraj.core.trajectory import load, _parse_topology, _TOPOLOGY_EXTS, _get_extension
+from mdtraj.core.trajectory import load, _parse_topology, _TOPOLOGY_EXTS, _get_extension, open
 
 
 def iterload(filename, chunk=100, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -256,7 +256,7 @@ metadata = dict(
     # runtime dependencies
     install_requires=['numpy>=1.6.0',
                       'scipy>=0.11',
-                      'mdtraj',
+                      'mdtraj>=1.4.0',
                       'matplotlib'],
     zip_safe=False,
 )
@@ -274,9 +274,9 @@ else:
     # setuptools>=2.2 can handle setup_requires
     metadata['setup_requires'] = ['numpy>=1.6.0',
                                   'setuptools>3.6',
-                                  'mdtraj>=1.2.0',
+                                  'mdtraj>=1.4.0',
                                   'nose',
-                                 ]
+                                  ]
 
     # when on git, we require cython
     if os.path.exists('.git'):


### PR DESCRIPTION
*all readers apply lag first, then stride.
- adapted test cases
- add new iterload from mdtraj (with a new patch not raising, if chunk % stride != 0), requires mdtraj >= 1.4
- adapted tica

Thanks to @fabian-paul for his great help!
