### PR TITLE
Describe group mindist better

### DIFF
--- a/pyemma/coordinates/data/featurizer.py
+++ b/pyemma/coordinates/data/featurizer.py
@@ -475,19 +475,22 @@ class ResidueMinDistanceFeature(DistanceFeature):
 
 class GroupMinDistanceFeature(DistanceFeature):
 
-    def __init__(self, top, group_pairs, distance_list, group_identifiers, threshold):
+    def __init__(self, top, group_definitions, group_pairs, distance_list, group_identifiers, threshold):
         self.top = top
         self.group_identifiers = group_identifiers
         self.distance_list = distance_list
+        self.group_definitions = group_definitions
         self.prefix_label = "GROUP_MINDIST"
         self.threshold = threshold
         self.distance_indexes = group_pairs
 
     def describe(self):
-        labels = ["%s %s - %s" % (self.prefix_label,
-                                  pair[0],
-                                  pair[1])
-                  for pair in self.distance_indexes]
+        labels = ["%s %u--%u: [%s...%s]--[%s...%s]" % (self.prefix_label, pair[0], pair[1],
+                                                       _describe_atom(self.top, self.group_definitions[pair[0]][0 ]),
+                                                       _describe_atom(self.top, self.group_definitions[pair[0]][-1]),
+                                                       _describe_atom(self.top, self.group_definitions[pair[1]][0]),
+                                                       _describe_atom(self.top, self.group_definitions[pair[1]][-1])
+                                                       ) for pair in self.distance_indexes]
         return labels
 
     @deprecated
@@ -1209,10 +1212,10 @@ class MDFeaturizer(object):
         """
 
         # Some thorough input checking and reformatting
-        __, group_pairs, distance_list, group_identifiers = _parse_groupwise_input(group_definitions, group_pairs, self._logger, 'add_group_mindist')
+        group_definitions, group_pairs, distance_list, group_identifiers = _parse_groupwise_input(group_definitions, group_pairs, self._logger, 'add_group_mindist')
         distance_list = self._check_indices(distance_list)
 
-        f = GroupMinDistanceFeature(self.topology, group_pairs, distance_list, group_identifiers, threshold)
+        f = GroupMinDistanceFeature(self.topology, group_definitions, group_pairs, distance_list, group_identifiers, threshold)
         self.__add_feature(f)
 
     def add_angles(self, indexes, deg=False, cossin=False):


### PR DESCRIPTION
Together with PR #561 , this PR allows for feature.describe() to behave like this:

``` python
residue_bw630 = 247
residue_bw350 = 135
FAH_feature.add_group_mindist([E249,K311_R314, R135,E247], group_pairs=np.array([[0,1], [2,3]]))
FAH_feature.describe()
```

``` python
['GROUP_MINDIST 0--1: [GLU 249 OE1 3946...GLU 249 OE2 3947]--[LYS 311 NZ 4956...ARG 314 NH2 5018]',
['GROUP_MINDIST 2--3: [ARG 135 NH1 2152...ARG 135 NH2 2155]--[GLU 247 OE1 3909...GLU 247 OE2 3910]']
```
