### PR TITLE
[util/annotators] simplified and extended shortcut. Added new impl for class method aliases.

### DIFF
--- a/pyemma/msm/estimators/_dtraj_stats.py
+++ b/pyemma/msm/estimators/_dtraj_stats.py
@@ -3,11 +3,11 @@ __author__ = 'noe'
 import numpy as np
 
 from msmtools import estimation as msmest
-from pyemma.util.annotators import shortcut
+from pyemma.util.annotators import alias, aliased
 from pyemma.util.linalg import submatrix
 from pyemma.util.discrete_trajectories import visited_set
 
-
+@aliased
 class DiscreteTrajectoryStats(object):
     r""" Statistics, count matrices and connectivity from discrete trajectories
 
@@ -118,7 +118,7 @@ class DiscreteTrajectoryStats(object):
         return self._nstates
 
     @property
-    @shortcut('dtrajs')
+    @alias('dtrajs')
     def discrete_trajectories(self):
         """
         A list of integer arrays with the original (unmapped) discrete trajectories:
@@ -131,7 +131,7 @@ class DiscreteTrajectoryStats(object):
         return self._hist.sum()
 
     @property
-    @shortcut('hist')
+    @alias('hist')
     def histogram(self):
         r""" Histogram of discrete state counts
 
@@ -196,7 +196,7 @@ class DiscreteTrajectoryStats(object):
 
         return C
 
-    @shortcut('hist_lagged')
+    @alias('hist_lagged')
     def histogram_lagged(self, connected_set=None, subset=None, effective=False):
         r""" Histogram of discrete state counts
 

--- a/pyemma/msm/estimators/estimated_hmsm.py
+++ b/pyemma/msm/estimators/estimated_hmsm.py
@@ -36,9 +36,9 @@ __docformat__ = "restructuredtext en"
 import numpy as _np
 
 from pyemma.msm.models.hmsm import HMSM as _HMSM
-from pyemma.util.annotators import shortcut
+from pyemma.util.annotators import alias, aliased
 
