### PR TITLE
[coor/pca|tica] added optional mean argument and skip first pass, if provided

### DIFF
--- a/pyemma/coordinates/tests/test_pca.py
+++ b/pyemma/coordinates/tests/test_pca.py
@@ -37,7 +37,7 @@ from pyemma.util.log import getLogger
 import pyemma.util.types as types
 
 
-logger = getLogger('TestTICA')
+logger = getLogger('TestPCA')
 
 
 class TestPCAExtensive(unittest.TestCase):
@@ -175,6 +175,15 @@ class TestPCAExtensive(unittest.TestCase):
     def test_trajectory_lengths(self):
         assert len(self.pca_obj.trajectory_lengths()) == 1
         assert self.pca_obj.trajectory_lengths()[0] == self.pca_obj.trajectory_length(0)
+    
+    def test_provided_means(self):
+        data = np.random.random((300, 3))
+        mean = data.mean(axis=0)
+        tica_obj = pca(data, mean=mean)
+
+        tica_calc_mean = pca(data)
+        np.testing.assert_allclose(tica_obj.mean, tica_calc_mean.mean)
+        np.testing.assert_allclose(tica_obj.cov, tica_calc_mean.cov)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/tests/test_tica.py
+++ b/pyemma/coordinates/tests/test_tica.py
@@ -317,5 +317,15 @@ class TestTICAExtensive(unittest.TestCase):
         assert (len(tica_obj._skipped_trajs)==2)
         assert np.allclose(tica_obj._skipped_trajs, [0,1])
 
+    def test_provided_means(self):
+        data = np.random.random((300, 3))
+        mean = data.mean(axis=0)
+        tica_obj = tica(data, mean=mean)
+        tica_calc_mean = tica(data)
+
+        np.testing.assert_allclose(tica_obj.mu, tica_calc_mean.mu)
+        np.testing.assert_allclose(tica_obj.cov, tica_calc_mean.cov)
+        np.testing.assert_allclose(tica_obj.cov_tau, tica_calc_mean.cov_tau)
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/transform/pca.py
+++ b/pyemma/coordinates/transform/pca.py
@@ -28,6 +28,8 @@ from .transformer import Transformer
 from pyemma.util.annotators import doc_inherit
 from pyemma.util.progressbar import ProgressBar
 from pyemma.util.progressbar.gui import show_progressbar
+from pyemma.coordinates.transform.transformer import SkipPassException
+from pyemma.util import types
 
 __all__ = ['PCA']
 __author__ = 'noe'
@@ -35,7 +37,7 @@ __author__ = 'noe'
 
 class PCA(Transformer):
 
-    def __init__(self, dim=-1, var_cutoff=1.0):
+    def __init__(self, dim=-1, var_cutoff=1.0, mean=None):
         r""" Principal component analysis.
 
         Given a sequence of multivariate data :math:`X_t`,
@@ -68,6 +70,9 @@ class PCA(Transformer):
             exceeds the fraction subspace_variance. var_cutoff=1.0 means all numerically available dimensions
             (see epsilon) will be used, unless set by dim. Setting var_cutoff smaller than 1.0 is exclusive with dim
 
+        mean : ndarray, optional, default None
+            Optionally pass pre-calculated means to avoid their re-computation.
+            The shape has to match the input dimension.
 
         """
         super(PCA, self).__init__()
@@ -78,6 +83,8 @@ class PCA(Transformer):
         self._dot_prod_tmp = None
         self.Y = None
         self._N = 0
+
+        self.mu = mean
 
         # set up result variables
         self.eigenvalues = None
@@ -122,7 +129,14 @@ class PCA(Transformer):
         indim = self.data_producer.dimension()
         self._logger.info("Running PCA on %i dimensional input" % indim)
         assert indim > 0, "Incoming data of PCA has 0 dimension!"
-        self.mu = np.zeros(indim)
+
+        if self.mu is not None:
+            self.mu = types.ensure_ndarray(self.mu, shape=(indim,))
+            self._given_mean = True
+        else:
+            self.mu = np.zeros(indim)
+            self._given_mean = False
+
         self.cov = np.zeros((indim, indim))
 
         # amount of chunks
@@ -158,6 +172,8 @@ class PCA(Transformer):
         # pass 1: means
         if ipass == 0:
             if t == 0:
