### PR TITLE
added signal handling to enable easy debugging of hung python processes.

### DIFF
--- a/pyemma/util/debug.py
+++ b/pyemma/util/debug.py
@@ -1,0 +1,48 @@
+''' registers some debug handlers on the importing Python process:
+1. SIGUSR1 -> show a stack trace of the current frame
+2. SIGUSR2 -> attach the Python debugger pdb to the current process
+
+
+
+Created on 15.10.2015
+
+@author: marscher
+'''
+import signal
+from log import getLogger
+
+logger = None
+
+
+def show_stacktrace(sig, frame):
+    import traceback
+    import StringIO
+
+    global logger
+    if logger is None:
+        logger = getLogger('dbg')
+
+    out = StringIO.StringIO()
+
+    traceback.print_stack(frame, file=out)
+
+    out.seek(0)
+    trace = out.read()
+    logger.error(trace)
+
+
+def handle_pdb(sig, frame):
+    import pdb
+
+    pdb.Pdb().set_trace(frame)
+
+
+def register_signal_handlers():
+    # Register handler
+    global logger
+
+    signal.signal(42, show_stacktrace)
+    signal.signal(43, handle_pdb)
+
+def unregister_signal_handlers():
+    pass

--- a/pyemma/util/debug.py
+++ b/pyemma/util/debug.py
@@ -8,8 +8,10 @@ Created on 15.10.2015
 
 @author: marscher
 '''
+from __future__ import absolute_import
+
 import signal
-from log import getLogger
+from .log import getLogger
 
 logger = None
 
@@ -28,7 +30,7 @@ def show_stacktrace(sig, frame):
 
     out.seek(0)
     trace = out.read()
-    logger.error(trace)
+    logger.info(trace)
 
 
 def handle_pdb(sig, frame):

--- a/pyemma/util/debug.py
+++ b/pyemma/util/debug.py
@@ -82,8 +82,8 @@ def register_signal_handlers():
     To obtain a stack trace, just send the signal 42 to the current Python process id.
     This id can be obtained via:
 
-    >>> import os # +doctest:SKIP
-    >>> os.getpid() # +doctest:SKIP
+    >>> import os # doctest: +SKIP
+    >>> os.getpid() # doctest: +SKIP
     34588
 
     To send the signal you can use kill on Linux and OSX::

--- a/pyemma/util/debug.py
+++ b/pyemma/util/debug.py
@@ -1,28 +1,49 @@
-''' registers some debug handlers on the importing Python process:
-1. SIGUSR1 -> show a stack trace of the current frame
-2. SIGUSR2 -> attach the Python debugger pdb to the current process
 
+# This file is part of PyEMMA.
+#
+# Copyright (c) 2015, 2014 Computational Molecular Biology Group, Freie Universitaet Berlin (GER)
+#
+# PyEMMA is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+''' This module registers some debug handlers upon the call of
+:py:func:register_signal_handlers
+
+1. Show a stack trace of the current frame
+2. Attach the Python debugger PDB to the current process
 
 Created on 15.10.2015
 
 @author: marscher
 '''
-from __future__ import absolute_import
+from __future__ import absolute_import as _
 
 import signal
-from .log import getLogger
+from .log import getLogger as _getLogger
 
-logger = None
+_logger = None
+
+SIGNAL_STACKTRACE = 42
+SIGNAL_PDB = 43
 
 
-def show_stacktrace(sig, frame):
+def _show_stacktrace(sig, frame):
     import traceback
     import StringIO
 
-    global logger
-    if logger is None:
-        logger = getLogger('dbg')
+    global _logger
+    if _logger is None:
+        _logger = _getLogger('dbg')
 
     out = StringIO.StringIO()
 
@@ -30,21 +51,50 @@ def show_stacktrace(sig, frame):
 
     out.seek(0)
     trace = out.read()
-    logger.info(trace)
+    _logger.info(trace)
+
+    unregister_signal_handlers()
 
 
-def handle_pdb(sig, frame):
+def _handle_pdb(sig, frame):
     import pdb
-
     pdb.Pdb().set_trace(frame)
 
 
 def register_signal_handlers():
-    # Register handler
-    global logger
+    r""" Registeres some debug helping functions at the current Python process.
 
-    signal.signal(42, show_stacktrace)
-    signal.signal(43, handle_pdb)
+    Namely a stack trace generator (which uses the logging system) and a debugger
+    attaching function.
+    To trigger them, send the corresponding signal to the process::
+
+    1. kill -42 $PID # obtain a stack trace
+    2. kill -43 $PID # attach the debugger to the current stack frame
+
+    For the first signal, a stack trace originating from the current frame will
+    be logged using PyEMMAs logging system.
+
+    The second signal stops your program at the current stack frame by using
+    Pythons internal debugger PDB.
+    See https://docs.python.org/2/library/pdb.html for information on how to use
+    the debugger.
+
+    To obtain a stack trace, just send the signal 42 to the current Python process id.
+    This id can be obtained via:
+
+    >>> import os # +doctest:SKIP
+    >>> os.getpid() # +doctest:SKIP
+    34588
+
+    To send the signal you can use kill on Linux and OSX::
+
+    kill -42 34588
+    """
+    signal.signal(SIGNAL_STACKTRACE, _show_stacktrace)
+    signal.signal(SIGNAL_PDB, _handle_pdb)
+
 
 def unregister_signal_handlers():
-    pass
+    """ set signal handlers to default """
+    signal.signal(SIGNAL_STACKTRACE, signal.SIG_IGN)
+    signal.signal(SIGNAL_PDB, signal.SIG_IGN)


### PR DESCRIPTION
Scenario: a long-running cell evaluation in a notebook or plain python process has to be investigated (non-responsive, no useful console/logging).

You can either attach a debugger or at least at which state the program is at the moment.

The newly introduced debug module in util will enable this for you:

``` python
import os
print os.getpid() # prints eg. 2000
from pyemma.util import debug
debug.register_signal_handlers()

while True:
    import time
    time.sleep(1)
```

Now you can send the signal to log a stack trace to file/stdout.

``` bash
kill -42 2000
```

or attach the debugger to the frame which is on top of the stack, when the signal is received and handled by Python.

``` bash
kill -43 2000
```

I've chosen these signal numbers, because IPython already reserved SIGUSR{1,2} and it is unlikely that other packages using these.
