### PR TITLE
[featurizer.py] minimum distance between residues and minimal distances between groups of atoms

### DIFF
--- a/pyemma/coordinates/data/featurizer.py
+++ b/pyemma/coordinates/data/featurizer.py
@@ -70,7 +70,6 @@ def _describe_atom(topology, index):
     at = topology.atom(index)
     return "%s %i %s %i" % (at.residue.name, at.residue.index, at.name, at.index)
 
-
 def _catch_unhashable(x):
     if hasattr(x, '__getitem__'):
         res = list(x)
@@ -142,6 +141,67 @@ def _parse_pairwise_input(indices1, indices2, MDlogger, fname=''):
 
     return atom_pairs
 
+def _parse_groupwise_input(group_definitions, group_pairs, MDlogger, mname=''):
+    r"""For input of group type (add_group_mindist), prepare the array of pairs of indices
+        and groups so that :py:func:`MinDistanceFeature` can work
+
+        This function will:
+            - check the input types
+            - sort the 1D arrays of each entry of group_definitions
+            - check for duplicates within each group_definition
+            - produce the list of pairs for all needed distances
+            - produce a list that maps each entry in the pairlist to a given group of distances
+        """
+
+    assert isinstance(group_definitions, list), "group_definitions has to be of type list, not %s"%type(group_definitions)
+    # Handle the special case of just one group
+    if len(group_definitions) == 1:
+        group_pairs = np.array([0,0], ndmin=2)
+
+    # Sort the elements within each group
+    new_groups = []
+    for igroup in group_definitions:
+        assert np.ndim(igroup) == 1, "The elements of the groups definition have to be of dim 1, not %u"%np.ndim(igroup)
+        new_groups.append(np.unique(igroup))
+
+    # Check for group duplicates
+    for ii, igroup in enumerate(new_groups[:-1]):
+        for jj, jgroup in enumerate(new_groups[ii+1:]):
+            if len(igroup) == len(jgroup):
+                assert not np.allclose(igroup, jgroup), "Some group definitions appear to be duplicated, e.g %u and %u"%(ii,ii+jj+1)
+
+    # Create and/or check the pair-list
+    if group_pairs == 'all':
+        new_pairs = np.array(list(_combinations(np.arange(len(group_definitions)), 2)))
+    else:
+        assert isinstance(group_pairs, np.ndarray)
+        assert group_pairs.shape[1] == 2
+        assert group_pairs.max() <= len(new_groups), "Cannot ask for group nr. %u if group_definitions only " \
+                                                    "contains %u groups"%(group_pairs.max(), len(new_groups))
+        assert group_pairs.min() >= 0, "Group pairs contains negative group indices"
+
+        new_pairs = np.zeros_like(group_pairs, dtype='int')
+        for ii, ipair in enumerate(group_pairs):
+            if ipair[0] == ipair[1]:
+                MDlogger.warning("%s will compute the mindist of group %u with itself. Is this wanted? "%(mname, ipair[0]))
+            new_pairs[ii,:] = np.sort(ipair)
+
+    # Create the large list of distances that will be computed, and an array containing group identfiers
+    # of the distances that actually characterize a pair of groups
+    group_distance_indexes = []
+    group_distance_identifiers = np.zeros_like(new_pairs)
+    b = 0
+    for ii, pair in enumerate(new_pairs):
+        if pair[0] != pair[1]:
+            group_distance_indexes.append(list(_product(new_groups[pair[0]],
+                                                        new_groups[pair[1]])))
+        else:
+            group_distance_indexes.append(list(_combinations(new_groups[pair[0]], 2)))
+
+        group_distance_identifiers[ii,:] = [b, b+len(group_distance_indexes[ii])]
+        b += len(group_distance_indexes[ii])
+
+    return new_groups, new_pairs, np.vstack(group_distance_indexes), group_distance_identifiers
 
 class CustomFeature(object):
 
@@ -292,6 +352,60 @@ class InverseDistanceFeature(DistanceFeature):
 
     # does not need own hash impl, since we take prefix label into account
 
