### PR TITLE
[msm] removed some imports to pyemma.msm.* which moved to msmtools.

### DIFF
--- a/pyemma/coordinates/clustering/interface.py
+++ b/pyemma/coordinates/clustering/interface.py
@@ -225,9 +225,9 @@ class AbstractClustering(Transformer):
 
         # obtain filenames from input (if possible, reader is a featurereader)
         if output_format == 'ascii':
-            from pyemma.msm.io import write_discrete_trajectory as write_dtraj
+            from msmtools.dtraj import write_discrete_trajectory as write_dtraj
         else:
-            from pyemma.msm.io import save_discrete_trajectory as write_dtraj
+            from msmtools.dtraj import save_discrete_trajectory as write_dtraj
         import os.path as path
 
         output_files = []

--- a/pyemma/msm/estimators/_dtraj_stats.py
+++ b/pyemma/msm/estimators/_dtraj_stats.py
@@ -2,7 +2,7 @@ __author__ = 'noe'
 
 import numpy as np
 
-from pyemma.msm import estimation as msmest
+from msmtools import estimation as msmest
 from pyemma.util.annotators import shortcut
 from pyemma.util.linalg import submatrix
 from pyemma.util.discrete_trajectories import visited_set
@@ -22,8 +22,7 @@ class DiscreteTrajectoryStats(object):
         # discrete trajectories
         self._dtrajs = ensure_dtraj_list(dtrajs)
 
-        # basic count statistics
-        import pyemma.msm.estimation as msmest
+        ## basic count statistics
         # histogram
         self._hist = msmest.count_states(self._dtrajs)
         # total counts

--- a/pyemma/msm/estimators/bayesian_hmsm.py
+++ b/pyemma/msm/estimators/bayesian_hmsm.py
@@ -127,7 +127,7 @@ class BayesianHMSM(_MaximumLikelihoodHMSM, _SampledHMSM, ProgressReporter):
         # here we blow up the output matrix (if needed) to the FULL state space because we want to use dtrajs in the
         # Bayesian HMM sampler
         if self.observe_active:
-            import pyemma.msm.estimation as msmest
+            import msmtools.estimation as msmest
             nstates_full = msmest.number_of_states(dtrajs)
             # pobs = _np.zeros((init_hmsm.nstates, nstates_full))  # currently unused because that produces zero cols
             eps = 0.01 / nstates_full  # default output probability, in order to avoid zero columns

--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -1,10 +1,10 @@
 __author__ = 'noe'
 
 import numpy as np
+from msmtools import estimation as msmest
 
 from pyemma.util.types import ensure_dtraj_list
 from pyemma._base.estimator import Estimator as _Estimator
-from pyemma.msm import estimation as msmest
 from pyemma.msm.estimators._dtraj_stats import DiscreteTrajectoryStats as _DiscreteTrajectoryStats
 from pyemma.msm.estimators.estimated_msm import EstimatedMSM as _EstimatedMSM
 from pyemma.util.units import TimeUnit

--- a/pyemma/msm/models/hmsm_sampled.py
+++ b/pyemma/msm/models/hmsm_sampled.py
@@ -97,7 +97,7 @@ class SampledHMSM(_HMSM, _SampledModel):
     #     Stores all eigenvalues, left and right eigenvectors for all sampled matrices
     #
     #     """
-    #     from pyemma.msm.analysis import rdl_decomposition
+    #     from msmtools.analysis import rdl_decomposition
     #     from pyemma.util import linalg
     #
     #     # left eigenvectors

