### PR TITLE
Decorator to check if estimator is estimated

### DIFF
--- a/pyemma/_base/estimator.py
+++ b/pyemma/_base/estimator.py
@@ -300,6 +300,8 @@ class Estimator(_BaseEstimator):
     """
     # counting estimator instances, incremented by name property.
     _ids = count(0)
+    # flag indicating if estimator's estimate method has been called
+    _estimated = False
 
     @property
     def name(self):
@@ -309,7 +311,6 @@ class Estimator(_BaseEstimator):
         except AttributeError:
             self._name = instance_name(self, next(self._ids))
             return self._name
-    
 
     @property
     def logger(self):
@@ -344,6 +345,7 @@ class Estimator(_BaseEstimator):
         if params:
             self.set_params(**params)
         self._model = self._estimate(X)
+        self._estimated = True
         return self._model
 
     def _estimate(self, X):

--- a/pyemma/msm/estimators/implied_timescales.py
+++ b/pyemma/msm/estimators/implied_timescales.py
@@ -26,6 +26,7 @@ Created on Jul 26, 2014
 from __future__ import absolute_import, print_function
 
 import numpy as np
+from pyemma.util.annotators import estimation_required
 
 from pyemma.util.statistics import confidence_interval
 from pyemma.util import types as _types
@@ -218,6 +219,7 @@ class ImpliedTimescales(Estimator, ProgressReporter):
         return self.nits
 
     @property
+    @estimation_required
     def timescales(self):
         r"""Returns the implied timescale estimates
 

--- a/pyemma/util/annotators.py
+++ b/pyemma/util/annotators.py
@@ -37,6 +37,8 @@ from __future__ import absolute_import
 from functools import wraps
 import warnings
 from six import PY2
