### PR TITLE
[frames_from_file] topology argument more flexible

### DIFF
--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -53,6 +53,9 @@ from pyemma.coordinates.clustering.assign import AssignCenters as _AssignCenters
 # stat
 from pyemma.coordinates.util.stat import histogram
 
+# types
+from mdtraj import Topology as _Topology, Trajectory as _Trajectory
+
 import numpy as _np
 import itertools as _itertools
 
@@ -488,7 +491,7 @@ def memory_reader(data):
     return _DataInMemory(data)
 
 
-def save_traj(traj_inp, indexes, outfile, topfile=None, stride = 1, chunksize=1000, verbose=False):
+def save_traj(traj_inp, indexes, outfile, topology=None, stride = 1, chunksize=1000, verbose=False):
     r""" Saves a sequence of frames as a single trajectory.
 
     Extracts the specified sequence of time/trajectory indexes from traj_inp
@@ -519,8 +522,8 @@ def save_traj(traj_inp, indexes, outfile, topfile=None, stride = 1, chunksize=10
         The name of the output file. Its extension will determine the file type written. Example: "out.dcd"
         If set to None, the trajectory object is returned to memory
 
-    topfile : str.
-        The topology file needed to read the files in the list :py:obj:`traj_inp`. If :py:obj:`traj_inp` is not a list,
+    topology : str, mdtraj.Trajectory, or mdtraj.Topology
+        The topology needed to read the files in the list :py:obj:`traj_inp`. If :py:obj:`traj_inp` is not a list,
         this parameter is ignored.
 
     stride  : integer, default is 1
@@ -546,14 +549,14 @@ def save_traj(traj_inp, indexes, outfile, topfile=None, stride = 1, chunksize=10
     # Determine the type of input and extract necessary parameters
     if isinstance(traj_inp, _FeatureReader):
         trajfiles = traj_inp.trajfiles
-        topfile  = traj_inp.topfile
+        topology  = traj_inp.topfile
         chunksize = traj_inp.chunksize
     else:
         # Do we have what we need?
         assert isinstance(traj_inp, list), "traj_inp has to be of type list, not %"%type(traj_inp)
-        assert isinstance(topfile,str), "traj_inp cannot be a list without an input " \
-                                        "topology file. " \
-                                        "Did you forget to parse the topology file?"
+        assert isinstance(topology,(str,_Topology, _Trajectory)), "traj_inp cannot be a list of files without an input " \
+                                        "topology of type str (eg filename.pdb), mdtraj.Trajectory or mdtraj.Topology. " \
+                                        "Got type %s instead"%type(topology)
         trajfiles = traj_inp
 
     # Convert to index (T,2) array if parsed a list or a list of arrays
@@ -575,7 +578,7 @@ def save_traj(traj_inp, indexes, outfile, topfile=None, stride = 1, chunksize=10
         # directly as an iterator in trajectory_iterator_list
         trajectory_iterator_list.append(_itertools.islice(_frames_from_file(
                                                 trajfiles[ff],
-                                                topfile,
+                                                topology,
                                                 frames, chunksize=chunksize,
                                                 verbose=verbose, stride = stride), None)
                                         )

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -491,7 +491,7 @@ def memory_reader(data):
     return _DataInMemory(data)
 
 
-def save_traj(traj_inp, indexes, outfile, topology=None, stride = 1, chunksize=1000, verbose=False):
+def save_traj(traj_inp, indexes, outfile, top=None, stride = 1, chunksize=1000, verbose=False):
     r""" Saves a sequence of frames as a single trajectory.
 
     Extracts the specified sequence of time/trajectory indexes from traj_inp
