### PR TITLE
Kmeans memory requirement management and default number of centers

### DIFF
--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -1206,7 +1206,8 @@ def cluster_kmeans(data=None, k=None, max_iter=10, tolerance=1e-5, stride=1,
         input data, if available in memory
 
     k: int
-        the number of cluster centers
+        the number of cluster centers. When not specified (None), min(sqrt(N), 5000) is chosen as default value,
+        where N denotes the number of data points
 
     max_iter : int
         maximum number of iterations before stopping. When not specified (None), min(sqrt(N),5000) is chosen
@@ -1290,7 +1291,7 @@ def cluster_kmeans(data=None, k=None, max_iter=10, tolerance=1e-5, stride=1,
     return _param_stage(data, res, stride=stride)
 
 
-def cluster_uniform_time(data=None, k=100, stride=1, metric='euclidean'):
+def cluster_uniform_time(data=None, k=None, stride=1, metric='euclidean'):
     r"""Uniform time clustering
 
     If given data, performs a clustering that selects data points uniformly in
@@ -1307,7 +1308,8 @@ def cluster_uniform_time(data=None, k=100, stride=1, metric='euclidean'):
         by source function input data, if available in memory
 
     k : int
-        the number of cluster centers
+        the number of cluster centers. When not specified (None), min(sqrt(N), 5000) is chosen as default value,
+        where N denotes the number of data points
 
     stride : int, optional, default = 1
         If set to 1, all input data will be used for estimation. Note that this
@@ -1341,7 +1343,7 @@ def cluster_uniform_time(data=None, k=100, stride=1, metric='euclidean'):
 
     """
     res = _UniformTimeClustering(k, metric=metric)
-    return _param_stage(data, res)
+    return _param_stage(data, res, stride=stride)
 
 
 def cluster_regspace(data=None, dmin=-1, max_centers=1000, stride=1, metric='euclidean'):

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -1189,7 +1189,7 @@ def cluster_mini_batch_kmeans(data=None, k=100, max_iter=10, batch_size=0.2, met
     return _param_stage(data, res, stride=1)
 
 
-def cluster_kmeans(data=None, k=100, max_iter=10, tolerance=1e-5, stride=1,
+def cluster_kmeans(data=None, k=None, max_iter=10, tolerance=1e-5, stride=1,
                    metric='euclidean', init_strategy='kmeans++', fixed_seed=False):
     r"""k-means clustering
 
@@ -1209,7 +1209,8 @@ def cluster_kmeans(data=None, k=100, max_iter=10, tolerance=1e-5, stride=1,
         the number of cluster centers
 
     max_iter : int
-        maximum number of iterations before stopping.
+        maximum number of iterations before stopping. When not specified (None), min(sqrt(N),5000) is chosen
+        as default value, where N denotes the number of data points
 
     tolerance : float
         stop iteration when the relative change in the cost function

--- a/pyemma/coordinates/clustering/kmeans.py
+++ b/pyemma/coordinates/clustering/kmeans.py
@@ -147,7 +147,7 @@ class KmeansClustering(AbstractClustering):
 
     def _calculate_required_memory(self, size):
         empty = np.empty(shape=(1, self.data_producer.dimension()), order='C', dtype=np.float32)
-        return long(empty[0, :].nbytes * size)
+        return empty[0, :].nbytes * size
 
     @doc_inherit
     def describe(self):

--- a/pyemma/coordinates/clustering/kmeans.py
+++ b/pyemma/coordinates/clustering/kmeans.py
@@ -51,7 +51,8 @@ class KmeansClustering(AbstractClustering):
         Parameters
         ----------
         n_clusters : int
-            amount of cluster centers
+            amount of cluster centers. When not specified (None), min(sqrt(N), 5000) is chosen as default value,
+            where N denotes the number of data points
 
         max_iter : int
             maximum number of iterations before stopping.
@@ -97,11 +98,17 @@ class KmeansClustering(AbstractClustering):
         self._cluster_centers_iter = []
         self._init_centers_indices = {}
         self._t_total = 0
+        traj_lengths = self.trajectory_lengths(stride=self._param_with_stride)
+        total_length = sum(traj_lengths)
+
+        if not self.n_clusters:
+            self.n_clusters = min(int(math.sqrt(total_length)), 5000)
+            self._logger.info("The number of cluster centers was not specified, "
+                              "using min(sqrt(N), 5000)=%s as n_clusters." % self.n_clusters)
+
         if self._init_strategy == 'kmeans++':
             self._progress_register(self.n_clusters, description="initialize kmeans++ centers", stage=0)
         self._progress_register(self.max_iter, description="kmeans iterations", stage=1)
-        traj_lengths = self.trajectory_lengths(stride=self._param_with_stride)
-        total_length = sum(traj_lengths)
 
         self._init_in_memory_chunks(total_length)
 

--- a/pyemma/coordinates/clustering/kmeans.py
+++ b/pyemma/coordinates/clustering/kmeans.py
@@ -29,10 +29,12 @@ import os
 import random
 import tempfile
 import numpy as np
+import psutil
 
 from . import kmeans_clustering
 
 from pyemma.util.annotators import doc_inherit
+from pyemma.util.units import bytes_to_string
 from pyemma.coordinates.clustering.interface import AbstractClustering
 from six.moves import range
 
@@ -115,15 +117,30 @@ class KmeansClustering(AbstractClustering):
                 random.seed(None)
 
     def _init_in_memory_chunks(self, size):
-        try:
+        available_mem = psutil.virtual_memory().available
+        required_mem = self._calculate_required_memory(size)
+        if required_mem <= available_mem:
             self._in_memory_chunks = np.empty(shape=(size, self.data_producer.dimension()),
                                               order='C', dtype=np.float32)
-        except MemoryError:
+        else:
             if self._oom_strategy == 'raise':
-                raise
-            self._in_memory_chunks = np.memmap(tempfile.mkstemp()[1], mode="w+",
-                                               shape=(size, self.data_producer.dimension()), order='C',
-                                               dtype=np.float32)
+                self._logger.warn('K-means failed to load all the data (%s required, %s available) into memory. '
+                                  'Consider using a larger stride or set the oom_strategy to \'memmap\' which works '
+                                  'with a memmapped temporary file.'
+                                  % (bytes_to_string(required_mem), bytes_to_string(available_mem)))
+                raise MemoryError
+            else:
+                self._logger.warn('K-means failed to load all the data (%s required, %s available) into memory '
+                                  'and now uses a memmapped temporary file which is comparably slow. '
+                                  'Consider using a larger stride.'
+                                  % (bytes_to_string(required_mem), bytes_to_string(available_mem)))
+                self._in_memory_chunks = np.memmap(tempfile.mkstemp()[1], mode="w+",
+                                                   shape=(size, self.data_producer.dimension()), order='C',
+                                                   dtype=np.float32)
+
+    def _calculate_required_memory(self, size):
+        empty = np.empty(shape=(1, self.data_producer.dimension()), order='C', dtype=np.float32)
+        return long(empty[0, :].nbytes * size)
 
     @doc_inherit
     def describe(self):
@@ -216,12 +233,6 @@ class KmeansClustering(AbstractClustering):
         # beginning - compute
         if first_chunk:
             self._t_total = 0
-            mem_req = int(1.0 / 1024 ** 2 * X[0, :].nbytes * self.n_frames_total(stride))
-            if mem_req > 100:
-                self._logger.warn('K-means implementation is currently memory inefficient.'
-                                  ' This calculation needs %i megabytes of main memory.'
-                                  ' If you get a memory error, try using a larger stride.'
-                                  % mem_req)
 
         # appends a true copy
         self._in_memory_chunks[self._t_total:self._t_total + len(X)] = X[:]

--- a/pyemma/coordinates/clustering/uniform_time.py
+++ b/pyemma/coordinates/clustering/uniform_time.py
@@ -18,6 +18,7 @@
 
 
 from __future__ import absolute_import, division
+import math
 import numpy as np
 from pyemma.coordinates.clustering.interface import AbstractClustering
 
@@ -53,6 +54,13 @@ class UniformTimeClustering(AbstractClustering):
         :return:
         """
         # initialize cluster centers
+        if not self.n_clusters:
+            traj_lengths = self.trajectory_lengths(stride=self._param_with_stride)
+            total_length = sum(traj_lengths)
+            self.n_clusters = min(int(math.sqrt(total_length)), 5000)
+            self._logger.info("The number of cluster centers was not specified, "
+                              "using min(sqrt(N), 5000)=%s as n_clusters." % self.n_clusters)
+
         self._clustercenters = np.zeros(
             (self.n_clusters, self.data_producer.dimension()), dtype=np.float32)
 

--- a/pyemma/util/tests/test_units.py
+++ b/pyemma/util/tests/test_units.py
@@ -4,7 +4,7 @@ from pyemma.util.units import bytes_to_string
 class TestUnits(unittest.TestCase):
 
     def test_human_readable_byte_size(self):
-        n_bytes = 1393500160L  # about 1.394 GB
+        n_bytes = 1393500160  # about 1.394 GB
         self.assertEqual(bytes_to_string(n_bytes), "1.3GB", "this number of bytes should "
                                                             "result in 1.3GB and not in %s" % bytes_to_string(n_bytes))
         self.assertEqual(bytes_to_string(0), "0B", "0 bytes should result in \"0B\"")

--- a/pyemma/util/tests/test_units.py
+++ b/pyemma/util/tests/test_units.py
@@ -1,0 +1,10 @@
+import unittest
+from pyemma.util.units import bytes_to_string
+
+class TestUnits(unittest.TestCase):
+
+    def test_human_readable_byte_size(self):
+        n_bytes = 1393500160L  # about 1.394 GB
+        self.assertEqual(bytes_to_string(n_bytes), "1.3GB", "this number of bytes should "
+                                                            "result in 1.3GB and not in %s" % bytes_to_string(n_bytes))
+        self.assertEqual(bytes_to_string(0), "0B", "0 bytes should result in \"0B\"")

--- a/pyemma/util/units.py
+++ b/pyemma/util/units.py
@@ -22,6 +22,7 @@ from __future__ import absolute_import
 __author__ = 'noe'
 
 import numpy as np
+import math
 
 class TimeUnit(object):
 
@@ -138,3 +139,18 @@ class TimeUnit(object):
 
         # nothing to do
         return times, self._unit
+
+def bytes_to_string(num, suffix='B'):
+    """
+    Returns the size of num (bytes) in a human readable form up to Yottabytes (YB).
+    :param num: The size of interest in bytes.
+    :param suffix: A suffix, default 'B' for 'bytes'.
+    :return: a human readable representation of a size in bytes
+    """
+    extensions = ["%s%s" % (x, suffix) for x in ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']]
+    if num == 0:
+        return "0%s" % extensions[0]
+    else:
+        n_bytes = float(abs(num))
+        place = int(math.floor(math.log(n_bytes, 1024)))
+        return "%.1f%s" % (np.sign(num) * (n_bytes / pow(1024, place)), extensions[place])

--- a/setup.py
+++ b/setup.py
@@ -234,6 +234,7 @@ metadata = dict(
                       'msmtools',
                       'bhmm==0.5.1',
                       'joblib==0.8.4',
+                      'psutil>=3.1.1'
                       ],
     zip_safe=False,
 )

--- a/tools/conda-recipe/meta.yaml
+++ b/tools/conda-recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - numpy >=1.7
     - scipy
     - six
+    - psutil
 
   run:
     - python
@@ -36,6 +37,7 @@ requirements:
     - numpy >=1.7
     - scipy
     - six
+    - psutil
 
 test:
   requires:


### PR DESCRIPTION
This PR deals with issues #470 and #520. 
- Removed the warning if kmeans needs more than 100MB of memory, adding a warning if the memory requires exceed what is available. In order to have the information available, psutil was added to the required packages list. 
- Changed the api default number of cluster centers to 'None', which results in a number of cluster centers chosen by min(sqrt(N), 5000), where N is the number of considered frames, i.e., takes stride into account.
