### PR TITLE
Fix joblib callback problem progressbars

### DIFF
--- a/pyemma/msm/api.py
+++ b/pyemma/msm/api.py
@@ -59,7 +59,7 @@ __all__ = ['markov_model',
 
 @shortcut('its')
 def timescales_msm(dtrajs, lags=None, nits=None, reversible=True, connected=True,
-                   errors=None, nsamples=50, n_jobs=1):
+                   errors=None, nsamples=50, n_jobs=1, show_progress=True):
     # format data
     r""" Calculate implied timescales from Markov state models estimated at a series of lag times.
 
@@ -177,12 +177,14 @@ def timescales_msm(dtrajs, lags=None, nits=None, reversible=True, connected=True
     if errors is None:
         estimator = _ML_MSM(reversible=reversible, connectivity=connectivity)
     elif errors == 'bayes':
-        estimator = _Bayes_MSM(reversible=reversible, connectivity=connectivity, nsamples=nsamples)
+        estimator = _Bayes_MSM(reversible=reversible, connectivity=connectivity,
+                               nsamples=nsamples, show_progress=show_progress)
     else:
         raise NotImplementedError('Error estimation method'+errors+'currently not implemented')
 
     # go
-    itsobj = _ImpliedTimescales(estimator, lags=lags, nits=nits, n_jobs=n_jobs)
+    itsobj = _ImpliedTimescales(estimator, lags=lags, nits=nits, n_jobs=n_jobs,
+                                show_progress=show_progress)
     itsobj.estimate(dtrajs)
     return itsobj
 
@@ -480,7 +482,8 @@ def estimate_markov_model(dtrajs, lag, reversible=True, sparse=False, connectivi
 
 
 def timescales_hmsm(dtrajs, nstates, lags=None, nits=None, reversible=True,
-                    connected=True, errors=None, nsamples=100, n_jobs=1):
+                    connected=True, errors=None, nsamples=100, n_jobs=1,
+                    show_progress=True):
     r""" Calculate implied timescales from Hidden Markov state models estimated at a series of lag times.
 
     Warning: this can be slow!
