### PR TITLE
[logging] Estimators and Transformers do not pickle logger instances

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -21,6 +21,7 @@ Changelog
 
 - Upon import no deprecation warning (about acf function) is shown.
 - coordinates: chunksize attribute moved to readers (no consequence for user-scripts)
+- coordinates: fixed bug in parallel evaluation of Estimators, when they have active loggers.
 - documentation fixes 
 
 2.0.1 (9-3-2015)

--- a/pyemma/_base/estimator.py
+++ b/pyemma/_base/estimator.py
@@ -321,6 +321,15 @@ class Estimator(_BaseEstimator):
             create_logger(self)
             return self._logger_instance
 
+    def __getstate__(self):
+        # do not pickle the logger instance
+        d = dict(self.__dict__)
+        try:
+            del d['_logger_instance']
+        except KeyError:
+            pass
+        return d
+
     def estimate(self, X, **params):
         """ Estimates the model given the data X
 

--- a/pyemma/coordinates/transform/transformer.py
+++ b/pyemma/coordinates/transform/transformer.py
@@ -809,3 +809,11 @@ class Transformer(six.with_metaclass(ABCMeta, ProgressReporter)):
             self._Y = trajs
 
         return trajs
+
+    def __getstate__(self):
+        d = dict(self.__dict__)
+        try:
+            del d['_logger_instance']
+        except KeyError:
+            pass
+        return d


### PR DESCRIPTION
Since this led to an exception during pickling Estimators/Transformers during
multiprocessing. So in case a logger has been created in an Estimator and n_jobs != 1 this crashed before this fix.