+class ResidueMinDistanceFeature(DistanceFeature):
+
+    def __init__(self, top, contacts, scheme, ignore_nonprotein):
+        self.top = top
+        self.contacts = contacts
+        self.scheme = scheme
+        self.prefix_label = "RES_DIST (%s)"%scheme
+
+        # mdtraj.compute_contacts might ignore part of the user input (if it is contradictory) and
+        # produce a warning. I think it is more robust to let it run once on a dummy trajectory to
+        # see what the actual size of the output is:
+        dummy_traj = mdtraj.Trajectory(np.zeros((top.n_atoms, 3)), top)
+        dummy_dist, dummy_pairs = mdtraj.compute_contacts(dummy_traj, contacts=contacts,
+                                                          scheme=scheme,
+                                                          ignore_nonprotein=ignore_nonprotein)
+        self._dimension = dummy_dist.shape[1]
+        self.distance_indexes = dummy_pairs
+
+    def describe(self):
+        labels = ["%s %s - %s" % (self.prefix_label,
+                                  self.top.residue(pair[0]),
+                                  self.top.residue(pair[1]))
+                  for pair in self.distance_indexes]
+        return labels
+
+    def map(self, traj):
+        return mdtraj.compute_contacts(traj, contacts=self.contacts, scheme=self.scheme)[0]
+
+class GroupMinDistanceFeature(DistanceFeature):
+
+    def __init__(self, top, group_pairs, distance_list, group_identifiers):
+        self.top = top
+        self.group_identifiers = group_identifiers
+        self.distance_list = distance_list
+        self.prefix_label = "GROUP_MINDIST"
+        self.distance_indexes = group_pairs
+
+    def describe(self):
+        labels = ["%s %s - %s" % (self.prefix_label,
+                                  pair[0],
+                                  pair[1])
+                  for pair in self.distance_indexes]
+        return labels
+
+    def map(self, traj):
+        # All needed distances
+        Dall = mdtraj.compute_distances(traj, self.distance_list)
+        # Just the minimas
+        Dargmin = np.zeros((traj.n_frames,self.dimension))
+        # Compute the min groupwise
+        for ii, (gi, gf) in enumerate(self.group_identifiers):
+            Dargmin[:, ii] =  Dall[:,gi:gf].min(1)
+
+        return Dargmin
 
 class ContactFeature(DistanceFeature):
 
@@ -325,7 +439,6 @@ class AngleFeature(object):
         self.cossin = cossin
 
     def describe(self):