@@ -520,6 +523,9 @@ def timescales_hmsm(dtrajs, nstates, lags=None, nits=None, reversible=True,
 
     n_jobs = 1 : int
         how many subprocesses to start to estimate the models for each lag time.
+
+    show_progress : bool, default=True
+        Show progressbars for calculation?
 
     Returns
     -------
@@ -579,14 +585,18 @@ def timescales_hmsm(dtrajs, nstates, lags=None, nits=None, reversible=True,
     if errors is None:
         estimator = _ML_HMSM(nstates=nstates, reversible=reversible, connectivity=connectivity)
     elif errors == 'bayes':
-        estimator = _Bayes_HMSM(nstates=nstates, reversible=reversible, connectivity=connectivity)
+        estimator = _Bayes_HMSM(nstates=nstates, reversible=reversible,
+                                connectivity=connectivity,
+                                show_progress=show_progress)
     else:
-        raise NotImplementedError('Error estimation method'+errors+'currently not implemented')
+        raise NotImplementedError('Error estimation method'+str(errors)+'currently not implemented')
 
     # go
-    itsobj = _ImpliedTimescales(estimator, lags=lags, nits=nits, n_jobs=n_jobs)
+    itsobj = _ImpliedTimescales(estimator, lags=lags, nits=nits, n_jobs=n_jobs,
+                                show_progress=show_progress)
     itsobj.estimate(dtrajs)
     return itsobj
+
 
 def estimate_hidden_markov_model(dtrajs, nstates, lag, reversible=True, connectivity='largest', observe_active=True,
                                  dt_traj='1 step', accuracy=1e-3, maxit=1000):
@@ -761,7 +771,7 @@ def estimate_hidden_markov_model(dtrajs, nstates, lag, reversible=True, connecti
 
 
 def bayesian_markov_model(dtrajs, lag, reversible=True, sparse=False, connectivity='largest',
-                          nsamples=100, conf=0.95, dt_traj='1 step'):
+                          nsamples=100, conf=0.95, dt_traj='1 step', show_progress=True):
     r""" Bayesian Markov model estimate using Gibbs sampling of the posterior
 
     Returns a :class:`SampledMSM <pyemma.msm.models.SampledMSM>` that contains the
@@ -828,6 +838,9 @@ def bayesian_markov_model(dtrajs, lag, reversible=True, sparse=False, connectivi
         |  'us',  'microsecond*'
         |  'ms',  'millisecond*'
         |  's',   'second*'
+
+    show_progress : bool, default=True
+        Show progressbars for calculation?
 
     Returns
     -------
@@ -919,12 +932,13 @@ def bayesian_markov_model(dtrajs, lag, reversible=True, sparse=False, connectivi
     """
     # TODO: store_data=True
     bmsm_estimator = _Bayes_MSM(lag=lag, reversible=reversible, sparse=sparse, connectivity=connectivity,
-                                dt_traj=dt_traj, nsamples=nsamples, conf=conf)
+                                dt_traj=dt_traj, nsamples=nsamples, conf=conf, show_progress=show_progress)
     return bmsm_estimator.estimate(dtrajs)
 
 
 def bayesian_hidden_markov_model(dtrajs, nstates, lag, nsamples=100, reversible=True, connectivity='largest',
-                                 observe_active=True, conf=0.95, dt_traj='1 step'):
+                                 observe_active=True, conf=0.95, dt_traj='1 step',
+                                 show_progress=True):
     r""" Bayesian Hidden Markov model estimate using Gibbs sampling of the posterior
 
     Returns a :class:`SampledHMSM <pyemma.msm.model.SampledHMSM>` that contains
@@ -990,6 +1004,9 @@ def bayesian_hidden_markov_model(dtrajs, nstates, lag, nsamples=100, reversible=
         |  'us',  'microsecond*'
         |  'ms',  'millisecond*'
         |  's',   'second*'
+
+    show_progress : bool, default=True
+        Show progressbars for calculation?
 
     Returns
     -------
@@ -1058,7 +1075,8 @@ def bayesian_hidden_markov_model(dtrajs, nstates, lag, nsamples=100, reversible=
 
     """
     bhmsm_estimator = _Bayes_HMSM(lag=lag, nstates=nstates, nsamples=nsamples, reversible=reversible,
-                                  connectivity=connectivity, observe_active=observe_active, dt_traj=dt_traj, conf=conf)
+                                  connectivity=connectivity, observe_active=observe_active,
+                                  dt_traj=dt_traj, conf=conf, show_progress=show_progress)
     return bhmsm_estimator.estimate(dtrajs)
 
 # TODO: need code examples
@@ -1078,23 +1096,23 @@ def tpt(msmobj, A, B):
         List of integer state labels for set A
     B : array_like
         List of integer state labels for set B
-        
+
     Returns
     -------
     tptobj : :class:`ReactiveFlux <pyemma.msm.flux.ReactiveFlux>` object
         A python object containing the reactive A->B flux network
         and several additional quantities, such as stationary probability,
         committors and set definitions.
-        
+
     Notes
     -----
     The central object used in transition path theory is
     the forward and backward committor function.
-    
+
     TPT (originally introduced in [1]_) for continuous systems has a
     discrete version outlined in [2]_. Here, we use the transition
     matrix formulation described in [3]_.
-    
+
 
     .. autoclass:: pyemma.msm.flux.reactive_flux.ReactiveFlux
         :members:
@@ -1140,7 +1158,7 @@ def tpt(msmobj, A, B):
     Examples
     --------
 
-        
+
     """
     T = msmobj.transition_matrix
     mu = msmobj.stationary_distribution

--- a/pyemma/msm/estimators/bayesian_msm.py
+++ b/pyemma/msm/estimators/bayesian_msm.py
@@ -92,14 +92,18 @@ class BayesianMSM(_MLMSM, _SampledMSM, ProgressReporter):
         Confidence interval. By default one-sigma (68.3%) is used. Use 95.4%
         for two sigma or 99.7% for three sigma.
 
+    show_progress : bool, default=True
+        Show progressbars for calculation?
+
     """
     def __init__(self, lag=1, nsamples=100, nsteps=None, reversible=True, count_mode='effective', sparse=False,
-                 connectivity='largest', dt_traj='1 step', conf=0.95):
+                 connectivity='largest', dt_traj='1 step', conf=0.95, show_progress=True):
         _MLMSM.__init__(self, lag=lag, reversible=reversible, count_mode=count_mode, sparse=sparse,
                         connectivity=connectivity, dt_traj=dt_traj)
         self.nsamples = nsamples
         self.nsteps = nsteps
         self.conf = conf
