### PR TITLE
[add_residue_mindist] gets residue_indices_2 argument

### DIFF
--- a/pyemma/coordinates/tests/test_featurizer.py
+++ b/pyemma/coordinates/tests/test_featurizer.py
@@ -360,9 +360,18 @@ class TestFeaturizer(unittest.TestCase):
 
     def test_Residue_Mindist_Ca_array(self):
         contacts=np.array([[20,10,], [10,0]])
-        self.feat.add_residue_mindist(scheme='ca', residue_pairs=contacts)
+        self.feat.add_residue_mindist(scheme='ca', residue_indices=contacts)
         D = self.feat.map(self.traj)
         Dref = mdtraj.compute_contacts(self.traj, scheme='ca', contacts=contacts)[0]
+        assert np.allclose(D, Dref)
+
+    def test_Residue_Mindist_Ca_groups_of_residues(self):
+        residue_group_1 = [1, 3]
+        residue_group_2 = [4, 4, 5, 6]
+        contacts=np.array(list(product(np.unique(residue_group_1), np.unique(residue_group_2))))
+        Dref = mdtraj.compute_contacts(self.traj, scheme='ca', contacts=contacts)[0]
+        self.feat.add_residue_mindist(scheme='ca', residue_indices=residue_group_1, residue_indices_2=residue_group_2)
+        D = self.feat.map(self.traj)
         assert np.allclose(D, Dref)
 
     def test_Group_Mindist_One_Group(self):


### PR DESCRIPTION
I think this is something like a feature request from @nsplattner . This extends the input mode for 
add_residue_mindist to make it easier to map situations where ligand-substrate are clearly defined. 

I'm aware we're not that convinced about the name of this feature, but that is another discussion. 

Please, @nsplattner , if this is not exactly what would help you most for the notebooks, let me know.
