### PR TITLE
[featurizer.pairs] opt arg excluded_neighbors added, default behaviour changed

### DIFF
--- a/pyemma/coordinates/data/featurizer.py
+++ b/pyemma/coordinates/data/featurizer.py
@@ -907,8 +907,6 @@ class MDFeaturizer(object):
 
                 iterable of integers (either list or ndarray(n, dtype=int)):
                     indices (not pairs of indices) of the atoms between which the distances shall be computed.
-                    Note that this will produce a pairlist different from the pairlist produced by :py:func:`pairs` in that this does not exclude
-                    1-2 neighbors.
 
         indices2: iterable of integers (either list or ndarray(n, dtype=int)), optional:
                     Only has effect if :py:obj:`indices` is an iterable of integers. Instead of the above behaviour,
@@ -934,7 +932,7 @@ class MDFeaturizer(object):
 
     def add_distances_ca(self, periodic=True):
         """
-        Adds the distances between all Ca's (except for 1- and 2-neighbors) to the feature list.
+        Adds the distances between all Ca's to the feature list.
 
         """
         distance_indexes = self.pairs(self.select_Ca())
@@ -957,8 +955,6 @@ class MDFeaturizer(object):
 
                 iterable of integers (either list or ndarray(n, dtype=int)):
                     indices (not pairs of indices) of the atoms between which the inverse distances shall be computed.
-                    Note that this will produce a pairlist different from the pairlist produced by :py:func:`pairs`
-                    in that this does not exclude 1-2 neighbors.
 
         indices2: iterable of integers (either list or ndarray(n, dtype=int)), optional:
                     Only has effect if :py:obj:`indices` is an iterable of integers. Instead of the above behaviour,
@@ -996,8 +992,6 @@ class MDFeaturizer(object):
 
                 iterable of integers (either list or ndarray(n, dtype=int)):
                     indices (not pairs of indices) of the atoms between which the contacts shall be computed.
-                    Note that this will produce a pairlist different from the pairlist produced by :py:func:`pairs` in that this does not exclude
-                    1-2 neighbors.
 
         indices2: iterable of integers (either list or ndarray(n, dtype=int)), optional:
                     Only has effect if :py:obj:`indices` is an iterable of integers. Instead of the above behaviour,

--- a/pyemma/coordinates/data/featurizer.py
+++ b/pyemma/coordinates/data/featurizer.py
@@ -808,23 +808,31 @@ class MDFeaturizer(object):
         return self.topology.select("mass >= 2")
 
     @staticmethod
-    def pairs(sel):
+    def pairs(sel, excluded_neighbors=2):
         """
-        Creates all pairs between indexes, except for 1 and 2-neighbors
+        Creates all pairs between indexes. Will except closest neighbors up to :py:obj:`excluded_neighbors`
+        (default is to exclude 1-2 and 1-3 and neighbors). The self-pair (i,i) is always excluded
 
         Parameters
         ----------
         sel : ndarray((n), dtype=int)
             array with selected atom indexes
 
-        Return:
+        excluded_neighbors: int, default = 2
+            number of neighbors that will be excluded when creating the pairs
+
+        Returns
         -------
         sel : ndarray((m,2), dtype=int)
-            m x 2 array with all pair indexes between different atoms that are at least 3 indexes apart,
-            i.e. if i is the index of an atom, the pairs [i,i-2], [i,i-1], [i,i], [i,i+1], [i,i+2], will
-            not be in sel. Moreover, the list is non-redundant, i.e. if [i,j] is in sel, then [j,i] is not.
+            m x 2 array with all pair indexes between different atoms that are at least :obj:`excluded_neighbors`
+            indexes apart, i.e. if i is the index of an atom, the pairs [i,i-n], [i,i-1], [i,i], [i,i+1], [i,i+n], will
+            not be in :py:obj:`sel` (n=excluded_neighbors). Moreover, the list is non-redundant,
+            i.e. if [i,j] is in sel, then [j,i] is not.
 
         """
+
+        assert isinstance(excluded_neighbors,int)
+
         p = []
         for i in range(len(sel)):
             for j in range(i + 1, len(sel)):
@@ -835,7 +843,7 @@ class MDFeaturizer(object):
                     I = sel[j]
                     J = sel[i]
                 # exclude 1 and 2 neighbors
-                if (J > I + 2):
+                if (J > I + excluded_neighbors):
                     p.append([I, J])
         return np.array(p)
 

--- a/pyemma/coordinates/data/featurizer.py
+++ b/pyemma/coordinates/data/featurizer.py
@@ -808,26 +808,26 @@ class MDFeaturizer(object):
         return self.topology.select("mass >= 2")
 
     @staticmethod
-    def pairs(sel, excluded_neighbors=2):
+    def pairs(sel, excluded_neighbors=0):
         """
         Creates all pairs between indexes. Will except closest neighbors up to :py:obj:`excluded_neighbors`
-        (default is to exclude 1-2 and 1-3 and neighbors). The self-pair (i,i) is always excluded
+        The self-pair (i,i) is always excluded
 
         Parameters
         ----------
         sel : ndarray((n), dtype=int)
             array with selected atom indexes
 
-        excluded_neighbors: int, default = 2
+        excluded_neighbors: int, default = 0
             number of neighbors that will be excluded when creating the pairs
 
         Returns
         -------
         sel : ndarray((m,2), dtype=int)
             m x 2 array with all pair indexes between different atoms that are at least :obj:`excluded_neighbors`
-            indexes apart, i.e. if i is the index of an atom, the pairs [i,i-n], [i,i-1], [i,i], [i,i+1], [i,i+n], will
-            not be in :py:obj:`sel` (n=excluded_neighbors). Moreover, the list is non-redundant,
-            i.e. if [i,j] is in sel, then [j,i] is not.
+            indexes apart, i.e. if i is the index of an atom, the pairs [i,i-2], [i,i-1], [i,i], [i,i+1], [i,i+2], will
+            not be in :py:obj:`sel` (n=excluded_neighbors) if :py:obj:`excluded_neighbors` = 2.
+            Moreover, the list is non-redundant,i.e. if [i,j] is in sel, then [j,i] is not.
 
         """
 

