### PR TITLE
[coor/data/numpy_filereader] new argument dims=[-1]

### DIFF
--- a/pyemma/coordinates/data/numpy_filereader.py
+++ b/pyemma/coordinates/data/numpy_filereader.py
@@ -28,7 +28,7 @@ import functools
 
 from pyemma._base.progress import ProgressReporter
 from pyemma.coordinates.data.interface import ReaderInterface
-
+from pyemma.util.types import is_iterable_of_int as _is_iterable_of_int
 
 class NumPyFileReader(ReaderInterface, ProgressReporter):
 
@@ -41,11 +41,15 @@ class NumPyFileReader(ReaderInterface, ProgressReporter):
     chunksize : int
         how many rows are read at once
 
+    usecols : iterable of integers, default = None
+        specifies the columns to be extracted from npy files. If left to None
+        all columns will be extracted
+
     mmap_mode : str (optional), default='r'
         binary NumPy arrays are being memory mapped using this flag.
     """
 
-    def __init__(self, filenames, chunksize=1000, mmap_mode='r'):
+    def __init__(self, filenames, chunksize=1000, mmap_mode='r', usecols=None):
         super(NumPyFileReader, self).__init__(chunksize=chunksize)
 
         if not isinstance(filenames, (list, tuple)):
@@ -61,6 +65,12 @@ class NumPyFileReader(ReaderInterface, ProgressReporter):
 
         # currently opened array
         self._array = None
+
+        # bookkeeping for dimensions
+        if not _is_iterable_of_int(usecols) and usecols is not None:
+                raise ValueError("usecols has to be an iterable of integers! "
+                                 "Instead, dims = %s" % usecols)
+        self._usecols = usecols
 
         self.__set_dimensions_and_lenghts()
 
@@ -133,6 +143,14 @@ class NumPyFileReader(ReaderInterface, ProgressReporter):
                              "Dimensions are = %s" % ndims)
 
         self._ndim = ndims[0]
+        if self._usecols is None:
+            self._usecols = np.arange(self._ndim)
+        else:
+            if np.max(self._usecols) > self._ndim:
+                raise ValueError("Cannot ask for dimension %u, "
+                                 "only %u are available"%(np.max(self._usecols), self._ndim))
+            else:
+                self._ndim=len(self._usecols)
 
         self._ntraj = len(self._filenames)
 
@@ -165,13 +183,13 @@ class NumPyFileReader(ReaderInterface, ProgressReporter):
                 self._itraj += 1
 
             if context.lag == 0:
-                return X
+                return X[:,self._usecols]
             else:
                 if not context.uniform_stride:
                     raise ValueError("Requested lagged data but was in random access mode. This is not supported.")
                 else:
                     Y = traj[context.lag::context.stride]
-                return X, Y
+                return X[:,self._usecols], Y[:,self._usecols]
 
         # chunked mode
         else:
@@ -207,6 +225,6 @@ class NumPyFileReader(ReaderInterface, ProgressReporter):
                     self.__load_file(self._filenames[self._itraj])
 
             if context.lag == 0:
-                return X
+                return X[:,self._usecols]
             else:
-                return X, Y
+                return X[:,self._usecols], Y[:,self._usecols]

--- a/pyemma/coordinates/tests/test_numpyfilereader.py
+++ b/pyemma/coordinates/tests/test_numpyfilereader.py
@@ -168,5 +168,23 @@ class TestNumPyFileReader(unittest.TestCase):
                                             "not equal for stride=%i"
                                             " and lag=%i" % (stride, lag))
 
+    def test_lagged_stridden_access_multiple_files_dims(self):
+        reader = NumPyFileReader(self.files2d, usecols=[1])
+        print(reader.trajectory_lengths())
+        strides = [2, 3, 5, 7, 15]
+        lags = [1, 3, 7, 10, 30]
+        for stride in strides:
+            for lag in lags:
+                chunks = {i: [] for i in range(reader.number_of_trajectories())}
+                for itraj, _, Y in reader.iterator(stride, lag):
+                    chunks[itraj].append(Y)
+
+                for i, k in enumerate(chunks.values()):
+                    stack = np.vstack(k)
+                    d = np.load(self.files2d[i])[:,reader._usecols]
+                    np.testing.assert_equal(stack, d[lag::stride],
+                                            "not equal for stride=%i"
+                                            " and lag=%i" % (stride, lag))
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This allows for creating npy_readears for which columns can be chosen at the moment of "chunk-extraction". See the lines

   https://github.com/gph82/PyEMMA/commit/3d13dcea273c4f851138f1a0c9280635bdb1ba00/#L186
   https://github.com/gph82/PyEMMA/commit/3d13dcea273c4f851138f1a0c9280635bdb1ba00/#L192
   https://github.com/gph82/PyEMMA/commit/3d13dcea273c4f851138f1a0c9280635bdb1ba00/#L228
   https://github.com/gph82/PyEMMA/commit/3d13dcea273c4f851138f1a0c9280635bdb1ba00/#L230

@marscher , I took the most convoluted test and replicated it no problem. Do you think that I need to replicate all tests with the new parameter?