--- a/pyemma/msm/models/msm.py
+++ b/pyemma/msm/models/msm.py
@@ -136,10 +136,10 @@ class MSM(_Model):
         list of this function (by mandatory or keyword arguments)
 
         """
-        import pyemma.msm.analysis as msmana
+        import msmtools.analysis as msmana
         # check input
         if P is not None:
-            import pyemma.msm.estimation as msmest
+            import msmtools.estimation as msmest
             if not msmana.is_transition_matrix(P):
                 raise ValueError('T is not a transition matrix.')
             # check connectivity
@@ -232,13 +232,13 @@ class MSM(_Model):
         if self.pi is not None:
             return self.pi
         else:
-            from pyemma.msm.analysis import stationary_distribution as _statdist
+            from msmtools.analysis import stationary_distribution as _statdist
             self.pi = _statdist(self.transition_matrix)
             return self.pi
 
     def _compute_eigenvalues(self, neig):
         """ Conducts the eigenvalue decomposition and stores k eigenvalues, left and right eigenvectors """
-        from pyemma.msm.analysis import eigenvalues as anaeig
+        from msmtools.analysis import eigenvalues as anaeig
 
         if self.reversible:
             self._eigenvalues = anaeig(self.transition_matrix, k=neig, ncv=self.ncv,
@@ -262,7 +262,7 @@ class MSM(_Model):
 
     def _compute_eigendecomposition(self, neig):
         """ Conducts the eigenvalue decomposition and stores k eigenvalues, left and right eigenvectors """
-        from pyemma.msm.analysis import rdl_decomposition
+        from msmtools.analysis import rdl_decomposition
 
         if self.reversible:
             self._R, self._D, self._L = rdl_decomposition(self.transition_matrix, norm='reversible',
@@ -373,7 +373,7 @@ class MSM(_Model):
             self._ensure_eigenvalues()
         else:
             self._ensure_eigenvalues(neig=k+1)
-        from pyemma.msm.analysis.dense.decomposition import timescales_from_eigenvalues as _timescales
+        from msmtools.analysis.dense.decomposition import timescales_from_eigenvalues as _timescales
 
         ts = _timescales(self._eigenvalues, tau=self._timeunit_model.dt)
         if k is None:
@@ -442,7 +442,7 @@ class MSM(_Model):
     def _mfpt(self, P, A, B, mu=None):
         self._assert_in_active(A)
         self._assert_in_active(B)
-        from pyemma.msm.analysis import mfpt as __mfpt
+        from msmtools.analysis import mfpt as __mfpt
         # scale mfpt by lag time
         return self._timeunit_model.dt * __mfpt(P, B, origin=A, mu=mu)
 
@@ -461,7 +461,7 @@ class MSM(_Model):
     def _committor_forward(self, P, A, B):
         self._assert_in_active(A)
         self._assert_in_active(B)
-        from pyemma.msm.analysis import committor as __committor
+        from msmtools.analysis import committor as __committor
         return __committor(P, A, B, forward=True)
 
     def committor_forward(self, A, B):
@@ -479,7 +479,7 @@ class MSM(_Model):
     def _committor_backward(self, P, A, B, mu=None):
         self._assert_in_active(A)
         self._assert_in_active(B)
-        from pyemma.msm.analysis import committor as __committor
+        from msmtools.analysis import committor as __committor
         return __committor(P, A, B, forward=False, mu=mu)
 
     def committor_backward(self, A, B):
@@ -618,7 +618,7 @@ class MSM(_Model):
             maxtime = 5 * self.timescales()[0]
         steps = np.arange(int(ceil(float(maxtime) / self._timeunit_model.dt)))
         # compute correlation
-        from pyemma.msm.analysis import correlation as _correlation
+        from msmtools.analysis import correlation as _correlation
         # TODO: this could be improved. If we have already done an eigenvalue decomposition, we could provide it.
         # TODO: for this, the correlation function must accept already-available eigenvalue decompositions.
         res = _correlation(self.transition_matrix, a, obs2=b, times=steps, k=k, ncv=ncv)
@@ -661,7 +661,7 @@ class MSM(_Model):
         # input checking is done in low-level API
         # TODO: this could be improved. If we have already done an eigenvalue decomposition, we could provide it.
         # TODO: for this, the correlation function must accept already-available eigenvalue decompositions.
-        from pyemma.msm.analysis import fingerprint_correlation as _fc
+        from msmtools.analysis import fingerprint_correlation as _fc
         return _fc(self.transition_matrix, a, obs2=b, tau=self._timeunit_model.dt, k=k, ncv=ncv)
 
     def relaxation(self, p0, a, maxtime=None, k=None, ncv=None):
@@ -736,7 +736,7 @@ class MSM(_Model):
         kmax = int(ceil(float(maxtime) / self._timeunit_model.dt))
         steps = np.array(range(kmax), dtype=int)
         # compute relaxation function
-        from pyemma.msm.analysis import relaxation as _relaxation
+        from msmtools.analysis import relaxation as _relaxation
         # TODO: this could be improved. If we have already done an eigenvalue decomposition, we could provide it.
         # TODO: for this, the correlation function must accept already-available eigenvalue decompositions.
         res = _relaxation(self.transition_matrix, p0, a, times=steps, k=k, ncv=ncv)
@@ -782,7 +782,7 @@ class MSM(_Model):
         # input checking is done in low-level API
         # TODO: this could be improved. If we have already done an eigenvalue decomposition, we could provide it.
         # TODO: for this, the correlation function must accept already-available eigenvalue decompositions.
-        from pyemma.msm.analysis import fingerprint_relaxation as _fr
+        from msmtools.analysis import fingerprint_relaxation as _fr
         return _fr(self.transition_matrix, p0, a, tau=self._timeunit_model.dt, k=k, ncv=ncv)
 
     ################################################################################
@@ -812,7 +812,7 @@ class MSM(_Model):
 
         Returns
         -------
-        pcca_obj : :class:`PCCA <pyemma.msm.analysis.dense.pcca.PCCA>`
+        pcca_obj : :class:`PCCA <msmtools.analysis.dense.pcca.PCCA>`
             An object containing all PCCA quantities. However, you can also ingore this return value and instead
             retrieve the quantities of your interest with the following MSM functions: :func:`metastable_memberships`,
             :func:`metastable_distributions`, :func:`metastable_sets` and :func:`metastable_assignments`.
@@ -830,7 +830,7 @@ class MSM(_Model):
             raise ValueError(
                 'Cannot compute PCCA for non-reversible matrices. Set reversible=True when constructing the MSM.')
 
-        from pyemma.msm.analysis.dense.pcca import PCCA
+        from msmtools.analysis.dense.pcca import PCCA
         # ensure that we have a pcca object with the right number of states
         try:
             # this will except if we don't have a pcca object

--- a/pyemma/msm/models/msm_sampled.py
+++ b/pyemma/msm/models/msm_sampled.py
@@ -93,7 +93,7 @@ class SampledMSM(MSM, SampledModel):
 #             it is recommended that ncv > 2*k
 #
 #         """