+from decorator import decorator
+from pyemma._base.estimator import Estimator
 
 __all__ = ['alias',
            'aliased',
@@ -226,3 +228,15 @@ def shortcut(*names):
                 globals_['__all__'].append(name)
         return f
     return wrap
+
+@decorator
+def estimation_required(func, *args, **kw):
+    """
+    Decorator checking the self._estimated flag in an Estimator instance, raising a value error if the decorated
+    function is called before estimator.estimate() has been called.
+    """
+    self = args[0] if len(args) > 0 else None
+    if self and isinstance(self, Estimator) and not self._estimated:
+        raise ValueError("Tried calling %s on %s which requires the estimator to be estimated."
+                         % (func.__name__, self.__class__.__name__))
+    return func(*args, **kw)

--- a/pyemma/util/annotators.py
+++ b/pyemma/util/annotators.py
@@ -97,8 +97,7 @@ class DocInherit(object):
 
 doc_inherit = DocInherit
 
-
-def deprecated(msg):
+class deprecated(object):
     """This is a decorator which can be used to mark functions
     as deprecated. It will result in a warning being emitted
     when the function is used.
@@ -109,34 +108,31 @@ def deprecated(msg):
         a user level hint which should indicate which feature to use otherwise.
 
     """
-    def deprecated_decorator(func):
 
-        @wraps(func)
-        def new_func(*args, **kwargs):
-            mod = func.__module__
-            filename = mod.__file__
-            lineno = func.__code__.co_firstlineno + 1
+    def __init__(self, msg = None):
+        self.msg = msg
 
-            user_msg = "Call to deprecated function %s. Called from %s line %i. " \
-                % (func.__name__, filename, lineno)
-            if msg:
-                user_msg += msg
+    def __call__(self, func):
+        mod = func.__module__
+        filename = mod.__file__ if hasattr(mod, '__file__') else None
+        lineno = func.__code__.co_firstlineno + 1
 
-            warnings.warn_explicit(
-                user_msg,
-                category=DeprecationWarning,
-                filename=func.__code__.co_filename,
-                lineno=func.__code__.co_firstlineno + 1
-            )
-            return func(*args, **kwargs)
+        user_msg = "Call to deprecated function %s. Called from %s line %i. " \
+                   % (func.__name__, filename if filename else mod, lineno)
 
-        new_func.__dict__['__deprecated__'] = True
+        if self.msg:
+            user_msg += self.msg
 
+        warnings.warn_explicit(
+            user_msg,
+            category=DeprecationWarning,
+            filename=func.__code__.co_filename,
+            lineno=func.__code__.co_firstlineno + 1
+        )
+
+        func.__dict__['__deprecated__'] = True
         # TODO: search docstring for notes section and append deprecation notice (with msg)
-
-        return new_func
-
-    return deprecated_decorator
+        return func
 
 
 class alias(object):
@@ -234,6 +230,13 @@ def estimation_required(func, *args, **kw):
     """
     Decorator checking the self._estimated flag in an Estimator instance, raising a value error if the decorated
     function is called before estimator.estimate() has been called.
+
+    If mixed with a property-annotation, this annotation needs to come first in the chain of function calls, i.e.,
+
+    @property
+    @estimation_required
+    def func(self):
+        ....
     """
     self = args[0] if len(args) > 0 else None
     if self and isinstance(self, Estimator) and not self._estimated:

--- a/pyemma/util/tests/test_estimation_required_decorator.py
+++ b/pyemma/util/tests/test_estimation_required_decorator.py
@@ -7,6 +7,15 @@ from pyemma.util.annotators import estimation_required, alias, aliased, deprecat
 @aliased
 class TestEstimator(Estimator):
 
+    def __init__(self):
+        self._prop = ""
+
+    @property
+    @estimation_required
+    def property_method_requires(self):
+        return self._prop
+
+    @deprecated()
     @estimation_required
     @alias('testimator_method_requires')
     def test_method_requires_estimation(self):
@@ -14,6 +23,7 @@ class TestEstimator(Estimator):
 
     @alias('testimator_method_requires_rev')
     @estimation_required
+    @deprecated()
     def test_method_requires_estimation_reverse(self):
         pass
 
@@ -25,6 +35,14 @@ class TestEstimator(Estimator):
 
 
 class TestEstimationRequired(unittest.TestCase):
+
+    def test_requires_estimation_property(self):
+        testimator = TestEstimator()
+        with self.assertRaises(ValueError) as ctx:
+            testimator.property_method_requires
+        self.assertTrue('Tried calling property_method_requires on TestEstimator' in ctx.exception.message)
+        testimator.estimate(None)
+        self.assertEqual("", testimator.property_method_requires, "should return an empty string since now estimated")
 
     def test_requires_estimation(self):
         testimator = TestEstimator()

--- a/pyemma/util/tests/test_estimation_required_decorator.py
+++ b/pyemma/util/tests/test_estimation_required_decorator.py
@@ -1,0 +1,53 @@
+
+import unittest
+from pyemma._base.estimator import Estimator
+from pyemma.util.annotators import estimation_required, alias, aliased, deprecated
+
+
+@aliased
+class TestEstimator(Estimator):
+
+    @estimation_required
+    @alias('testimator_method_requires')
+    def test_method_requires_estimation(self):
+        pass
+
+    @alias('testimator_method_requires_rev')
+    @estimation_required
+    def test_method_requires_estimation_reverse(self):
+        pass
+
+    def test_method_does_not_require_estimation(self):
+        pass
+
+    def _estimate(self, X):
+        pass
+
+
+class TestEstimationRequired(unittest.TestCase):
+
+    def test_requires_estimation(self):
+        testimator = TestEstimator()
+        self.assertRaises(ValueError, testimator.test_method_requires_estimation)
+        testimator.estimate(None)
+        # now that we called 'estimate()', should not raise
+        testimator.test_method_requires_estimation()
+
+    def test_requires_estimation_alias(self):
+        testimator = TestEstimator()
+        self.assertRaises(ValueError, testimator.testimator_method_requires)
+        testimator.estimate(None)
+        # now that we called 'estimate()', should not raise
+        testimator.testimator_method_requires()
+
+    def test_requires_estimation_alias_reverse(self):
+        testimator = TestEstimator()
+        self.assertRaises(ValueError, testimator.testimator_method_requires_rev)
+        testimator.estimate(None)
+        # now that we called 'estimate()', should not raise
+        testimator.testimator_method_requires_rev()
+
+    def test_does_not_require_estimation(self):
+        testimator = TestEstimator()
+        # does not require 'estimate()', should not raise
+        testimator.test_method_does_not_require_estimation()

--- a/pyemma/util/tests/test_estimation_required_decorator.py
+++ b/pyemma/util/tests/test_estimation_required_decorator.py
@@ -18,16 +18,16 @@ class TestEstimator(Estimator):
     @deprecated()
     @estimation_required
     @alias('testimator_method_requires')
-    def test_method_requires_estimation(self):
+    def method_requires_estimation(self):
         pass
 
     @alias('testimator_method_requires_rev')
     @estimation_required
     @deprecated()
-    def test_method_requires_estimation_reverse(self):
+    def method_requires_estimation_reverse(self):
         pass
 
-    def test_method_does_not_require_estimation(self):
+    def method_does_not_require_estimation(self):
         pass
 
     def _estimate(self, X):
@@ -46,10 +46,10 @@ class TestEstimationRequired(unittest.TestCase):
 
     def test_requires_estimation(self):
         testimator = TestEstimator()
-        self.assertRaises(ValueError, testimator.test_method_requires_estimation)
+        self.assertRaises(ValueError, testimator.method_requires_estimation)
         testimator.estimate(None)
         # now that we called 'estimate()', should not raise
-        testimator.test_method_requires_estimation()
+        testimator.method_requires_estimation()
 
     def test_requires_estimation_alias(self):
         testimator = TestEstimator()
@@ -68,4 +68,4 @@ class TestEstimationRequired(unittest.TestCase):
     def test_does_not_require_estimation(self):
         testimator = TestEstimator()
         # does not require 'estimate()', should not raise
-        testimator.test_method_does_not_require_estimation()
+        testimator.method_does_not_require_estimation()

--- a/pyemma/util/tests/test_estimation_required_decorator.py
+++ b/pyemma/util/tests/test_estimation_required_decorator.py
@@ -40,7 +40,7 @@ class TestEstimationRequired(unittest.TestCase):
         testimator = TestEstimator()
         with self.assertRaises(ValueError) as ctx:
             testimator.property_method_requires
-        self.assertTrue('Tried calling property_method_requires on TestEstimator' in ctx.exception.message)
+        self.assertTrue('Tried calling property_method_requires on TestEstimator' in str(ctx.exception))
         testimator.estimate(None)
         self.assertEqual("", testimator.property_method_requires, "should return an empty string since now estimated")
 

--- a/setup.py
+++ b/setup.py
@@ -234,6 +234,7 @@ metadata = dict(
                       'msmtools',
                       'bhmm==0.5.1',
                       'joblib==0.8.4',
+                      'decorator>=4.0.0'
                       ],
     zip_safe=False,
 )

--- a/tools/conda-recipe/meta.yaml
+++ b/tools/conda-recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - numpy >=1.7
     - scipy
     - six
+    - decorator
 
   run:
     - python
@@ -36,6 +37,7 @@ requirements:
     - numpy >=1.7
     - scipy
     - six
+    - decorator
 
 test:
   requires:


### PR DESCRIPTION
This PR contains a decorator that can be applied to estimator methods that need an estimated state to return meaningful results, see issue #532. Also it contains a modification of the deprecated annotation allowing to deprecate class methods as well (parenthesis required then, see included test case).
Last, the "timescales" property-method of "implied_timescales" has been decorated with "estimation_required".
