### PR TITLE
[setup] require setuptools>=18 to avoid a cython bug.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -170,7 +170,7 @@ def get_cmdclass():
             import pkg_resources
             dir = pkg_resources.resource_filename('numpy', 'core/include')
             self.include_dirs = [dir]
-            # self.include_dirs = [] # gets overwritten by super init
+            print("init include dirs to:", self.include_dirs)
             build_ext.initialize_options(self)
 
     sdist_class = versioneer_cmds['sdist']

--- a/setup.py
+++ b/setup.py
@@ -167,11 +167,19 @@ def get_cmdclass():
         """
         def initialize_options(self):
             build_ext.initialize_options(self)
-            import pkg_resources
-            dir = pkg_resources.resource_filename('numpy', 'core/include')
+            try:
+                import numpy
+                dir = numpy.get_include()
+            except ImportError:
+                # this method should work for pip installations, where the numpy
+                # egg is located in the source folder
+                import pkg_resources
+                dir = pkg_resources.resource_filename('numpy', 'core/include')
+
+            if not os.path.isdir(dir):
+                raise RuntimeError("NumPy include dir '%s' not found")
+
             self.include_dirs = [dir]
-            print("init include dirs to:", self.include_dirs)
-            build_ext.initialize_options(self)
 
     sdist_class = versioneer_cmds['sdist']
     class sdist(sdist_class):


### PR DESCRIPTION
This bug occurred prior setuptools version 18, if several setuptools projects
are being installed at once.

Fixes #567
