### PR TITLE
rewrote logging settings handling

### DIFF
--- a/pyemma/logging.yml
+++ b/pyemma/logging.yml
@@ -1,0 +1,32 @@
+# PyEMMA's default logging settings
+# If you want to enable file logging, uncomment the file related handlers and handlers
+# 
+formatters:
+    simpleFormater:
+        format: '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
+        datefmt: '%d-%m-%y %H:%M:%S'
+
+handlers:
+    console:
+        class: logging.StreamHandler
+        formatter: simpleFormater
+        level: DEBUG
+        stream: ext://sys.stdout
+#    file:
+#        class : logging.FileHandler
+#        formatter: simpleFormater
+#        level: INFO
+#        filename: pyemma.log
+
+loggers:
+    clogger:
+        level: INFO
+        handlers: [console]
+    #flogger:
+    #    level: INFO
+    #    handlers: [file]
+
+root:
+# global log level
+    level: INFO
+    handlers: [console] #, file]

--- a/pyemma/pyemma.cfg
+++ b/pyemma/pyemma.cfg
@@ -5,17 +5,14 @@
 # - comments are not allowed in line, since they would be appended to the value!
 ################################################################################
 
-[Logging]
-enabled = True
-toconsole = True
-tofile = False
-file = pyemma.log
-level = WARNING 
-format = %%(asctime)s %%(name)-12s %%(levelname)-8s %%(message)s
-
-
-# pyemma configuration section
 [pyemma]
+# Source to logging configuration file (YAML)
+# special value: DEFAULT (use default config)
+# if this is set to a filename, it will be red to configure logging. If it is a
+# relative path, it is assumed to be located next to where you start your interpreter
+logging_config = DEFAULT
+# show or hide progress bars globally?
 show_progress_bars = True
 # useful for trajectory formats, for which one has to read the whole file to get len
+# eg. XTC format.
 use_trajectory_lengths_cache = True

--- a/pyemma/util/config.py
+++ b/pyemma/util/config.py
@@ -36,6 +36,12 @@ The same applies for the filename ".pyemma.cfg" (hidden file).
 The default values are stored in latter file to ensure these values are always
 defined. This is preferred over hardcoding them somewhere in the Python code.
 
+After the first import of pyemma, you will find a .pyemma directory in your
+user directory. It contains a pyemma.cfg and logging.yml. The latter is a YAML
+file to configure the logging system.
+For details have a look at the brief documentation: 
+https://docs.python.org/2/howto/logging.html
+
 Default configuration file
 --------------------------
 Default settings are stored in a provided pyemma.cfg file, which is included in
@@ -47,20 +53,12 @@ the Python package:
 To access the config at runtime eg. the logging section:
 
 >>> from pyemma import config
->>> print(config.Logging.level)  # doctest: +SKIP
-WARNING
 >>> print(config.show_progress_bars)
 True
 
-Setting configuration values by section:
-
->>> config.Logging.level = 'DEBUG'
->>> print(config.Logging.level)
-DEBUG
-
 or
 
->>> config.show_progress_bars = 'False'
+>>> config.show_progress_bars = False
 >>> print(config.show_progress_bars)
 False
 
@@ -253,7 +251,7 @@ class Wrapper(object):
             conf_values[name] = value
         else:
             raise KeyError('"%s" is not a valid config section.' % name)
- 
+
     def __setattr__(self, name, value):
         if name not in ('wrapped', ):
             self.__setitem__(name, value)
@@ -261,3 +259,4 @@ class Wrapper(object):
             object.__setattr__(self, name, value)
 
 sys.modules[__name__] = Wrapper(sys.modules[__name__])
+

--- a/setup.py
+++ b/setup.py
@@ -259,7 +259,7 @@ else:
                                   ]
 
     metadata['package_data'] = {
-                                'pyemma': ['pyemma.cfg'],
+                                'pyemma': ['pyemma.cfg', 'logging.yml'],
                                 'pyemma.coordinates.tests': ['data/*'],
                                 'pyemma.datasets': ['*.npz'],
                                 'pyemma.util.tests': ['data/*'],

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# This file is part of MSMTools.
+# This file is part of PyEMMA.
 #
 # Copyright (c) 2015, 2014 Computational Molecular Biology Group, Freie Universitaet Berlin (GER)
 #
@@ -234,6 +234,7 @@ metadata = dict(
                       'msmtools',
                       'bhmm==0.5.1',
                       'joblib==0.8.4',
+                      'pyyaml',
                       'psutil>=3.1.1',
                       'decorator>=4.0.0',
                       ],

--- a/tools/conda-recipe/meta.yaml
+++ b/tools/conda-recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - mock
     - msmtools
     - numpy >=1.7
+    - pyyaml
     - scipy
     - six
     - psutil
@@ -36,6 +37,7 @@ requirements:
     - mock
     - msmtools
     - numpy >=1.7
+    - pyyaml
     - scipy
     - six
     - psutil


### PR DESCRIPTION
- a fully flexible logging.yml (YAML) has been added to pyemma dir (default settings: loglevel INFO, stdout, no file logging)
- a copy of logging.yml is created in users .pyemma dir and used in favor of default file
- replaced [Logging] section from pyemma.cfg with logging_config directive (file or DEFAULT keyword)

This can be safely postponed to 2.1
