### PR TITLE
[plots] lazily import matplotlib (upon usage).

### DIFF
--- a/pyemma/plots/markovtests.py
+++ b/pyemma/plots/markovtests.py
@@ -21,7 +21,7 @@ __author__ = 'noe'
 
 import math
 import numpy as np
-import matplotlib.pylab as plt
+
 
 def _add_ck_subplot(cktest, ax, i, j, ipos=None, jpos=None, y01=True, units='steps', dt=1.):
     # plot estimates
@@ -88,6 +88,8 @@ def plot_cktest(cktest, figsize=None, diag=False,  y01=True, layout=None,
         padding space on top of subplots (as a fraction of 1.0)
 
     """
+    import matplotlib.pylab as plt
+
     sharey = y01
     # first fix subfigure layout
     if diag:

--- a/pyemma/plots/networks.py
+++ b/pyemma/plots/networks.py
@@ -21,8 +21,6 @@ from __future__ import absolute_import
 import math
 import numpy as np
 
-from matplotlib import pylab as plt
-from matplotlib import rcParams
 from pyemma.util import types as _types
 from six.moves import range
 
@@ -65,6 +63,8 @@ class NetworkPlot(object):
         <matplotlib.figure.Figure...
 
         """
+        from matplotlib import pylab as plt
+
         if A.shape[0] >= 50:
             import warnings
             warnings.warn("The layout optimization method will take a long"
@@ -74,6 +74,7 @@ class NetworkPlot(object):
         self.pos = pos
         self.xpos = xpos
         self.ypos = ypos
+        self.plt = plt
 
     def _draw_arrow(self, x1, y1, x2, y2, Dx, Dy, label="", width=1.0,
                     arrow_curvature=1.0, color="grey",
@@ -83,6 +84,7 @@ class NetworkPlot(object):
         Will allow the given patches at start end end.
 
         """
+        plt = self.plt
         # set arrow properties
         dist = math.sqrt(
             ((x2 - x1) / float(Dx))**2 + ((y2 - y1) / float(Dy))**2)
@@ -131,6 +133,8 @@ class NetworkPlot(object):
         The thicknesses and labels of the arrows are taken from the off-diagonal matrix elements in A.
 
         """
+        plt = self.plt
+
         if self.pos is None:
             self.layout_automatic()
         # number of nodes
@@ -166,6 +170,7 @@ class NetworkPlot(object):
         fig = plt.gcf()
         fig.set_size_inches(figsize, forward=True)
         # font sizes
+        from matplotlib import rcParams
         old_fontsize = rcParams['font.size']
         rcParams['font.size'] = 20
         # remove axis labels
@@ -500,6 +505,7 @@ def plot_flux(flux, pos=None, state_sizes=None, flux_scale=1.0,
     (<matplotlib.figure.Figure..., array...)
 
     """
+    from matplotlib import pylab as plt
     F = flux_scale * getattr(flux, attribute_to_plot)
     c = flux.committor
     if state_sizes is None:
@@ -517,6 +523,7 @@ def plot_flux(flux, pos=None, state_sizes=None, flux_scale=1.0,
                            figpadding=figpadding, xticks=show_committor, yticks=False, show_frame=show_frame,
                            **textkwargs)
     if show_committor:
+        
         plt.xlabel('Committor probability')
     return ax, plot.pos
 

--- a/pyemma/plots/plots2d.py
+++ b/pyemma/plots/plots2d.py
@@ -16,16 +16,16 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
-
 from __future__ import absolute_import
-__author__ = 'noe'
 
 import numpy as _np
-import matplotlib.pylab as _plt
 from scipy.interpolate import griddata as gd
 
+__author__ = 'noe'
+
+
 def contour(x, y, z, ncontours = 50, colorbar=True, fig=None, ax=None, method='linear', zlim=None, cmap=None):
+    import matplotlib.pylab as _plt
     # check input
     if (ax is None):
         if fig is None:
@@ -80,6 +80,7 @@ def scatter_contour(x, y, z, ncontours = 50, colorbar=True, fig=None, ax=None, c
     ax : Axes object containing the plot
 
     """
+    import matplotlib.pylab as _plt
     ax = contour(x, y, z, ncontours=ncontours, colorbar=colorbar, fig=fig, ax=ax, cmap=cmap)
 
     # scatter points
@@ -92,7 +93,8 @@ def scatter_contour(x, y, z, ncontours = 50, colorbar=True, fig=None, ax=None, c
     return ax
 
 
-def plot_free_energy(xall, yall, weights=None, ax=None, nbins=100, offset=0.1, cmap=_plt.cm.spectral, cbar=True, cbar_label='Free energy (kT)'):
+def plot_free_energy(xall, yall, weights=None, ax=None, nbins=100, offset=0.1,
+                     cmap='spectral', cbar=True, cbar_label='Free energy (kT)'):
     """Free energy plot given 2D scattered data
 
     Builds a 2D-histogram of the given data points and plots -log(p) where p is
@@ -128,7 +130,9 @@ def plot_free_energy(xall, yall, weights=None, ax=None, nbins=100, offset=0.1, c
     fig : Figure object containing the plot
 
     """
-    z,x,y = _np.histogram2d(xall, yall, bins=nbins, weights=weights)
+    import matplotlib.pylab as _plt
+
+    z, x, y = _np.histogram2d(xall, yall, bins=nbins, weights=weights)
     z += offset
     # compute free energies
     F = -_np.log(z)
@@ -143,3 +147,4 @@ def plot_free_energy(xall, yall, weights=None, ax=None, nbins=100, offset=0.1, c
             cbar.ax.set_ylabel(cbar_label)
 
     return ax, _plt.gcf()
+

--- a/pyemma/plots/timescales.py
+++ b/pyemma/plots/timescales.py
@@ -16,14 +16,13 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
-
 from __future__ import absolute_import
+
 from six.moves import range
+import numpy as _np
+
 __author__ = 'noe'
 
-import numpy as _np
-import matplotlib.pylab as _plt
 
 def plot_implied_timescales(ITS, ax=None, outfile=None, show_mle=True, show_mean=True,
                             xlog=False, ylog=True, confidence=0.95, refs=None,
@@ -70,6 +69,8 @@ def plot_implied_timescales(ITS, ax=None, outfile=None, show_mle=True, show_mean
     ax : Axes object containing the plot
 
     """
+    import matplotlib.pylab as _plt
+
     # check input
     if (ax is None):
         ax = _plt.gca()


### PR DESCRIPTION
This partially addresses #420. It saves ~0.3s during import according to
`timeit.timeit('imp()', 'def imp(): import pyemma;')`

by importing matplotlib when it is needed and not during definition of the module.