@@ -522,7 +522,7 @@ def save_traj(traj_inp, indexes, outfile, topology=None, stride = 1, chunksize=1
         The name of the output file. Its extension will determine the file type written. Example: "out.dcd"
         If set to None, the trajectory object is returned to memory
 
-    topology : str, mdtraj.Trajectory, or mdtraj.Topology
+    top : str, mdtraj.Trajectory, or mdtraj.Topology
         The topology needed to read the files in the list :py:obj:`traj_inp`. If :py:obj:`traj_inp` is not a list,
         this parameter is ignored.
 
@@ -549,14 +549,14 @@ def save_traj(traj_inp, indexes, outfile, topology=None, stride = 1, chunksize=1
     # Determine the type of input and extract necessary parameters
     if isinstance(traj_inp, _FeatureReader):
         trajfiles = traj_inp.trajfiles
-        topology  = traj_inp.topfile
+        top  = traj_inp.topfile
         chunksize = traj_inp.chunksize
     else:
         # Do we have what we need?
         assert isinstance(traj_inp, list), "traj_inp has to be of type list, not %"%type(traj_inp)
-        assert isinstance(topology,(str,_Topology, _Trajectory)), "traj_inp cannot be a list of files without an input " \
-                                        "topology of type str (eg filename.pdb), mdtraj.Trajectory or mdtraj.Topology. " \
-                                        "Got type %s instead"%type(topology)
+        assert isinstance(top,(str,_Topology, _Trajectory)), "traj_inp cannot be a list of files without an input " \
+                                        "top of type str (eg filename.pdb), mdtraj.Trajectory or mdtraj.Topology. " \
+                                        "Got type %s instead"%type(top)
         trajfiles = traj_inp
 
     # Convert to index (T,2) array if parsed a list or a list of arrays
@@ -578,7 +578,7 @@ def save_traj(traj_inp, indexes, outfile, topology=None, stride = 1, chunksize=1
         # directly as an iterator in trajectory_iterator_list
         trajectory_iterator_list.append(_itertools.islice(_frames_from_file(
                                                 trajfiles[ff],
-                                                topology,
+                                                top,
                                                 frames, chunksize=chunksize,
                                                 verbose=verbose, stride = stride), None)
                                         )

--- a/pyemma/coordinates/data/frames_from_file.py
+++ b/pyemma/coordinates/data/frames_from_file.py
@@ -30,7 +30,7 @@ __all__ = ['frames_from_file']
 
 log = getLogger(__name__)
 
-def frames_from_file(file_name, topology, frames, chunksize = 100,
+def frames_from_file(file_name, top, frames, chunksize = 100,
                      stride = 1, verbose = False):
     r"""Reads one "file_name" molecular trajectory and returns an mdtraj trajectory object 
         containing only the specified "frames" in the specified order.
@@ -44,7 +44,7 @@ def frames_from_file(file_name, topology, frames, chunksize = 100,
     file_name: str.
         Absolute path to the molecular trajectory file, ex. trajout.xtc 
 
-    topology : str, mdtraj.Trajectory, or mdtraj.Topology
+    top : str, mdtraj.Trajectory, or mdtraj.Topology
         Topology information to load the molecular trajectroy file in :py:obj:`file_name`
 
     frames : ndarray of shape (n_frames, ) and integer type
@@ -74,9 +74,9 @@ def frames_from_file(file_name, topology, frames, chunksize = 100,
     assert isinstance(frames, np.ndarray), "input frames frames must be a numpy ndarray, got %s instead "%type(frames)
     assert np.ndim(frames) == 1, "input frames frames must have ndim = 1, got np.ndim = %u instead "%np.ndim(frames)
     assert isinstance(file_name, str), "input file_name must be a string, got %s instead"%type(file_name)
-    assert isinstance(topology, (str, md.Trajectory, md.Topology)), "input topology must of one of type: " \
+    assert isinstance(top, (str, md.Trajectory, md.Topology)), "input topology must of one of type: " \
                                                                     "str, mdtraj.Trajectory, or mdtraj.Topology. " \
-                                                                    "Got %s instead" % type(topology)
+                                                                    "Got %s instead" % type(top)
 
     traj = None
     cum_frames = 0
@@ -86,7 +86,7 @@ def frames_from_file(file_name, topology, frames, chunksize = 100,
     orig_order = frames.argsort().argsort()
     sorted_frames = np.sort(frames)
 
-    for jj, traj_chunk in enumerate(md.iterload(file_name, top=topology,
+    for jj, traj_chunk in enumerate(md.iterload(file_name, top=top,
                                                 chunk=chunksize, stride=stride)):
 
         # Create an indexing array for this trajchunk

--- a/pyemma/coordinates/data/frames_from_file.py
+++ b/pyemma/coordinates/data/frames_from_file.py
@@ -30,8 +30,8 @@ __all__ = ['frames_from_file']
 
 log = getLogger(__name__)
 
-def frames_from_file(file_name, pdbfile, frames, chunksize = 100,
-                     stride = 1, verbose = False, **kwargs):
+def frames_from_file(file_name, topology, frames, chunksize = 100,
+                     stride = 1, verbose = False):
     r"""Reads one "file_name" molecular trajectory and returns an mdtraj trajectory object 
         containing only the specified "frames" in the specified order.
 
@@ -44,8 +44,8 @@ def frames_from_file(file_name, pdbfile, frames, chunksize = 100,
     file_name: str.
         Absolute path to the molecular trajectory file, ex. trajout.xtc 
 
-    pdb_file : str.
-        Absolute path to the molecular trajectory file that can be used as topology by mdtraj
+    topology : str, mdtraj.Trajectory, or mdtraj.Topology
+        Topology information to load the molecular trajectroy file in :py:obj:`file_name`
 
     frames : ndarray of shape (n_frames, ) and integer type
         Contains the frame indices to be retrieved from "file_name". There is no restriction as to what 
@@ -74,7 +74,9 @@ def frames_from_file(file_name, pdbfile, frames, chunksize = 100,
     assert isinstance(frames, np.ndarray), "input frames frames must be a numpy ndarray, got %s instead "%type(frames)
     assert np.ndim(frames) == 1, "input frames frames must have ndim = 1, got np.ndim = %u instead "%np.ndim(frames)
     assert isinstance(file_name, str), "input file_name must be a string, got %s instead"%type(file_name)
-    assert isinstance(pdbfile, str), "input pdbfile must be a string, got %s instead" % type(pdbfile)
+    assert isinstance(topology, (str, md.Trajectory, md.Topology)), "input topology must of one of type: " \
+                                                                    "str, mdtraj.Trajectory, or mdtraj.Topology. " \
+                                                                    "Got %s instead" % type(topology)
 
     traj = None
     cum_frames = 0
@@ -84,7 +86,7 @@ def frames_from_file(file_name, pdbfile, frames, chunksize = 100,
     orig_order = frames.argsort().argsort()
     sorted_frames = np.sort(frames)
 
-    for jj, traj_chunk in enumerate(md.iterload(file_name, top=pdbfile,
+    for jj, traj_chunk in enumerate(md.iterload(file_name, top=topology,
                                                 chunk=chunksize, stride=stride)):
 
         # Create an indexing array for this trajchunk

--- a/pyemma/coordinates/tests/test_frames_from_file.py
+++ b/pyemma/coordinates/tests/test_frames_from_file.py
@@ -55,6 +55,8 @@ class TestFramesFromFile(unittest.TestCase):
         self.frames = randint(0, high = 100, size = self.n_frames)
         self.chunksize = 30
 
+        self.mdTrajectory = md.load(self.pdbfile)
+
     def test_returns_trajectory(self):
         assert isinstance(_frames_from_file(self.trajfiles, self.pdbfile, self.frames),
                           md.Trajectory)
@@ -96,6 +98,36 @@ class TestFramesFromFile(unittest.TestCase):
             frames = randint(0, high = floor(100/stride), size = self.n_frames)
 
             traj_test = _frames_from_file(self.trajfiles, self.pdbfile, frames,
+                                          chunksize=self.chunksize,
+                                          stride = stride,
+                                          verbose=False)
+            traj_ref = md.load(self.trajfiles, top=self.pdbfile, stride = stride)[frames]
+
+            (found_diff, errmsg) = compare_coords_md_trajectory_objects(traj_test, traj_ref, atom=0, mess=False)
+            self.assertFalse(found_diff, errmsg)
+
+    def test_gets_the_right_frames_with_stride_with_chunk_mdTrajectory_input(self):
+
+        for stride in [2, 3, 5, 6, 10, 15]:
+            # Make sure we don't overshoot the number of available frames (100)
+            frames = randint(0, high = floor(100/stride), size = self.n_frames)
+
+            traj_test = _frames_from_file(self.trajfiles, self.mdTrajectory, frames,
+                                          chunksize=self.chunksize,
+                                          stride = stride,
+                                          verbose=False)
+            traj_ref = md.load(self.trajfiles, top=self.pdbfile, stride = stride)[frames]
+
+            (found_diff, errmsg) = compare_coords_md_trajectory_objects(traj_test, traj_ref, atom=0, mess=False)
+            self.assertFalse(found_diff, errmsg)
+
+    def test_gets_the_right_frames_with_stride_with_chunk_mdTopology_input(self):
+
+        for stride in [2, 3, 5, 6, 10, 15]:
+            # Make sure we don't overshoot the number of available frames (100)
+            frames = randint(0, high = floor(100/stride), size = self.n_frames)
+
+            traj_test = _frames_from_file(self.trajfiles, self.mdTrajectory.top, frames,
                                           chunksize=self.chunksize,
                                           stride = stride,
                                           verbose=False)

--- a/pyemma/coordinates/tests/test_save_traj.py
+++ b/pyemma/coordinates/tests/test_save_traj.py
@@ -95,12 +95,12 @@ class TestSaveTraj(unittest.TestCase):
 
     def test_list_input_save_IO(self):
         # Test that we're saving to disk alright
-        save_traj(self.trajfiles, self.sets, self.outfile, topology=self.pdbfile)
+        save_traj(self.trajfiles, self.sets, self.outfile, top=self.pdbfile)
         exist = os.stat(self.outfile)
         self.assertTrue(exist, "Could not write to disk")
 
     def test_list_input_returns_trajectory(self):
-        self.assertTrue(isinstance(save_traj(self.trajfiles, self.sets, None, topology=self.pdbfile),
+        self.assertTrue(isinstance(save_traj(self.trajfiles, self.sets, None, top=self.pdbfile),
                           md.Trajectory))
 
     def test_reader_input_save_correct_frames_disk(self):
@@ -127,7 +127,7 @@ class TestSaveTraj(unittest.TestCase):
 
     def test_list_input_save_correct_frames_disk(self):
 
-        save_traj(self.trajfiles, self.sets, self.outfile, topology=self.pdbfile)
+        save_traj(self.trajfiles, self.sets, self.outfile, top=self.pdbfile)
 
         # Reload the object to memory
         traj = md.load(self.outfile, top=self.pdbfile)
@@ -140,7 +140,7 @@ class TestSaveTraj(unittest.TestCase):
     def test_list_input_save_correct_frames_mem(self):
 
         # Keep object in memory
-        traj = save_traj(self.trajfiles, self.sets, None, topology=self.pdbfile)
+        traj = save_traj(self.trajfiles, self.sets, None, top=self.pdbfile)
 
         # Check for diffs
         (found_diff, errmsg) = compare_coords_md_trajectory_objects(traj, self.traj_ref, atom=0)

--- a/pyemma/coordinates/tests/test_save_traj.py
+++ b/pyemma/coordinates/tests/test_save_traj.py
@@ -95,12 +95,12 @@ class TestSaveTraj(unittest.TestCase):
 
     def test_list_input_save_IO(self):
         # Test that we're saving to disk alright
-        save_traj(self.trajfiles, self.sets, self.outfile, topfile=self.pdbfile)
+        save_traj(self.trajfiles, self.sets, self.outfile, topology=self.pdbfile)
         exist = os.stat(self.outfile)
         self.assertTrue(exist, "Could not write to disk")
 
     def test_list_input_returns_trajectory(self):
-        self.assertTrue(isinstance(save_traj(self.trajfiles, self.sets, None, topfile=self.pdbfile),
+        self.assertTrue(isinstance(save_traj(self.trajfiles, self.sets, None, topology=self.pdbfile),
                           md.Trajectory))
 
     def test_reader_input_save_correct_frames_disk(self):
@@ -127,7 +127,7 @@ class TestSaveTraj(unittest.TestCase):
 
     def test_list_input_save_correct_frames_disk(self):
 
-        save_traj(self.trajfiles, self.sets, self.outfile, topfile=self.pdbfile)
+        save_traj(self.trajfiles, self.sets, self.outfile, topology=self.pdbfile)
 
         # Reload the object to memory
         traj = md.load(self.outfile, top=self.pdbfile)
@@ -140,7 +140,7 @@ class TestSaveTraj(unittest.TestCase):
     def test_list_input_save_correct_frames_mem(self):
 
         # Keep object in memory
-        traj = save_traj(self.trajfiles, self.sets, None, topfile=self.pdbfile)
+        traj = save_traj(self.trajfiles, self.sets, None, topology=self.pdbfile)
 
         # Check for diffs
         (found_diff, errmsg) = compare_coords_md_trajectory_objects(traj, self.traj_ref, atom=0)


### PR DESCRIPTION
Now topologies can be parsed not only in form of filenames but actually as true mdtraj.Topology or mdtraj.Trajectory objects. This avoids reading the pdbfile every frames_from_file gets called.

In the "worst-case-scenario" for save_traj and save_trajs (eg. a sample of 50 frames composed by 1 frame of 50 different files), the speedup is of about 1.5
