### PR TITLE
[LogHandling] Garbage collect unused Logger instances.

### DIFF
--- a/pyemma/_base/estimator.py
+++ b/pyemma/_base/estimator.py
@@ -23,13 +23,15 @@ import inspect
 
 from pyemma._ext.sklearn.base import BaseEstimator as _BaseEstimator
 from pyemma._ext.sklearn.parameter_search import ParameterGrid
-from pyemma.util.log import getLogger
 from pyemma.util import types as _types
 
 # imports for external usage
 from pyemma._ext.sklearn.base import clone as clone_estimator
+from pyemma._base.logging import create_logger, instance_name
+from itertools import count
 
-__author__ = 'noe'
+__author__ = 'noe, marscher'
+
 
 def get_estimator(estimator):
     """ Returns an estimator object given an estimator object or class
@@ -296,19 +298,26 @@ class Estimator(_BaseEstimator):
     """ Base class for pyEMMA estimators
 
     """
+    # counting estimator instances, incremented by name property.
+    _ids = count(0)
 
-    def __create_logger(self):
-        name = "%s[%s]" % (self.__class__.__name__, hex(id(self)))
-        self._logger = getLogger(name)
+    @property
+    def name(self):
+        try:
+            return self._name
+        except AttributeError:
+            self._name = instance_name(self, next(self._ids))
+            return self._name
+    
 
     @property
     def logger(self):
         """ The logger for this Estimator """
         try:
-            return self._logger
+            return self._logger_instance
         except AttributeError:
-            self.__create_logger()
-            return self._logger
+            create_logger(self)
+            return self._logger_instance
 
     def estimate(self, X, **params):
         """ Estimates the model given the data X

--- a/pyemma/_base/logging.py
+++ b/pyemma/_base/logging.py
@@ -1,0 +1,44 @@
+'''
+Created on 30.08.2015
+
+@author: marscher
+'''
+import logging
+import weakref
+from pyemma.util.log import getLogger
+
+__all__ = ['create_logger', 'instance_name']
+
+_refs = {}
+
+def _cleanup_logger(obj):
+    # callback function used in conjunction with weakref.ref to remove logger for transformer instance
+    key = obj._logger_instance.name
+
+    def remove_logger(weak):
+        d = logging.getLogger().manager.loggerDict
+        del d[key]
+        del _refs[key]
+    return remove_logger
+
+def _clean_dead_refs():
+    # cleans dead weakrefs
+    global _refs
+     
+    if len(_refs) == 0:
+        return
+    _refs = [r for r in _refs if r() is not None]
+    
+def instance_name(self, id):
+    i = self.__module__.rfind(".")
+    j = self.__module__.find(".") + 1
+    package = self.__module__[j:i]
+    instance_name = "%s.%s[%i]" % (package, self.__class__.__name__, id)
+    return instance_name
+
+def create_logger(self):
+    # creates a logger based on the the attribe "name" of self
+    self._logger_instance = getLogger(self.name)
+    r = weakref.ref(self, _cleanup_logger(self))
+    _refs[self.name] = r
+    return self._logger_instance


### PR DESCRIPTION
Uses weakrefs on each Transformer instance with a callback function to remove
the corresponding logger. Otherwise these loggers accumulate and never gets removed for one session, which may be cause problems if one creates tons of Estimators/Transformers.
