### PR TITLE
Mdtraj topology

### DIFF
--- a/pyemma/coordinates/data/featurizer.py
+++ b/pyemma/coordinates/data/featurizer.py
@@ -808,17 +808,21 @@ class MDFeaturizer(object):
     # counting instances, incremented by name property.
     _ids = count(0)
 
-    def __init__(self, topfile):
+    def __init__(self, topology):
         """extracts features from MD trajectories.
 
        Parameters
        ----------
 
-       topfile : str
-           a path to a topology file (pdb etc.)
+       topfile : str or mdtraj.Topology
+           a path to a topology file (pdb etc.) or an mdtraj Topology() object
        """
-        self.topologyfile = topfile
-        self.topology = (mdtraj.load(topfile)).topology
+        self.topologyfile = None
+        if type(topology) is str:
+            self.topology = (mdtraj.load(topology)).topology
+            self.topologyfile = topology
+        else:
+            self.topology = topology
         self.active_features = []
         self._dim = 0
 

--- a/pyemma/coordinates/data/featurizer.py
+++ b/pyemma/coordinates/data/featurizer.py
@@ -808,7 +808,7 @@ class MDFeaturizer(object):
     # counting instances, incremented by name property.
     _ids = count(0)
 
-    def __init__(self, topology):
+    def __init__(self, topfile):
         """extracts features from MD trajectories.
 
        Parameters
@@ -818,11 +818,11 @@ class MDFeaturizer(object):
            a path to a topology file (pdb etc.) or an mdtraj Topology() object
        """
         self.topologyfile = None
-        if type(topology) is str:
-            self.topology = (mdtraj.load(topology)).topology
-            self.topologyfile = topology
+        if type(topfile) is str:
+            self.topology = (mdtraj.load(topfile)).topology
+            self.topologyfile = topfile
         else:
-            self.topology = topology
+            self.topology = topfile
         self.active_features = []
         self._dim = 0
 

--- a/pyemma/coordinates/tests/test_featurizer.py
+++ b/pyemma/coordinates/tests/test_featurizer.py
@@ -245,7 +245,7 @@ class TestFeaturizer(unittest.TestCase):
         self.assertEqual(len(desc), self.feat.dimension())
 
     def test_backbone_dihedrals(self):
-        self.feat = MDFeaturizer(topfile=self.asn_leu_pdbfile)
+        self.feat = MDFeaturizer(topology=self.asn_leu_pdbfile)
         self.feat.add_backbone_torsions()
 
         traj = mdtraj.load(self.asn_leu_pdbfile)
@@ -257,7 +257,7 @@ class TestFeaturizer(unittest.TestCase):
         self.assertEqual(len(desc), self.feat.dimension())
 
     def test_backbone_dihedrals_deg(self):
-        self.feat = MDFeaturizer(topfile=self.asn_leu_pdbfile)
+        self.feat = MDFeaturizer(topology=self.asn_leu_pdbfile)
         self.feat.add_backbone_torsions(deg=True)
 
         traj = mdtraj.load(self.asn_leu_pdbfile)
@@ -268,7 +268,7 @@ class TestFeaturizer(unittest.TestCase):
         self.assertEqual(len(desc), self.feat.dimension())
 
     def test_backbone_dihedrals_cossin(self):
-        self.feat = MDFeaturizer(topfile=self.asn_leu_pdbfile)
+        self.feat = MDFeaturizer(topology=self.asn_leu_pdbfile)
         self.feat.add_backbone_torsions(cossin=True)
 
         traj = mdtraj.load(self.asn_leu_traj, top=self.asn_leu_pdbfile)
@@ -282,7 +282,7 @@ class TestFeaturizer(unittest.TestCase):
         self.assertEqual(len(desc), self.feat.dimension())
 
     def test_backbone_dihedrials_chi(self):
-        self.feat = MDFeaturizer(topfile=self.asn_leu_pdbfile)
+        self.feat = MDFeaturizer(topology=self.asn_leu_pdbfile)
         self.feat.add_chi1_torsions()
 
         traj = mdtraj.load(self.asn_leu_pdbfile)
@@ -293,7 +293,7 @@ class TestFeaturizer(unittest.TestCase):
         self.assertEqual(len(desc), self.feat.dimension())
 
     def test_backbone_dihedrials_chi_cossin(self):
-        self.feat = MDFeaturizer(topfile=self.asn_leu_pdbfile)
+        self.feat = MDFeaturizer(topology=self.asn_leu_pdbfile)
         self.feat.add_chi1_torsions(cossin=True)
 
         traj = mdtraj.load(self.asn_leu_pdbfile)

--- a/pyemma/coordinates/tests/test_featurizer.py
+++ b/pyemma/coordinates/tests/test_featurizer.py
@@ -245,7 +245,7 @@ class TestFeaturizer(unittest.TestCase):
         self.assertEqual(len(desc), self.feat.dimension())
 
     def test_backbone_dihedrals(self):
-        self.feat = MDFeaturizer(topology=self.asn_leu_pdbfile)
+        self.feat = MDFeaturizer(topfile=self.asn_leu_pdbfile)
         self.feat.add_backbone_torsions()
 
         traj = mdtraj.load(self.asn_leu_pdbfile)
@@ -257,7 +257,7 @@ class TestFeaturizer(unittest.TestCase):
         self.assertEqual(len(desc), self.feat.dimension())
 
     def test_backbone_dihedrals_deg(self):
-        self.feat = MDFeaturizer(topology=self.asn_leu_pdbfile)
+        self.feat = MDFeaturizer(topfile=self.asn_leu_pdbfile)
         self.feat.add_backbone_torsions(deg=True)
 
         traj = mdtraj.load(self.asn_leu_pdbfile)
@@ -268,7 +268,7 @@ class TestFeaturizer(unittest.TestCase):
         self.assertEqual(len(desc), self.feat.dimension())
 
     def test_backbone_dihedrals_cossin(self):
-        self.feat = MDFeaturizer(topology=self.asn_leu_pdbfile)
+        self.feat = MDFeaturizer(topfile=self.asn_leu_pdbfile)
         self.feat.add_backbone_torsions(cossin=True)
 
         traj = mdtraj.load(self.asn_leu_traj, top=self.asn_leu_pdbfile)
@@ -282,7 +282,7 @@ class TestFeaturizer(unittest.TestCase):
         self.assertEqual(len(desc), self.feat.dimension())
 
     def test_backbone_dihedrials_chi(self):
-        self.feat = MDFeaturizer(topology=self.asn_leu_pdbfile)
+        self.feat = MDFeaturizer(topfile=self.asn_leu_pdbfile)
         self.feat.add_chi1_torsions()
 
         traj = mdtraj.load(self.asn_leu_pdbfile)
@@ -293,7 +293,7 @@ class TestFeaturizer(unittest.TestCase):
         self.assertEqual(len(desc), self.feat.dimension())
 
     def test_backbone_dihedrials_chi_cossin(self):
-        self.feat = MDFeaturizer(topology=self.asn_leu_pdbfile)
+        self.feat = MDFeaturizer(topfile=self.asn_leu_pdbfile)
         self.feat.add_chi1_torsions(cossin=True)
 
         traj = mdtraj.load(self.asn_leu_pdbfile)


### PR DESCRIPTION
Allow using an mdtraj.Topology object when initializing a featurizer.

For convenience and integration of PyEmma into OpenPathSampling.