+                if self._given_mean:
+                    raise SkipPassException()
                 self._logger.debug("start to calculate mean for traj nr %i" % itraj)
                 self._sum_tmp = np.empty(X.shape[1])
             np.sum(X, axis=0, out=self._sum_tmp)

--- a/pyemma/coordinates/transform/tica.py
+++ b/pyemma/coordinates/transform/tica.py
@@ -21,12 +21,13 @@
 # ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from pyemma.util import types
 '''
 Created on 19.01.2015
 
 @author: marscher
 '''
-from .transformer import Transformer
+from .transformer import Transformer, SkipPassException
 
 from pyemma.util.progressbar import ProgressBar
 from pyemma.util.progressbar.gui import show_progressbar
@@ -45,7 +46,7 @@ class MeaningOfLagWithStrideWarning(UserWarning):
 class TICA(Transformer):
 
     def __init__(self, lag, dim=-1, var_cutoff=1.0, kinetic_map=False, epsilon=1e-6,
-                 force_eigenvalues_le_one=False):
+                 force_eigenvalues_le_one=False, mean=None):
         r""" Time-lagged independent component analysis (TICA) [1]_, [2]_, [3]_.
 
         Parameters
@@ -70,6 +71,9 @@ class TICA(Transformer):
         force_eigenvalues_le_one : boolean
             Compute covariance matrix and time-lagged covariance matrix such
             that the generalized eigenvalues are always guaranteed to be <= 1.
+        mean : ndarray, optional, default None
+            Optionally pass pre-calculated means to avoid their re-computation.
+            The shape has to match the input dimension.
 
         Notes
         -----
@@ -126,7 +130,8 @@ class TICA(Transformer):
         self.cov = None
         self.cov_tau = None
         # mean
-        self.mu = None
+        self.mu = mean
+
         self._N_mean = 0
         self._N_cov = 0
         self._N_cov_tau = 0
@@ -140,6 +145,7 @@ class TICA(Transformer):
 
         # skipped trajectories
         self._skipped_trajs = []
+
     @property
     def lag(self):
         """ lag time of correlation matrix :math:`C_{\tau}` """
@@ -194,12 +200,18 @@ class TICA(Transformer):
                           " trajectory, no matter what value of stride is used.",
                           MeaningOfLagWithStrideWarning)
 
+        if self.mu is not None:
+            self.mu = types.ensure_ndarray(self.mu, shape=(indim,))
+            self._given_mean = True
+        else:
+            self.mu = np.zeros(indim)
+            self._given_mean = False
+
         self._N_mean = 0
         self._N_cov = 0
         self._N_cov_tau = 0
-        # create mean array and covariance matrices
-        self.mu = np.zeros(indim)
 
+        # create covariance matrices
         self.cov = np.zeros((indim, indim))
         self.cov_tau = np.zeros_like(self.cov)
 
@@ -240,6 +252,10 @@ class TICA(Transformer):
         :return:
         """
         if ipass == 0:
+
+            # if we have a user-given mean, skip ipass 0 now:
+            if self._given_mean:
+                raise SkipPassException(self._lag)
 
             if self._force_eigenvalues_le_one:
                 # MSM-like counting

--- a/pyemma/coordinates/transform/tica.py
+++ b/pyemma/coordinates/transform/tica.py
@@ -255,6 +255,9 @@ class TICA(Transformer):
 
             # if we have a user-given mean, skip ipass 0 now:
             if self._given_mean:
+                if self._force_eigenvalues_le_one:
+                    self._logger.warning("Constraint of eigenvalues <= 1 is active,"
+                                         "so the mean also depends on the lag time!")
                 raise SkipPassException(self._lag)
 
             if self._force_eigenvalues_le_one:
@@ -380,7 +383,6 @@ class TICA(Transformer):
         # compute cumulative variance
         self.cumvar = np.cumsum(self.eigenvalues ** 2)
         self.cumvar /= self.cumvar[-1]
-
 
         if len(self._skipped_trajs) >= 1:
             self._skipped_trajs = np.asarray(self._skipped_trajs)


### PR DESCRIPTION
I introduced a new a new exception type (SkipPassException) to break the inner loops in Transformer.parametrize. In this case we can not simply return True in param_add_data, because this would terminate the whole parametrization routine.

Fixes #62, #331.