-
+@aliased
 class EstimatedHMSM(_HMSM):
 
     def __init__(self, dtrajs_full, dtrajs_lagged, dt_model, lagtime, nstates_obs, observable_set, dtrajs_obs,
@@ -78,7 +78,7 @@ class EstimatedHMSM(_HMSM):
         return self._observable_set
 
     @property
-    @shortcut('dtrajs_full')
+    @alias('dtrajs_full')
     def discrete_trajectories_full(self):
         """
         A list of integer arrays with the original trajectories.
@@ -87,7 +87,7 @@ class EstimatedHMSM(_HMSM):
         return self._dtrajs_full
 
     @property
-    @shortcut('dtrajs_lagged')
+    @alias('dtrajs_lagged')
     def discrete_trajectories_lagged(self):
         """
         Transformed original trajectories that are used as an input into the HMM estimation
@@ -96,7 +96,7 @@ class EstimatedHMSM(_HMSM):
         return self._dtrajs_lagged
 
     @property
-    @shortcut('dtrajs_obs')
+    @alias('dtrajs_obs')
     def discrete_trajectories_obs(self):
         """
         A list of integer arrays with the discrete trajectories mapped to the observation mode used.

--- a/pyemma/msm/estimators/estimated_msm.py
+++ b/pyemma/msm/estimators/estimated_msm.py
@@ -5,10 +5,10 @@ import copy
 import numpy as np
 
 from pyemma.msm.models.msm import MSM
-from pyemma.util.annotators import shortcut
+from pyemma.util.annotators import alias, aliased
 from pyemma.util.units import TimeUnit
 
-
+@aliased
 class EstimatedMSM(MSM):
     r"""Estimates a Markov model from discrete trajectories.
 
@@ -140,7 +140,7 @@ class EstimatedMSM(MSM):
         return self._connected_sets
 
     @property
-    @shortcut('dtrajs_full')
+    @alias('dtrajs_full')
     def discrete_trajectories_full(self):
         """
         A list of integer arrays with the original (unmapped) discrete trajectories:
@@ -150,7 +150,7 @@ class EstimatedMSM(MSM):
         return self._dtrajs_full
 
     @property
-    @shortcut('dtrajs_active')
+    @alias('dtrajs_active')
     def discrete_trajectories_active(self):
         """
         A list of integer arrays with the discrete trajectories mapped to the connectivity mode used.
@@ -358,7 +358,7 @@ class EstimatedMSM(MSM):
         # TODO: frames. Anyway, this is a nontrivial issue.
         self._check_is_estimated()
         # generate synthetic states
-        from pyemma.msm.generation import generate_traj as _generate_traj
+        from msmtools.generation import generate_traj as _generate_traj
 
         syntraj = _generate_traj(self.transition_matrix, N, start=start, stop=stop, dt=stride)
         # result

--- a/pyemma/util/discrete_trajectories.py
+++ b/pyemma/util/discrete_trajectories.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2015, 2014 Computational Molecular Biology Group, Free University
 # Berlin, 14195 Berlin, Germany.
 # All rights reserved.
@@ -22,11 +21,6 @@
 # ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-__author__ = 'noe'
-
-from pyemma.util.types import ensure_dtraj_list as _ensure_dtraj_list
-
 r"""This module implements IO and manipulation function for discrete trajectories
 
 Discrete trajectories are generally ndarrays of type integer
@@ -36,11 +30,11 @@ We store them either as single column ascii files or as ndarrays of shape (n,) i
 .. moduleauthor:: F. Noe <frank DOT noe AT fu-berlin DOT de>
 
 """
-
 import numpy as np
-
-from pyemma.util.annotators import shortcut
 from pyemma.util.types import ensure_dtraj_list as _ensure_dtraj_list
+from pyemma.util.annotators import shortcut
+
+__author__ = 'noe'
 
 ################################################################################
 # ascii

--- a/pyemma/util/tests/test_shortcut.py
+++ b/pyemma/util/tests/test_shortcut.py
@@ -23,17 +23,41 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from pyemma.util.annotators import shortcut
+
+from __future__ import absolute_import
+from pyemma.util.annotators import shortcut, aliased, alias
 import unittest
 
-@shortcut("bar")
+@shortcut("bar", "bar2")
 def foo():
     """ sample docstring"""
     return True
 
-class TestShortcut(unittest.TestCase):
+@aliased
+class Foo(object):
+    @alias("bar2", "bar3")
+    def bar(self):
+        """ doc """
+        pass
+
+class TestShortcut_and_Aliases(unittest.TestCase):
 
     def test_shortcut(self):
-        self.assertEqual( bar.__doc__ , foo.__doc__)
+        self.assertEqual(bar.__doc__, foo.__doc__)
         result = bar()
         self.assertTrue(result)
+        
+        self.assertEqual(bar2.__doc__, foo.__doc__)
+        result = bar2()
+        self.assertTrue(result)
+
+    def test_alias_class(self):
+        assert hasattr(Foo, "bar3")
+        assert hasattr(Foo, "bar3")
+
+    def test_alias_class_inst(self):
+        inst = Foo()
+        assert hasattr(inst, "bar2")
+        assert hasattr(inst, "bar3")
+        self.assertEqual(inst.bar.__doc__, inst.bar2.__doc__)
+


### PR DESCRIPTION
- shortcut decorator may only be used for functions
- alias/aliased decorators are only for use with classes

Due to my research, there is no reliably working way (at least if one wants to support multiple python versions) to determine if a function is a class member, **before** one has an instance of this class. Since we want these aliases before instance creation, this is the only way it can work.

Above Python3.3 there is a way to obtain the class of an unbound method, but all prior versions lack the language features to obtain it (easily). Dirty hacks are not desired. 