-        self.top
 
         if self.cossin:
             sin_cos = ("ANGLE: COS(%s - %s - %s)",
@@ -761,8 +874,8 @@ class MDFeaturizer(object):
                     n x 2 array with the pairs of atoms between which the distances shall be computed
 
                 iterable of integers (either list or ndarray(n, dtype=int)):
-                    indices (**not pairs of indices**) of the atoms between which the distances shall be computed.
-                    Note that this will produce a pairlist different from the pairlist produced by :py:func:`pairs` in that this **does not** exclude
+                    indices (not pairs of indices) of the atoms between which the distances shall be computed.
+                    Note that this will produce a pairlist different from the pairlist produced by :py:func:`pairs` in that this does not exclude
                     1-2 neighbors.
 
         indices2: iterable of integers (either list or ndarray(n, dtype=int)), optional:
@@ -771,7 +884,7 @@ class MDFeaturizer(object):
 
 
         .. note::
-            When using the *iterable of integers* input, :py:obj:`indices` and :py:obj:`indices2`
+            When using the iterable of integers input, :py:obj:`indices` and :py:obj:`indices2`
             will be sorted numerically and made unique before converting them to a pairlist.
             Please look carefully at the output of :py:func:`describe()` to see what features exactly have been added.
         """
@@ -811,9 +924,9 @@ class MDFeaturizer(object):
                     n x 2 array with the pairs of atoms between which the inverse distances shall be computed
 
                 iterable of integers (either list or ndarray(n, dtype=int)):
-                    indices (**not pairs of indices**) of the atoms between which the inverse distances shall be computed.
-                    Note that this will produce a pairlist different from the pairlist produced by :py:func:`pairs` in that this **does not** exclude
-                    1-2 neighbors.
+                    indices (not pairs of indices) of the atoms between which the inverse distances shall be computed.
+                    Note that this will produce a pairlist different from the pairlist produced by :py:func:`pairs`
+                    in that this does not exclude 1-2 neighbors.
 
         indices2: iterable of integers (either list or ndarray(n, dtype=int)), optional:
                     Only has effect if :py:obj:`indices` is an iterable of integers. Instead of the above behaviour,
@@ -850,8 +963,8 @@ class MDFeaturizer(object):
                     n x 2 array with the pairs of atoms between which the contacts shall be computed
 
                 iterable of integers (either list or ndarray(n, dtype=int)):
-                    indices (**not pairs of indices**) of the atoms between which the contacts shall be computed.
-                    Note that this will produce a pairlist different from the pairlist produced by :py:func:`pairs` in that this **does not** exclude
+                    indices (not pairs of indices) of the atoms between which the contacts shall be computed.
+                    Note that this will produce a pairlist different from the pairlist produced by :py:func:`pairs` in that this does not exclude
                     1-2 neighbors.
 
         indices2: iterable of integers (either list or ndarray(n, dtype=int)), optional:
@@ -875,6 +988,76 @@ class MDFeaturizer(object):
 
         atom_pairs = self._check_indices(atom_pairs)
         f = ContactFeature(self.topology, atom_pairs, threshold, periodic)
+        self.__add_feature(f)
+
+    def add_residue_mindist(self,
+                            residue_pairs='all',
+                            scheme='closest-heavy',
+                            ignore_nonprotein=True):
+        r"""
+        Adds the minimum distance between residues to the feature list. See below how
+        the minimum distance can be defined.
+
+        Parameters
+        ----------
+        residue_pairs : can be of two types:
+
+            'all'
+                Computes distances between all pairs of residues excluding first and second neighbors
+
+            ndarray((n, 2), dtype=int):
+                n x 2 array with the pairs residues for which distances will be computed
+
+        scheme : 'ca', 'closest', 'closest-heavy', default is closest-heavy
+                Has effect only if :py:obj:`group_def` ='residues'. Within a residue, determines the sub-group atoms
+                that will be considered when computing distances
+
+        ignore_nonprotein : boolean, default True
+                Ignore residues that are not of protein type (e.g. water molecules, post-traslational modifications etc)
+
+
+        .. note::
+            Using :py:obj:`scheme` = 'closest' or 'closest-heavy' with :py:obj:`residue pairs` = 'all'
+            will compute nearly all interatomic distances, for every frame, before extracting the closest pairs.
+            This can be very time consuming. Those schemes are intended to be used with a subset of residues chosen
+            via :py:obj:`residue_pairs`.
+        """
+
+        if scheme != 'ca' and residue_pairs == 'all':
+            self._logger.warning("Using all residue pairs with schemes like closest or closest-heavy is "
+                                 "very time consuming. Consider reducing the residue pairs")
+
+        f = ResidueMinDistanceFeature(self.topology, residue_pairs, scheme, ignore_nonprotein)
+        self.__add_feature(f)
+
+    def add_group_mindist(self,
+                            group_definitions,
+                            group_pairs='all',
+                            ):
+        r"""
+        Adds the minimum distance between groups of atoms to the feature list. If the groups of
+        atoms are identical to residues, use :py:obj:`add_residue_mindist <pyemma.coordinates.data.featurizer.MDFeaturizer.add_residue_mindist>`.
+
+        Parameters
+        ----------
+
+        group_definition : list of 1D-arrays/iterables containing the group definitions via atom indices.
+            If there is only one group_definition, it is assumed the minimum distance within this group (excluding the
+            self-distance) is wanted. In this case, :py:obj:`group_pairs` is ignored.
+
+        group_pairs :  Can be of two types:
+            'all'
+                Computes minimum distances between all pairs of groups contained in the group definitions
+
+            ndarray((n, 2), dtype=int):
+                n x 2 array with the pairs of groups for which the minimum distances will be computed.
+        """
+
+        # Some thorough input checking and reformatting
+        __, group_pairs, distance_list, group_identifiers = _parse_groupwise_input(group_definitions, group_pairs, self._logger, 'add_group_mindist')
+        distance_list = self._check_indices(distance_list)
+
+        f = GroupMinDistanceFeature(self.topology, group_pairs, distance_list, group_identifiers)
         self.__add_feature(f)
 
     @deprecated
@@ -1013,7 +1196,7 @@ class MDFeaturizer(object):
             If left to None, all atoms of :py:obj:`ref` will be used.
 
         precentered: bool, default=False
-            Use this boolean at your own risk to let mdtraj know that the target conformations are **already**
+            Use this boolean at your own risk to let mdtraj know that the target conformations are already
             centered at the origin, i.e., their (uniformly weighted) center of mass lies at the origin.
             This will speed up the computation of the rmsd.
         """

--- a/pyemma/coordinates/tests/test_featurizer.py
+++ b/pyemma/coordinates/tests/test_featurizer.py
@@ -327,6 +327,70 @@ class TestFeaturizer(unittest.TestCase):
         ref_Y = mdtraj.rmsd(self.traj, self.traj[self.ref_frame], atom_indices=self.atom_indices, precentered=True)
         verbose_assertion_minrmsd(ref_Y, test_Y, self)
 
+    def test_Residue_Mindist_Ca_all(self):
+        self.feat.add_residue_mindist(scheme='ca')
+        D = self.feat.map(self.traj)
+        Dref = mdtraj.compute_contacts(self.traj, scheme='ca')[0]
+        assert np.allclose(D, Dref)
+
+
+    def test_Residue_Mindist_Ca_array(self):
+        contacts=np.array([[20,10,], [10,0]])
+        self.feat.add_residue_mindist(scheme='ca', residue_pairs=contacts)
+        D = self.feat.map(self.traj)
+        Dref = mdtraj.compute_contacts(self.traj, scheme='ca', contacts=contacts)[0]
+        assert np.allclose(D, Dref)
+
+    def test_Group_Mindist_One_Group(self):
+        group0= [0,20,30,0]
+        self.feat.add_group_mindist(group_definitions=[group0]) # Even with duplicates
+        D = self.feat.map(self.traj)
+        dist_list = list(combinations(np.unique(group0),2))
+        Dref = mdtraj.compute_distances(self.traj, dist_list)
+        assert np.allclose(D.squeeze(), Dref.min(1))
+
+    def test_Group_Mindist_All_Three_Groups(self):
+        group0 = [0,20,30,0]
+        group1 = [1,21,31,1]
+        group2 = [2,22,32,2]
+        self.feat.add_group_mindist(group_definitions=[group0, group1, group2])
+        D = self.feat.map(self.traj)
+
+        # Now the references, computed separately for each combination of groups
+        dist_list_01 = np.array(list(product(np.unique(group0),np.unique(group1))))
+        dist_list_02 = np.array(list(product(np.unique(group0),np.unique(group2))))
+        dist_list_12 = np.array(list(product(np.unique(group1),np.unique(group2))))
+        Dref_01 = mdtraj.compute_distances(self.traj, dist_list_01).min(1)
+        Dref_02 = mdtraj.compute_distances(self.traj, dist_list_02).min(1)
+        Dref_12 = mdtraj.compute_distances(self.traj, dist_list_12).min(1)
+        Dref = np.vstack((Dref_01,Dref_02,Dref_12)).T
+
+        assert np.allclose(D.squeeze(), Dref)
+
+    def test_Group_Mindist_Some_Three_Groups(self):
+        group0 = [0,20,30,0]
+        group1 = [1,21,31,1]
+        group2 = [2,22,32,2]
+
+        group_pairs=np.array([[0,1],
+                              [2,2],
+                              [0,2]])
+
+        self.feat.add_group_mindist(group_definitions=[group0, group1, group2], group_pairs=group_pairs)
+        D = self.feat.map(self.traj)
+
+        # Now the references, computed separately for each combination of groups
+        dist_list_01 = np.array(list(product(np.unique(group0),np.unique(group1))))
+        dist_list_02 = np.array(list(product(np.unique(group0),np.unique(group2))))
+        dist_list_22 = np.array(list(combinations(np.unique(group2),2)))
+        Dref_01 = mdtraj.compute_distances(self.traj, dist_list_01).min(1)
+        Dref_02 = mdtraj.compute_distances(self.traj, dist_list_02).min(1)
+        Dref_22 = mdtraj.compute_distances(self.traj, dist_list_22).min(1)
+        Dref = np.vstack((Dref_01,Dref_22,Dref_02)).T
+
+        assert np.allclose(D.squeeze(), Dref)
+
+
 class TestFeaturizerNoDubs(unittest.TestCase):
 
     def testAddFeaturesWithDuplicates(self):
@@ -393,6 +457,14 @@ class TestFeaturizerNoDubs(unittest.TestCase):
         featurizer.add_minrmsd_to_ref(pdbfile)
         self.assertEquals(len(featurizer.active_features), 10)
 
+        featurizer.add_residue_mindist()
+        featurizer.add_residue_mindist()
+        self.assertEquals(len(featurizer.active_features), 11)
+
+        featurizer.add_group_mindist([[0,1],[0,2]])
+        featurizer.add_group_mindist([[0,1],[0,2]])
+        self.assertEquals(len(featurizer.active_features), 12)
+
     def test_labels(self):
         """ just checks for exceptions """
         featurizer = MDFeaturizer(pdbfile)
@@ -405,6 +477,8 @@ class TestFeaturizerNoDubs(unittest.TestCase):
         cs.dimension = lambda: 3
         featurizer.add_custom_feature(cs)
         featurizer.add_minrmsd_to_ref(pdbfile)
+        featurizer.add_residue_mindist()
+        featurizer.add_group_mindist([[0,1],[0,2]])
 
         featurizer.describe()
 


### PR DESCRIPTION
As usual, this is more a basis for discussion/refactoring renaming than an PR
These two new features (which are very similar) are presented separated to keep the input simple:
- add_residue_mindist only operates with residue based indexing, and is just an interface to http://mdtraj.org/latest/api/generated/mdtraj.compute_contacts.html. I
- add_group_mindist is very flexible, and allows the user to define arbitrary atom groups via atom indices. The user can ask mindists among all groups or only some of them. Eg., if 4 groups have been defined, perhaps the user wants mindist_0-1 and mindist_2-3, but not mindist_0_3 etc. Think of two separate salt bridges or two separate ionic-locks in different parts of the molecule. If given only one group, add_group_mindist automatically assumes the minimal distance within that group is wanted (not clear about the use-case, but still)
- _parse_groupwise_input mimics what _parse_pairwise_input does, but with a group-type of input. Perhaps in the future more features will be defined among groups and this parser/input-checker is useful. Already discussed with @marscher  the possibility of outsourcing it to some other util file, or even to the feature object itself. I really do not have an opinion about that.