-#         from pyemma.msm.analysis import rdl_decomposition
+#         from msmtools.analysis import rdl_decomposition
 #         from pyemma.util import linalg
 #
 #         # left eigenvectors

--- a/pyemma/msm/tests/test_bayesian_hmsm.py
+++ b/pyemma/msm/tests/test_bayesian_hmsm.py
@@ -39,13 +39,13 @@ class TestBHMM(unittest.TestCase):
         # shape
         assert np.array_equal(np.shape(Psamples), (self.nsamples, self.nstates, self.nstates))
         # consistency
-        import pyemma.msm.analysis as msmana
+        import msmtools.analysis as msmana
         for P in Psamples:
             assert msmana.is_transition_matrix(P)
             assert msmana.is_reversible(P)
 
     def test_transition_matrix_stats(self):
-        import pyemma.msm.analysis as msmana
+        import msmtools.analysis as msmana
         # mean
         Pmean = self.sampled_hmm_lag10.sample_mean('transition_matrix')
         # test shape and consistency

--- a/pyemma/msm/tests/test_bayesian_msm.py
+++ b/pyemma/msm/tests/test_bayesian_msm.py
@@ -39,13 +39,13 @@ class TestBMSM(unittest.TestCase):
         # shape
         assert np.array_equal(np.shape(Psamples), (self.nsamples, self.nstates, self.nstates))
         # consistency
-        import pyemma.msm.analysis as msmana
+        import msmtools.analysis as msmana
         for P in Psamples:
             assert msmana.is_transition_matrix(P)
             assert msmana.is_reversible(P)
 
     def test_transition_matrix_stats(self):