+        self.show_progress = show_progress
 
     def _estimate(self, dtrajs):
         """
@@ -130,10 +134,13 @@ class BayesianMSM(_MLMSM, _SampledMSM, ProgressReporter):
         tsampler = tmatrix_sampler(self.count_matrix_active, reversible=self.reversible, T0=self.transition_matrix,
                                    nsteps=self.nsteps)
 
-        self._progress_register(self.nsamples, description="Sampling models", stage=0)
+        self._progress_register(self.nsamples, description="Sampling MSMs", stage=0)
 
-        def call_back():
-            self._progress_update(1, stage=0)
+        if self.show_progress:
+            def call_back():
+                self._progress_update(1, stage=0)
+        else:
+            call_back = None
 
         sample_Ps, sample_mus = tsampler.sample(nsamples=self.nsamples,
                                                 return_statdist=True,

--- a/pyemma/msm/estimators/maximum_likelihood_hmsm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_hmsm.py
@@ -262,7 +262,7 @@ class MaximumLikelihoodHMSM(_Estimator, _EstimatedHMSM):
 
         return self
 
-    def cktest(self, mlags=10, conf=0.95, err_est=False):
+    def cktest(self, mlags=10, conf=0.95, err_est=False, show_progress=True):
         """ Conducts a Chapman-Kolmogorow test.
 
         Parameters
@@ -278,6 +278,8 @@ class MaximumLikelihoodHMSM(_Estimator, _EstimatedHMSM):
             compute errors also for all estimations (computationally expensive)
             If False, only the prediction will get error bars, which is often
             sufficient to validate a model.
+        show_progress : bool, default=True
+            Show progressbars for calculation?
 
 
         References
@@ -296,6 +298,8 @@ class MaximumLikelihoodHMSM(_Estimator, _EstimatedHMSM):
 
         """
         from pyemma.msm.estimators import ChapmanKolmogorovValidator
-        ck = ChapmanKolmogorovValidator(self, self, np.eye(self.nstates), mlags=mlags, conf=conf, err_est=err_est)
+        ck = ChapmanKolmogorovValidator(self, self, np.eye(self.nstates),
+                                        mlags=mlags, conf=conf, err_est=err_est,
+                                        show_progress=show_progress)
         ck.estimate(self._dtrajs_full)
         return ck

--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -208,7 +208,8 @@ class MaximumLikelihoodMSM(_Estimator, _EstimatedMSM):
 
         return self
 
-    def cktest(self, nsets, memberships=None, mlags=10, conf=0.95, err_est=False):
+    def cktest(self, nsets, memberships=None, mlags=10, conf=0.95, err_est=False,
+               show_progress=True):
         """ Conducts a Chapman-Kolmogorow test.
 
         Parameters
@@ -229,7 +230,8 @@ class MaximumLikelihoodMSM(_Estimator, _EstimatedMSM):
             compute errors also for all estimations (computationally expensive)
             If False, only the prediction will get error bars, which is often
             sufficient to validate a model.
-
+        show_progress : bool, default=True
+            Show progressbars for calculation?
 
         References
         ----------

--- a/setup.py
+++ b/setup.py
@@ -239,7 +239,7 @@ metadata = dict(
                       'matplotlib',
                       'msmtools',
                       'bhmm',
-                      'joblib',
+                      'joblib==0.8.4',
                       ],
     zip_safe=False,
 )


### PR DESCRIPTION
- for n_jobs=1 no progressbars was shown
- added possibilty to hide progress of individual objects (was actually introduced as a workaround for hiding them in estimate_param_scan, which clones estimators and only takes ctor variables into account).
- auto-hiding works for all progressbars (needed to call _progress_force_finish(stage) to accomplish).
