### PR TITLE
Fix inspect getargspec python35 deprecation

### DIFF
--- a/pyemma/_base/model.py
+++ b/pyemma/_base/model.py
@@ -18,11 +18,11 @@
 
 from __future__ import absolute_import
 import numpy as _np
-import inspect
+#import inspect
 import warnings
 
 from pyemma.util.statistics import confidence_interval
-from pyemma.util.reflection import call_member
+from pyemma.util.reflection import call_member, getargspec_no_self
 
 __author__ = 'noe'
 
@@ -43,7 +43,7 @@ class Model(object):
             set_model_param_method = getattr(self, 'set_model_params')
             # introspect the constructor arguments to find the model parameters
             # to represent
-            args, varargs, kw, default = inspect.getargspec(set_model_param_method)
+            args, varargs, kw, default = getargspec_no_self(set_model_param_method)
             if varargs is not None:
                 raise RuntimeError("pyEMMA models should always specify their parameters in the signature"
                                    " of their set_model_params (no varargs). %s doesn't follow this convention."

--- a/pyemma/_base/progress/reporter.py
+++ b/pyemma/_base/progress/reporter.py
@@ -95,8 +95,8 @@ class ProgressReporter(object):
 
         assert callable(call_back)
         # check we have the desired function signature
-        import inspect
-        argspec = inspect.getargspec(call_back)
+        from pyemma.util.reflection import getargspec_no_self
+        argspec = getargspec_no_self(call_back)
         assert len(argspec.args) == 2
         assert argspec.varargs is not None
         assert argspec.keywords is not None

--- a/pyemma/_ext/sklearn/base.py
+++ b/pyemma/_ext/sklearn/base.py
@@ -208,10 +208,6 @@ class BaseEstimator(object):
                                " of their __init__ (no varargs)."
                                " %s doesn't follow this convention."
                                % (cls, ))
-        # Remove 'self'
-        # XXX: This is going to fail if the init is a staticmethod, but
-        # who would do this?
-        args.pop(0)
         args.sort()
         return args
 

--- a/pyemma/_ext/sklearn/base.py
+++ b/pyemma/_ext/sklearn/base.py
@@ -35,13 +35,13 @@ from __future__ import absolute_import
 # License: BSD 3 clause
 
 import copy
-import inspect
 import warnings
 
 import numpy as np
 from scipy import sparse
 
 import six
+from pyemma.util.reflection import getargspec_no_self
 
 ###############################################################################
 def clone(estimator, safe=True):
@@ -201,7 +201,7 @@ class BaseEstimator(object):
 
         # introspect the constructor arguments to find the model parameters
         # to represent
-        args, varargs, kw, default = inspect.getargspec(init)
+        args, varargs, kw, default = getargspec_no_self(init)
         if varargs is not None:
             raise RuntimeError("scikit-learn estimators should always "
                                "specify their parameters in the signature"

--- a/pyemma/util/reflection.py
+++ b/pyemma/util/reflection.py
@@ -16,11 +16,112 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from six import string_types
-import inspect
+from __future__ import division, print_function, absolute_import
 
-__author__ = 'noe'
-__code_fixer__ = 'marscher'
+import inspect
+from six import string_types
+from collections import namedtuple
+
+__author__ = 'noe, marscher'
+
+
+# Add a replacement for inspect.getargspec() which is deprecated in python 3.5
+# The version below is borrowed from Django,
+# https://github.com/django/django/pull/4846
+
+# Note an inconsistency between inspect.getargspec(func) and
+# inspect.signature(func). If `func` is a bound method, the latter does *not* 
+# list `self` as a first argument, while the former *does*.
+# Hence cook up a common ground replacement: `getargspec_no_self` which
+# mimics `inspect.getargspec` but does not list `self`.
+#
+# This way, the caller code does not need to know whether it uses a legacy
+# .getargspec or bright and shiny .signature.
+
+try:
+    # is it python 3.3 or higher?
+    inspect.signature
+
+    # Apparently, yes. Wrap inspect.signature
+
+    ArgSpec = namedtuple('ArgSpec', ['args', 'varargs', 'keywords', 'defaults'])
+
+    def getargspec_no_self(func):
+        """inspect.getargspec replacement using inspect.signature.
+
+        inspect.getargspec is deprecated in python 3. This is a replacement
+        based on the (new in python 3.3) `inspect.signature`.
+
+        Parameters
+        ----------
+        func : callable
+            A callable to inspect
+
+        Returns
+        -------
+        argspec : ArgSpec(args, varargs, varkw, defaults)
+            This is similar to the result of inspect.getargspec(func) under
+            python 2.x.
+            NOTE: if the first argument of `func` is self, it is *not*, I repeat
+            *not* included in argspec.args.
+            This is done for consistency between inspect.getargspec() under
+            python 2.x, and inspect.signature() under python 3.x.
+        """
+        sig = inspect.signature(func)
+        args = [
+            p.name for p in sig.parameters.values()
+            if p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD
+        ]
+        varargs = [
+            p.name for p in sig.parameters.values()
+            if p.kind == inspect.Parameter.VAR_POSITIONAL
+        ]
+        varargs = varargs[0] if varargs else None
+        varkw = [
+            p.name for p in sig.parameters.values()
+            if p.kind == inspect.Parameter.VAR_KEYWORD
+        ]
+        varkw = varkw[0] if varkw else None
+        defaults = [
+            p.default for p in sig.parameters.values()
+            if (p.kind == inspect.Parameter.POSITIONAL_OR_KEYWORD and
+               p.default is not p.empty)
+        ] or None
+        
+        if args[0] == 'self':
+            args.pop(0)
+        
+        return ArgSpec(args, varargs, varkw, defaults)
+
+except AttributeError:
+    # python 2.x
+    def getargspec_no_self(func):
+        """inspect.getargspec replacement for compatibility with python 3.x.
+
+        inspect.getargspec is deprecated in python 3. This wraps it, and
+        *removes* `self` from the argument list of `func`, if present.
+        This is done for forward compatibility with python 3.
+
+        Parameters
+        ----------
+        func : callable
+            A callable to inspect
+
+        Returns
+        -------
+        argspec : ArgSpec(args, varargs, varkw, defaults)
+            This is similar to the result of inspect.getargspec(func) under
+            python 2.x.
+            NOTE: if the first argument of `func` is self, it is *not*, I repeat
+            *not* included in argspec.args.
+            This is done for consistency between inspect.getargspec() under
+            python 2.x, and inspect.signature() under python 3.x.
+        """
+        argspec = inspect.getargspec(func)
+        if argspec.args[0] == 'self':
+            argspec.args.pop(0)
+        return argspec
+
 
 def call_member(obj, f, *args, **kwargs):
     """ Calls the specified method, property or attribute of the given object


### PR DESCRIPTION
fixes 
`DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() instead` 
