### PR TITLE
[minRMSD] dimensions was incorrectly n_atoms, now it's 1

### DIFF
--- a/pyemma/coordinates/data/featurizer.py
+++ b/pyemma/coordinates/data/featurizer.py
@@ -546,7 +546,7 @@ class MinRmsdFeature(object):
 
     @property
     def dimension(self):
-        return self.ref.n_atoms
+        return 1
 
     def map(self, traj):
         return np.array(mdtraj.rmsd(traj, self.ref, atom_indices=self.atom_indices), ndmin=2).T


### PR DESCRIPTION
This was passing the tests because there the map method (instead of get_output) is used. Phew!
