### PR TITLE
[clustering.interface] added methods index_states and sample_index_by_…

### DIFF
--- a/pyemma/coordinates/clustering/interface.py
+++ b/pyemma/coordinates/clustering/interface.py
@@ -71,14 +71,14 @@ class AbstractClustering(Transformer):
         return self._dtrajs  # returning what we have saved
 
     @property
-    def index_states(self):
-        """Returns trajectory/time indexes for all the microstates.
+    def index_cluster(self):
+        """Returns trajectory/time indexes for all the clusters
 
         Returns
         -------
         indexes : list of ndarray( (N_i, 2) )
-            For each state, all trajectory and time indexes where this state occurs.
-            Each matrix has a number of rows equal to the number of occurances of the corresponding state,
+            For each state, all trajectory and time indexes where this cluster occurs.
+            Each matrix has a number of rows equal to the number of occurrences of the corresponding state,
             with rows consisting of a tuple (i, t), where i is the index of the trajectory and t is the time index
             within the trajectory.
         """
@@ -90,17 +90,17 @@ class AbstractClustering(Transformer):
 
         return self._index_states
 
-    def sample_indexes_by_state(self, states, nsample, replace=True):
+    def sample_indexes_by_cluster(self, clusters, nsample, replace=True):
         """Samples trajectory/time indexes according to the given sequence of states.
 
         Parameters
         ----------
-        states : iterable of integers
-            It contains the state indexes to be sampled
+        clusters : iterable of integers
+            It contains the cluster indexes to be sampled
 
         nsample : int
-            Number of samples per state. If replace = False, the number of returned samples per state could be smaller
-            if less than nsample indexes are available for a state.
+            Number of samples per cluster. If replace = False, the number of returned samples per cluster could be smaller
+            if less than nsample indexes are available for a cluster.
 
         replace : boolean, optional
             Whether the sample is with or without replacement
@@ -108,7 +108,7 @@ class AbstractClustering(Transformer):
         Returns
         -------
         indexes : list of ndarray( (N, 2) )
-            List of the sampled indices by state.
+            List of the sampled indices by cluster.
             Each element is an index array with a number of rows equal to N=len(sequence), with rows consisting of a
             tuple (i, t), where i is the index of the trajectory and t is the time index within the trajectory.
         """
@@ -117,7 +117,7 @@ class AbstractClustering(Transformer):
         if len(self._index_states) == 0: # has never been run
             self._index_states = index_states(self.dtrajs)
 
-        return sample_indexes_by_state(self._index_states[states], nsample, replace=replace)
+        return sample_indexes_by_state(self._index_states[clusters], nsample, replace=replace)
 
     def _map_array(self, X):
         """get closest index of point in :attr:`clustercenters` to x."""

--- a/pyemma/coordinates/clustering/interface.py
+++ b/pyemma/coordinates/clustering/interface.py
@@ -71,7 +71,7 @@ class AbstractClustering(Transformer):
         return self._dtrajs  # returning what we have saved
 
     @property
-    def index_cluster(self):
+    def index_clusters(self):
         """Returns trajectory/time indexes for all the clusters
 
         Returns

--- a/pyemma/coordinates/tests/test_cluster_samples.py
+++ b/pyemma/coordinates/tests/test_cluster_samples.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2015, 2014 Computational Molecular Biology Group, Free University
+# Berlin, 14195 Berlin, Germany.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+"""
+Test the save_trajs function of the coordinates API by comparing
+the direct, sequential retrieval of frames via mdtraj.load_frame() vs
+the retrival via save_trajs
+@author: gph82, clonker
+"""
+
+import unittest
+
+import numpy as np
+import pyemma.coordinates as coor
+
+class TestClusterSamples(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestClusterSamples, cls).setUpClass()
+
+    def setUp(self):
+        self.input_trajs = [[0,1,2],
+                            [3,4,5],
+                            [6,7,8],
+                            [0,1,2],
+                            [3,4,5],
+                            [6,7,8]]
+        self.cluster_obj = coor.cluster_regspace(data=self.input_trajs, dmin=.5)
+
+    def test_index_states(self):
+        # Test that the catalogue is being set up properly
+
+        # The assingment-catalogue is easy to see from the above dtrajs
+        ref = [[[0,0],[3,0]], # appearances of the 1st cluster
+               [[0,1],[3,1]], # appearances of the 2nd cluster
+               [[0,2],[3,2]], # appearances of the 3rd cluster
+               [[1,0],[4,0]], #    .....
+               [[1,1],[4,1]],
+               [[1,2],[4,2]],
+               [[2,0],[5,0]],
+               [[2,1],[5,1]],
+               [[2,2],[5,2]],
+               ]
+
+        for cc in np.arange(self.cluster_obj.n_clusters):
+            assert np.allclose(self.cluster_obj.index_states[cc], ref[cc])
+
+    def test_sample_indexes_by_state(self):
+        samples = self.cluster_obj.sample_indexes_by_state(np.arange(self.cluster_obj.n_clusters), 10)
+
+        # For each sample, check that you're actually retrieving the i-th center
+        for ii, isample in enumerate(samples):
+            assert np.in1d([self.cluster_obj.dtrajs[pair[0]][pair[1]] for pair in isample],ii).all()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyemma/coordinates/tests/test_cluster_samples.py
+++ b/pyemma/coordinates/tests/test_cluster_samples.py
@@ -65,7 +65,7 @@ class TestClusterSamples(unittest.TestCase):
                ]
 
         for cc in np.arange(self.cluster_obj.n_clusters):
-            assert np.allclose(self.cluster_obj.index_cluster[cc], ref[cc])
+            assert np.allclose(self.cluster_obj.index_clusters[cc], ref[cc])
 
     def test_sample_indexes_by_state(self):
         samples = self.cluster_obj.sample_indexes_by_cluster(np.arange(self.cluster_obj.n_clusters), 10)

--- a/pyemma/coordinates/tests/test_cluster_samples.py
+++ b/pyemma/coordinates/tests/test_cluster_samples.py
@@ -65,10 +65,10 @@ class TestClusterSamples(unittest.TestCase):
                ]
 
         for cc in np.arange(self.cluster_obj.n_clusters):
-            assert np.allclose(self.cluster_obj.index_states[cc], ref[cc])
+            assert np.allclose(self.cluster_obj.index_cluster[cc], ref[cc])
 
     def test_sample_indexes_by_state(self):
-        samples = self.cluster_obj.sample_indexes_by_state(np.arange(self.cluster_obj.n_clusters), 10)
+        samples = self.cluster_obj.sample_indexes_by_cluster(np.arange(self.cluster_obj.n_clusters), 10)
 
         # For each sample, check that you're actually retrieving the i-th center
         for ii, isample in enumerate(samples):


### PR DESCRIPTION
…state

This ports the index_states and sample_indexes_by_state from util.discrete_trajectories to the clustering interface. Now the clustering object also has these methods, which up to now only the estimated_MSM had (I think). 
