### PR TITLE
[coord.data.featurizer] _describe_atom now uses resSeq

### DIFF
--- a/pyemma/coordinates/data/featurizer.py
+++ b/pyemma/coordinates/data/featurizer.py
@@ -70,7 +70,7 @@ def _describe_atom(topology, index):
     """
     #assert isinstance(index, int)
     at = topology.atom(index)
-    return "%s %i %s %i" % (at.residue.name, at.residue.index, at.name, at.index)
+    return "%s %i %s %i" % (at.residue.name, at.residue.resSeq, at.name, at.index)
 
 def _catch_unhashable(x):
     if hasattr(x, '__getitem__'):


### PR DESCRIPTION
The function _describe_atom is used in feature.describe(), and uses at.residue.index to inform about the residue in which atom XXX is by using sequential, monotonic, 0-indexed residue indices. 

at.residue.resSeq produces the Residue Sequence record (generally 1-based, but depends on topology, via http://mdtraj.org/latest/atom_selection.html#keywords)

I think that resSeq makes more sense if one is interested in 1-indexed residue indices, which will be coincident with pdb-literature. If somebody cites the GLU90 ARG130 contact, these are 1-indexed, and the description of the feature (which nonetheless includes also the atom-index) should be compatible with that.