--- a/pyemma/coordinates/tests/test_featurizer.py
+++ b/pyemma/coordinates/tests/test_featurizer.py
@@ -128,7 +128,7 @@ class TestFeaturizer(unittest.TestCase):
     def test_distances(self):
         sel = np.array([1, 2, 5, 20], dtype=int)
         pairs_expected = np.array([[1, 5], [1, 20], [2, 5], [2, 20], [5, 20]])
-        pairs = self.feat.pairs(sel)
+        pairs = self.feat.pairs(sel, excluded_neighbors=2)
         assert(pairs.shape == pairs_expected.shape)
         assert(np.all(pairs == pairs_expected))
         self.feat.add_distances(pairs, periodic=False)  # unperiodic distances such that we can compare
@@ -141,7 +141,7 @@ class TestFeaturizer(unittest.TestCase):
     def test_inverse_distances(self):
         sel = np.array([1, 2, 5, 20], dtype=int)
         pairs_expected = np.array([[1, 5], [1, 20], [2, 5], [2, 20], [5, 20]])
-        pairs = self.feat.pairs(sel)
+        pairs = self.feat.pairs(sel, excluded_neighbors=2)
         assert(pairs.shape == pairs_expected.shape)
         assert(np.all(pairs == pairs_expected))
         self.feat.add_inverse_distances(pairs, periodic=False)  # unperiodic distances such that we can compare
@@ -154,7 +154,7 @@ class TestFeaturizer(unittest.TestCase):
     def test_ca_distances(self):
         sel = self.feat.select_Ca()
         assert(np.all(sel == range(self.traj.n_atoms)))  # should be all for this Ca-traj
-        pairs = self.feat.pairs(sel)
+        pairs = self.feat.pairs(sel, excluded_neighbors=0)
         self.feat.add_distances_ca(periodic=False)  # unperiodic distances such that we can compare
         assert(self.feat.dimension() == pairs.shape[0])
         X = self.traj.xyz[:, pairs[:, 0], :]
@@ -165,7 +165,7 @@ class TestFeaturizer(unittest.TestCase):
     def test_contacts(self):
         sel = np.array([1, 2, 5, 20], dtype=int)
         pairs_expected = np.array([[1, 5], [1, 20], [2, 5], [2, 20], [5, 20]])
-        pairs = self.feat.pairs(sel)
+        pairs = self.feat.pairs(sel, excluded_neighbors=2)
         assert(pairs.shape == pairs_expected.shape)
         assert(np.all(pairs == pairs_expected))
         self.feat.add_contacts(pairs, threshold=0.5, periodic=False)  # unperiodic distances such that we can compare
@@ -476,7 +476,7 @@ class TestFeaturizerNoDubs(unittest.TestCase):
 
         # try to fool it with ca selection
         ca = featurizer.select_Ca()
-        ca = featurizer.pairs(ca)
+        ca = featurizer.pairs(ca, excluded_neighbors=0)
         featurizer.add_distances(ca)
         self.assertEqual(len(featurizer.active_features), 4)
         featurizer.add_distances_ca()

--- a/pyemma/coordinates/tests/test_featurizer.py
+++ b/pyemma/coordinates/tests/test_featurizer.py
@@ -594,5 +594,30 @@ class TestPairwiseInputParser(unittest.TestCase):
                                             )))
         assert np.allclose(dist_list, _parse_pairwise_input(group1, group2, self.feat._logger))
 
+class TestStaticMethods(unittest.TestCase):
+
+    def setUp(self):
+        self.feat = MDFeaturizer(pdbfile)
+
+    def test_pairs(self):
+        n_at = 5
+        pairs = self.feat.pairs(np.arange(n_at), excluded_neighbors=3)
+        assert np.allclose(pairs, [0,4])
+
+        pairs = self.feat.pairs(np.arange(n_at), excluded_neighbors=2)
+        assert np.allclose(pairs, [[0,3],[0,4],
+                                   [1,4]])
+
+        pairs = self.feat.pairs(np.arange(n_at), excluded_neighbors=1)
+        assert np.allclose(pairs, [[0,2], [0,3],[0,4],
+                                   [1,3], [1,4],
+                                   [2,4]])
+
+        pairs = self.feat.pairs(np.arange(n_at), excluded_neighbors=0)
+        assert np.allclose(pairs, [[0,1], [0,2], [0,3],[0,4],
+                                   [1,2], [1,3], [1,4],
+                                   [2,3], [2,4],
+                                   [3,4]])
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This closes #478. @franknoe , if I set default exclusions=0 tests break. Might be that people are already using it that way. I'd suggest we leave it like this for now. The entire "pairwise_parse" area will be a bit of construction site once I have more time (hTICA needs very good handling of this)