-        import pyemma.msm.analysis as msmana
+        import msmtools.analysis as msmana
         # mean
         Pmean = self.sampled_msm_lag100.sample_mean('transition_matrix')
         # test shape and consistency

--- a/pyemma/msm/tests/test_cktest.py
+++ b/pyemma/msm/tests/test_cktest.py
@@ -33,8 +33,8 @@ import unittest
 import numpy as np
 
 from pyemma import msm
-from pyemma.msm.generation import generate_traj
-from pyemma.msm.estimation import count_matrix, largest_connected_set, largest_connected_submatrix, transition_matrix
+from msmtools.generation import generate_traj
+from msmtools.estimation import count_matrix, largest_connected_set, largest_connected_submatrix, transition_matrix
 from pyemma.util.numeric import assert_allclose
 from pyemma.msm.tests.birth_death_chain import BirthDeathChain
 from pyemma.msm import estimate_markov_model

--- a/pyemma/msm/tests/test_hmsm.py
+++ b/pyemma/msm/tests/test_hmsm.py
@@ -4,13 +4,9 @@ Test MLHMM.
 """
 
 import unittest
-from os.path import abspath, join
-from os import pardir
-
 import numpy as np
-
 from pyemma import msm
-from pyemma.msm import analysis as msmana
+from msmtools import analysis as msmana
 
 
 class TestMLHMM(unittest.TestCase):
@@ -52,7 +48,7 @@ class TestMLHMM(unittest.TestCase):
         assert self.hmsm_lag10.nstates == 2
 
     def test_transition_matrix(self):
-        import pyemma.msm.analysis as msmana
+        import msmtools.analysis as msmana
         for P in [self.hmsm_lag1.transition_matrix, self.hmsm_lag1.transition_matrix]:
             assert msmana.is_transition_matrix(P)
             assert msmana.is_reversible(P)

--- a/pyemma/msm/tests/test_its.py
+++ b/pyemma/msm/tests/test_its.py
@@ -31,7 +31,7 @@ r"""Unit test for the its method
 import unittest
 import numpy as np
 from pyemma import msm
-from pyemma.msm.analysis import timescales
+from msmtools.analysis import timescales
 from pyemma.msm.api import timescales_msm
 
 

--- a/pyemma/msm/tests/test_msm.py
+++ b/pyemma/msm/tests/test_msm.py
@@ -39,8 +39,8 @@ from os.path import abspath, join
 from os import pardir
 
 from pyemma.msm.generation import generate_traj
-from pyemma.msm.estimation import count_matrix, largest_connected_set, largest_connected_submatrix, transition_matrix
-from pyemma.msm.analysis import stationary_distribution, timescales
+from msmtools.estimation import count_matrix, largest_connected_set, largest_connected_submatrix, transition_matrix
+from msmtools.analysis import stationary_distribution, timescales
 from pyemma.util.numeric import assert_allclose
 from pyemma.msm.tests.birth_death_chain import BirthDeathChain
 from pyemma.msm import estimate_markov_model
@@ -269,7 +269,7 @@ class TestMSMDoubleWell(unittest.TestCase):
         # shape
         assert (np.all(P.shape == (msm.nstates, msm.nstates)))
         # test transition matrix properties
-        import pyemma.msm.analysis as msmana
+        import msmtools.analysis as msmana
 
         assert (msmana.is_transition_matrix(P))
         assert (msmana.is_connected(P))

--- a/pyemma/msm/tests/test_tpt.py
+++ b/pyemma/msm/tests/test_tpt.py
@@ -34,7 +34,7 @@ import numpy as np
 from pyemma.util.numeric import assert_allclose
 
 from pyemma.msm import markov_model, tpt
-import pyemma.msm.analysis as msmana
+import msmtools.analysis as msmana
 
 
 class TestReactiveFluxFunctions(unittest.TestCase):


### PR DESCRIPTION
Also show a deprecation warning, if a deprecated module is being imported from pyemma.
