### PR TITLE
[coor/feature_reader+cache] workaround for missing __len__ function for xyz files.

### DIFF
--- a/pyemma/util/exceptions.py
+++ b/pyemma/util/exceptions.py
@@ -49,3 +49,9 @@ class NotConvergedWarning(RuntimeWarning):
     a conditional termination criterion.
 
     """
+    pass
+
+
+class EfficiencyWarning(UserWarning):
+    r"""Some operation or input data leads to a lack of efficiency"""
+    pass


### PR DESCRIPTION
Fixes #621

Shows a EfficiencyWarning because it reads the whole file (once by default, because the result will be cached).
