### PR TITLE
[coor/transformer|readers] made chunksize an attribute of reader interface

### DIFF
--- a/pyemma/coordinates/data/data_in_memory.py
+++ b/pyemma/coordinates/data/data_in_memory.py
@@ -113,7 +113,7 @@ class DataInMemory(ReaderInterface):
         traj = self._data[self._itraj]
 
         # complete trajectory mode
-        if self._chunksize == 0:
+        if self.chunksize == 0:
             if not ctx.uniform_stride:
                 X = self._data[self._itraj][ctx.ra_indices_for_traj(self._itraj)]
                 self._itraj += 1
@@ -155,14 +155,14 @@ class DataInMemory(ReaderInterface):
                     self._t = 0
                 return Y0
             else:
-                upper_bound = min(self._t + self._chunksize * ctx.stride, traj_len)
+                upper_bound = min(self._t + self.chunksize * ctx.stride, traj_len)
                 slice_x = slice(self._t, upper_bound, ctx.stride)
 
                 X = traj[slice_x]
 
                 if ctx.lag != 0:
                     upper_bound_Y = min(
-                         self._t + ctx.lag + self._chunksize * ctx.stride, traj_len)
+                         self._t + ctx.lag + self.chunksize * ctx.stride, traj_len)
                     slice_y = slice(self._t + ctx.lag, upper_bound_Y, ctx.stride)
                     Y = traj[slice_y]
 

--- a/pyemma/coordinates/data/interface.py
+++ b/pyemma/coordinates/data/interface.py
@@ -34,9 +34,10 @@ class ReaderInterface(Transformer):
     """
 
     def __init__(self, chunksize=100):
-        super(ReaderInterface, self).__init__(chunksize=chunksize)
+        super(ReaderInterface, self).__init__()
         # needs to be set, to ensure some getters of Transformer will work.
         self._data_producer = self
+        self.chunksize = chunksize
 
         # internal counters
         self._t = 0
@@ -58,6 +59,18 @@ class ReaderInterface(Transformer):
         import inspect
         res = inspect.getouterframes(inspect.currentframe())[1]
         self._logger.debug(str(res))
+
+    @property
+    def chunksize(self):
+        """chunksize defines how much data is being processed at once."""
+        return self._cs
+
+    @chunksize.setter
+    def chunksize(self, size):
+        if not size >= 0:
+            raise ValueError("chunksize has to be positive")
+
+        self._cs = int(size)
 
     def number_of_trajectories(self):
         """

--- a/pyemma/coordinates/data/numpy_filereader.py
+++ b/pyemma/coordinates/data/numpy_filereader.py
@@ -150,7 +150,7 @@ class NumPyFileReader(ReaderInterface, ProgressReporter):
             traj_len = context.ra_trajectory_length(self._itraj)
 
         # complete trajectory mode
-        if self._chunksize == 0:
+        if self.chunksize == 0:
             if not context.uniform_stride:
                 X = traj[context.ra_indices_for_traj(self._itraj)]
                 self._itraj += 1
@@ -179,12 +179,12 @@ class NumPyFileReader(ReaderInterface, ProgressReporter):
                 X = traj[context.ra_indices_for_traj(self._itraj)[self._t:min(self._t + self.chunksize, traj_len)]]
                 upper_bound = min(self._t + self.chunksize, traj_len)
             else:
-                upper_bound = min(self._t + self._chunksize * context.stride, traj_len)
+                upper_bound = min(self._t + self.chunksize * context.stride, traj_len)
                 slice_x = slice(self._t, upper_bound, context.stride)
                 X = traj[slice_x]
 
             if context.lag != 0:
-                upper_bound_Y = min(self._t + context.lag + self._chunksize * context.stride, traj_len)
+                upper_bound_Y = min(self._t + context.lag + self.chunksize * context.stride, traj_len)
                 slice_y = slice(self._t + context.lag, upper_bound_Y, context.stride)
                 Y = traj[slice_y]
 

--- a/pyemma/coordinates/transform/transformer.py
+++ b/pyemma/coordinates/transform/transformer.py
@@ -170,8 +170,10 @@ class Transformer(six.with_metaclass(ABCMeta, ProgressReporter)):
     # counting transformer instances, incremented by name property.
     _ids = count(0)
 
-    def __init__(self, chunksize=100):
-        self.chunksize = chunksize
+    def __init__(self, chunksize=None):
+        self._logger.warning("Given deprecated argument 'chunksize=%s'"
+                             " to transformer. Ignored - please set the "
+                             "chunksize in the reader" % chunksize)
         self._in_memory = False
         self._data_producer = None
         self._parametrized = False
@@ -212,21 +214,22 @@ class Transformer(six.with_metaclass(ABCMeta, ProgressReporter)):
     @property
     def chunksize(self):
         """chunksize defines how much data is being processed at once."""
-        return self._chunksize
+        return self.data_producer.chunksize
 
     @chunksize.setter
     def chunksize(self, size):
         if not size >= 0:
             raise ValueError("chunksize has to be positive")
-        self._chunksize = int(size)
+
+        self.data_producer.chunksize = int(size)
 
     def _n_chunks(self, stride=1):
         """ rough estimate of how many chunks will be processed """
-        if self._chunksize != 0:
+        if self.chunksize != 0:
             if not TransformerIteratorContext.is_uniform_stride(stride):
-                chunks = ceil(len(stride[:, 0]) / float(self._chunksize))
+                chunks = ceil(len(stride[:, 0]) / float(self.chunksize))
             else:
-                chunks = sum([ceil(l / float(self._chunksize))
+                chunks = sum([ceil(l / float(self.chunksize))
                               for l in self.trajectory_lengths(stride)])
         else:
             chunks = 1


### PR DESCRIPTION
Actually every derived transformer used to store an individual chunksize, which
has been ignored. So a transformer asks its data producer for the chunksize,
which is finally answered by the reader.
