### PR TITLE
[coor/traj_info_cache] added support for .npy

### DIFF
--- a/pyemma/coordinates/data/traj_info_cache.py
+++ b/pyemma/coordinates/data/traj_info_cache.py
@@ -30,7 +30,10 @@ else:
     import dbm as anydbm
 
 import os
+import numpy as np
 import mdtraj
+
+from mdtraj.formats.registry import _FormatRegistry as md_registry
 from threading import Semaphore
 from pyemma.util.config import conf_values
 
@@ -72,8 +75,15 @@ class _TrajectoryInfoCache(object):
         return int(result)
 
     def __determine_len(self, filename):
-        with mdtraj.open(filename) as fh:
-            return len(fh)
+        _, ext = os.path.splitext(filename)
+        if ext in md_registry.loaders:
+            with mdtraj.open(filename) as fh:
+                return len(fh)
+        elif ext in ('.npy'):
+            x = np.load(filename, mmap_mode='r')
+            return len(x)
+        else:
+            raise ValueError('file %s is unsupported.')
 
     def __format_value(self, filename, length):
         return str(length)

--- a/pyemma/coordinates/tests/test_traj_info_cache.py
+++ b/pyemma/coordinates/tests/test_traj_info_cache.py
@@ -27,6 +27,7 @@ import unittest
 import os
 import tempfile
 from glob import glob
+import numpy as np
 
 from pyemma.coordinates.data.traj_info_cache import _TrajectoryInfoCache as TrajectoryInfoCache
 import mdtraj
@@ -55,6 +56,23 @@ class TestTrajectoryInfoCache(unittest.TestCase):
                 desired[f] = len(fh)
 
         self.assertEqual(results, desired)
+
+    def test_with_npy_file(self):
+        from pyemma.util.files import TemporaryDirectory
+        lengths = [1, 23, 27, ]
+        different_lengths_array = [np.empty((n, 3)) for n in lengths]
+        files = []
+        with TemporaryDirectory() as td:
+            for i, x in enumerate(different_lengths_array):
+                fn = "%i.npy" % i
+                np.save(fn, x)
+                files.append(fn)
+
+            # cache it and compare
+            results = {f: self.db[f] for f in files}
+            expected = {fn: len(different_lengths_array[i]) for i, fn in enumerate(files)}
+
+            self.assertEqual(results, expected)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Assuming you're opening the same .npy files, their lengths (first dim) is being
cached in the same manner as trajectory files.
