### PR TITLE
Fix mlmsm revpi

### DIFF
--- a/pyemma/msm/api.py
+++ b/pyemma/msm/api.py
@@ -265,6 +265,7 @@ def markov_model(P, dt_model='1 step'):
 
 
 def estimate_markov_model(dtrajs, lag, reversible=True, statdist=None,
+                          count_mode='sliding',
                           sparse=False, connectivity='largest',
                           dt_traj='1 step', maxiter=1000000, maxerr=1e-8):
     r""" Estimates a Markov model from discrete trajectories
@@ -287,6 +288,26 @@ def estimate_markov_model(dtrajs, lag, reversible=True, statdist=None,
         Stationary vector on the full state-space. Transition matrix
         will be estimated such that statdist is its equilibrium
         distribution.
+    count_mode : str, optional, default='sliding'
+        mode to obtain count matrices from discrete trajectories. Should be
+        one of:
+
+        * 'sliding' : A trajectory of length T will have :math:`T-tau` counts
+          at time indexes
+
+              .. math::
+
+                 (0 \rightarrow \tau), (1 \rightarrow \tau+1), ..., (T-\tau-1 \rightarrow T-1)
+
+        * 'effective' : Uses an estimate of the transition counts that are
+          statistically uncorrelated. Recommended when used with a
+          Bayesian MSM.
+        * 'sample' : A trajectory of length T will have :math:`T/tau` counts
+          at time indexes
+
+              .. math::
+
+                    (0 \rightarrow \tau), (\tau \rightarrow 2 \tau), ..., (((T/tau)-1) \tau \rightarrow T)
     sparse : bool, optional
         If true compute count matrix, transition matrix and all
         derived quantities using sparse matrix algebra.  In this case
@@ -474,6 +495,7 @@ def estimate_markov_model(dtrajs, lag, reversible=True, statdist=None,
     """
     # transition matrix estimator
     mlmsm = _ML_MSM(lag=lag, reversible=reversible, statdist_constraint=statdist,
+                    count_mode=count_mode,
                     sparse=sparse, connectivity=connectivity,
                     dt_traj=dt_traj, maxiter=maxiter,
                     maxerr=maxerr)
@@ -787,6 +809,7 @@ def estimate_hidden_markov_model(dtrajs, nstates, lag, reversible=True, connecti
 
 def bayesian_markov_model(dtrajs, lag, reversible=True, statdist=None,
                           sparse=False, connectivity='largest',
+                          count_mode ='effective',
                           nsamples=100, conf=0.95, dt_traj='1 step',
                           show_progress=True):
     r""" Bayesian Markov model estimate using Gibbs sampling of the posterior
@@ -811,6 +834,30 @@ def bayesian_markov_model(dtrajs, lag, reversible=True, statdist=None,
         matrices will be returned by the corresponding functions instead of
         numpy arrays. This behavior is suggested for very large numbers of
         states (e.g. > 4000) because it is likely to be much more efficient.
+    statdist : (M,) ndarray, optional
+        Stationary vector on the full state-space. Transition matrix
+        will be estimated such that statdist is its equilibrium
+        distribution.
+    count_mode : str, optional, default='sliding'
+        mode to obtain count matrices from discrete trajectories. Should be
+        one of:
+
+        * 'sliding' : A trajectory of length T will have :math:`T-tau` counts
+          at time indexes
+
+              .. math::
+
+                 (0 \rightarrow \tau), (1 \rightarrow \tau+1), ..., (T-\tau-1 \rightarrow T-1)
+
+        * 'effective' : Uses an estimate of the transition counts that are
+          statistically uncorrelated. Recommended when used with a
+          Bayesian MSM.
+        * 'sample' : A trajectory of length T will have :math:`T/tau` counts
+          at time indexes
+
+              .. math::
+
+                    (0 \rightarrow \tau), (\tau \rightarrow 2 \tau), ..., (((T/tau)-1) \tau \rightarrow T)
     connectivity : str, optional, default = 'largest'
         Connectivity mode. Three methods are intended (currently only 'largest'
         is implemented):
@@ -953,6 +1000,7 @@ def bayesian_markov_model(dtrajs, lag, reversible=True, statdist=None,
     # TODO: store_data=True
     bmsm_estimator = _Bayes_MSM(lag=lag, reversible=reversible,
                                 statdist_constraint=statdist,
+                                count_mode=count_mode,
                                 sparse=sparse, connectivity=connectivity,
                                 dt_traj=dt_traj, nsamples=nsamples, conf=conf, show_progress=show_progress)
     return bmsm_estimator.estimate(dtrajs)

--- a/pyemma/msm/api.py
+++ b/pyemma/msm/api.py
@@ -785,8 +785,10 @@ def estimate_hidden_markov_model(dtrajs, nstates, lag, reversible=True, connecti
     return hmsm_estimator.estimate(dtrajs)
 
 
-def bayesian_markov_model(dtrajs, lag, reversible=True, sparse=False, connectivity='largest',
-                          nsamples=100, conf=0.95, dt_traj='1 step', show_progress=True):
+def bayesian_markov_model(dtrajs, lag, reversible=True, statdist=None,
+                          sparse=False, connectivity='largest',
+                          nsamples=100, conf=0.95, dt_traj='1 step',
+                          show_progress=True):
     r""" Bayesian Markov model estimate using Gibbs sampling of the posterior
 
     Returns a :class:`BayesianMSM` that contains the
@@ -949,7 +951,9 @@ def bayesian_markov_model(dtrajs, lag, reversible=True, sparse=False, connectivi
 
     """
     # TODO: store_data=True
-    bmsm_estimator = _Bayes_MSM(lag=lag, reversible=reversible, sparse=sparse, connectivity=connectivity,
+    bmsm_estimator = _Bayes_MSM(lag=lag, reversible=reversible,
+                                statdist_constraint=statdist,
+                                sparse=sparse, connectivity=connectivity,
                                 dt_traj=dt_traj, nsamples=nsamples, conf=conf, show_progress=show_progress)
     return bmsm_estimator.estimate(dtrajs)
 

--- a/pyemma/msm/models/msm.py
+++ b/pyemma/msm/models/msm.py
@@ -141,7 +141,7 @@ class MSM(_Model):
         # check input
         if P is not None:
             import msmtools.estimation as msmest
-            if not msmana.is_transition_matrix(P):
+            if not msmana.is_transition_matrix(P, tol=1e-8):
                 raise ValueError('T is not a transition matrix.')
             # check connectivity
             # TODO: abusing C-connectivity test for T. Either provide separate T-connectivity test or move to a central

--- a/pyemma/msm/tests/test_bayesian_msm.py
+++ b/pyemma/msm/tests/test_bayesian_msm.py
@@ -230,5 +230,226 @@ class TestBMSM(unittest.TestCase):
     # TODO: these tests can be made compact because they are almost the same. can define general functions for testing
     # TODO: samples and stats, only need to implement consistency check individually.
 
+class TestBMSMRevPi(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        # load observations
+        import pyemma.datasets
+        data = pyemma.datasets.load_2well_discrete()
+        obs_micro = data.dtraj_T100K_dt10
+        pi_micro = data.msm.stationary_distribution
+        pi_macro = np.zeros(2)
+        pi_macro[0] = pi_micro[0:50].sum()
+        pi_macro[1] = pi_micro[50:].sum()
+        # coarse-grain microstates to two metastable states
+        cg = np.zeros(100, dtype=int)
+        cg[50:] = 1
+        obs_macro = cg[obs_micro]
+
+        # hidden states
+        cls.nstates = 2
+        # samples
+        cls.nsamples = 100
+
+        cls.lag = 100
+        cls.sampled_msm_lag100 = bayesian_markov_model(obs_macro, cls.lag, reversible=True, statdist=pi_macro,
+                                                       nsamples=cls.nsamples)
+
+    def test_reversible(self):
+        assert self.sampled_msm_lag100.is_reversible
+
+    def test_lag(self):
+        assert self.sampled_msm_lag100.lagtime == self.lag
+
+    def test_nstates(self):
+        assert self.sampled_msm_lag100.nstates == self.nstates
+
+    def test_transition_matrix_samples(self):
+        Psamples = self.sampled_msm_lag100.sample_f('transition_matrix')
+        # shape
+        assert np.array_equal(np.shape(Psamples), (self.nsamples, self.nstates, self.nstates))
+        # consistency
+        import msmtools.analysis as msmana
+        for P in Psamples:
+            assert msmana.is_transition_matrix(P)
+            assert msmana.is_reversible(P)
+
+    def test_transition_matrix_stats(self):
+        import msmtools.analysis as msmana
+        # mean
+        Pmean = self.sampled_msm_lag100.sample_mean('transition_matrix')
+        # test shape and consistency
+        assert np.array_equal(Pmean.shape, (self.nstates, self.nstates))
+        assert msmana.is_transition_matrix(Pmean)
+        # std
+        Pstd = self.sampled_msm_lag100.sample_std('transition_matrix')
+        # test shape
+        assert np.array_equal(Pstd.shape, (self.nstates, self.nstates))
+        # conf
+        L, R = self.sampled_msm_lag100.sample_conf('transition_matrix')
+        # test shape
+        assert np.array_equal(L.shape, (self.nstates, self.nstates))
+        assert np.array_equal(R.shape, (self.nstates, self.nstates))
+        # test consistency
+        assert np.all(L <= Pmean)
+        assert np.all(R >= Pmean)
+
+    def test_eigenvalues_samples(self):
+        samples = self.sampled_msm_lag100.sample_f('eigenvalues')
+        # shape
+        self.assertEqual(np.shape(samples), (self.nsamples, self.nstates))
+        # consistency
+        for ev in samples:
+            assert np.isclose(ev[0], 1)
+            assert np.all(ev[1:] < 1.0)
+
+    def test_eigenvalues_stats(self):
+        # mean
+        mean = self.sampled_msm_lag100.sample_mean('eigenvalues')
+        # test shape and consistency
+        assert np.array_equal(mean.shape, (self.nstates,))
+        assert np.isclose(mean[0], 1)
+        assert np.all(mean[1:] < 1.0)
+        # std
+        std = self.sampled_msm_lag100.sample_std('eigenvalues')
+        # test shape
+        assert np.array_equal(std.shape, (self.nstates,))
+        # conf
+        L, R = self.sampled_msm_lag100.sample_conf('eigenvalues')
+        # test shape
+        assert np.array_equal(L.shape, (self.nstates,))
+        assert np.array_equal(R.shape, (self.nstates,))
+        # test consistency
+        assert np.all(L <= mean)
+        assert np.all(R >= mean)
+
+    def test_eigenvectors_left_samples(self):
+        samples = self.sampled_msm_lag100.sample_f('eigenvectors_left')
+        # shape
+        np.testing.assert_equal(np.shape(samples), (self.nsamples, self.nstates, self.nstates))
+        # consistency
+        for evec in samples:
+            assert np.sign(evec[0,0]) == np.sign(evec[0,1])
+            assert np.sign(evec[1,0]) != np.sign(evec[1,1])
+
+    def test_eigenvectors_left_stats(self):
+        # mean
+        mean = self.sampled_msm_lag100.sample_mean('eigenvectors_left')
+        # test shape and consistency
+        assert np.array_equal(mean.shape, (self.nstates, self.nstates))
+        assert np.sign(mean[0,0]) == np.sign(mean[0,1])
+        assert np.sign(mean[1,0]) != np.sign(mean[1,1])
+        # std
+        std = self.sampled_msm_lag100.sample_std('eigenvectors_left')
+        # test shape
+        assert np.array_equal(std.shape, (self.nstates, self.nstates))
+        # conf
+        L, R = self.sampled_msm_lag100.sample_conf('eigenvectors_left')
+        # test shape
+        assert np.array_equal(L.shape, (self.nstates, self.nstates))
+        assert np.array_equal(R.shape, (self.nstates, self.nstates))
+        # Eigenvectors are constant acorss the sample, skip this test,
+        # since it can not handle the case for which L, mean, and R are
+        # numerically equal
+        # test consistency 
+        # assert np.all(L <= mean)
+        # assert np.all(R >= mean)
+
+    def test_eigenvectors_right_samples(self):
+        samples = self.sampled_msm_lag100.sample_f('eigenvectors_right')
+        # shape
+        np.testing.assert_equal(np.shape(samples), (self.nsamples, self.nstates, self.nstates))
+        # consistency
+        for evec in samples:
+            assert np.sign(evec[0,0]) == np.sign(evec[1,0])
+            assert np.sign(evec[0,1]) != np.sign(evec[1,1])
+
+    def test_eigenvectors_right_stats(self):
+        # mean
+        mean = self.sampled_msm_lag100.sample_mean('eigenvectors_right')
+        # test shape and consistency
+        np.testing.assert_equal(mean.shape, (self.nstates, self.nstates))
+        assert np.sign(mean[0,0]) == np.sign(mean[1,0])
+        assert np.sign(mean[0,1]) != np.sign(mean[1,1])
+        # std
+        std = self.sampled_msm_lag100.sample_std('eigenvectors_right')
+        # test shape
+        assert np.array_equal(std.shape, (self.nstates, self.nstates))
+        # conf
+        L, R = self.sampled_msm_lag100.sample_conf('eigenvectors_right')
+        # test shape
+        assert np.array_equal(L.shape, (self.nstates, self.nstates))
+        assert np.array_equal(R.shape, (self.nstates, self.nstates))
+        # test consistency
+        # Eigenvectors are constant acorss the sample, skip this test,
+        # since it can not handle the case for which L, mean, and R are
+        # numerically equal
+        # assert np.all(L <= mean)
+        # assert np.all(R >= mean)
+
+    def test_stationary_distribution_samples(self):
+        samples = self.sampled_msm_lag100.sample_f('stationary_distribution')
+        # shape
+        assert np.array_equal(np.shape(samples), (self.nsamples, self.nstates))
+        # consistency
+        for mu in samples:
+            assert np.isclose(mu.sum(), 1.0)
+            assert np.all(mu > 0.0)
+
+    def test_stationary_distribution_stats(self):
+        # mean
+        mean = self.sampled_msm_lag100.sample_mean('stationary_distribution')
+        # test shape and consistency
+        assert np.array_equal(mean.shape, (self.nstates, ))
+        assert np.isclose(mean.sum(), 1.0)
+        assert np.all(mean > 0.0)
+        assert np.max(np.abs(mean[0]-mean[1])) < 0.05
+        # std
+        std = self.sampled_msm_lag100.sample_std('stationary_distribution')
+        # test shape
+        assert np.array_equal(std.shape, (self.nstates, ))
+        # conf
+        L, R = self.sampled_msm_lag100.sample_conf('stationary_distribution')
+        # test shape
+        assert np.array_equal(L.shape, (self.nstates, ))
+        assert np.array_equal(R.shape, (self.nstates, ))
+        # test consistency, i.e. fixed stationary distribution
+        assert np.allclose(std, 0.0)
+        assert np.allclose(L-mean, 0.0)
+        assert np.allclose(R-mean, 0.0)                      
+
+
+    def test_timescales_samples(self):
+        samples = self.sampled_msm_lag100.sample_f('timescales')
+        # shape
+        np.testing.assert_equal(np.shape(samples), (self.nsamples, self.nstates-1))
+        # consistency
+        for l in samples:
+            assert np.all(l > 0.0)
+
+    def test_timescales_stats(self):
+        # mean
+        mean = self.sampled_msm_lag100.sample_mean('timescales')
+        # test shape and consistency
+        assert np.array_equal(mean.shape, (self.nstates-1, ))
+        assert np.all(mean > 0.0)
+        # std
+        std = self.sampled_msm_lag100.sample_std('timescales')
+        # test shape
+        assert np.array_equal(std.shape, (self.nstates-1, ))
+        # conf
+        L, R = self.sampled_msm_lag100.sample_conf('timescales')
+        # test shape
+        assert np.array_equal(L.shape, (self.nstates-1, ))
+        assert np.array_equal(R.shape, (self.nstates-1, ))
+        # test consistency
+        assert np.all(L <= mean)
+        assert np.all(R >= mean)
+
+    # TODO: these tests can be made compact because they are almost the same. can define general functions for testing
+    # TODO: samples and stats, only need to implement consistency check individually.
+
+    
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/msm/tests/test_bayesian_msm.py
+++ b/pyemma/msm/tests/test_bayesian_msm.py
@@ -133,7 +133,7 @@ class TestBMSM(unittest.TestCase):
         self._eigenvalues_stats(self.bmsm_rev)
         self._eigenvalues_stats(self.bmsm_revpi)
         
-    def _eigenvalues_stats(self, msm):
+    def _eigenvalues_stats(self, msm, tol=1e-12):
         # mean
         mean = msm.sample_mean('eigenvalues')
         # test shape and consistency
@@ -150,8 +150,8 @@ class TestBMSM(unittest.TestCase):
         assert np.array_equal(L.shape, (self.nstates,))
         assert np.array_equal(R.shape, (self.nstates,))
         # test consistency
-        assert np.all(L <= mean)
-        assert np.all(R >= mean)
+        assert np.all(L-tol <= mean)
+        assert np.all(R+tol >= mean)
 
     def test_eigenvectors_left_samples(self):
         self._eigenvectors_left_samples(self.bmsm_rev)
@@ -277,8 +277,8 @@ class TestBMSM(unittest.TestCase):
             assert np.all(l > 0.0)
 
     def test_timescales_stats(self):
-        self._timescales_samples(self.bmsm_rev)
-        self._timescales_samples(self.bmsm_revpi) 
+        self._timescales_stats(self.bmsm_rev)
+        self._timescales_stats(self.bmsm_revpi) 
 
     def _timescales_stats(self, msm):
         # mean

--- a/pyemma/msm/tests/test_bayesian_msm.py
+++ b/pyemma/msm/tests/test_bayesian_msm.py
@@ -19,6 +19,7 @@
 from __future__ import absolute_import
 import unittest
 import numpy as np
+import scipy
 from pyemma.msm import bayesian_markov_model
 from os.path import abspath, join
 from os import pardir
@@ -30,218 +31,15 @@ class TestBMSM(unittest.TestCase):
     def setUpClass(cls):
         # load observations
         import pyemma.datasets
-        obs_micro = pyemma.datasets.load_2well_discrete().dtraj_T100K_dt10
-        # coarse-grain microstates to two metastable states
-        cg = np.zeros(100, dtype=int)
-        cg[50:] = 1
-        obs_macro = cg[obs_micro]
-
-        # hidden states
-        cls.nstates = 2
-        # samples
-        cls.nsamples = 100
-
-        cls.lag = 100
-        cls.sampled_msm_lag100 = bayesian_markov_model(obs_macro, cls.lag, reversible=True, nsamples=cls.nsamples)
-
-    def test_reversible(self):
-        assert self.sampled_msm_lag100.is_reversible
-
-    def test_lag(self):
-        assert self.sampled_msm_lag100.lagtime == self.lag
-
-    def test_nstates(self):
-        assert self.sampled_msm_lag100.nstates == self.nstates
-
-    def test_transition_matrix_samples(self):
-        Psamples = self.sampled_msm_lag100.sample_f('transition_matrix')
-        # shape
-        assert np.array_equal(np.shape(Psamples), (self.nsamples, self.nstates, self.nstates))
-        # consistency
-        import msmtools.analysis as msmana
-        for P in Psamples:
-            assert msmana.is_transition_matrix(P)
-            assert msmana.is_reversible(P)
-
-    def test_transition_matrix_stats(self):
-        import msmtools.analysis as msmana
-        # mean
-        Pmean = self.sampled_msm_lag100.sample_mean('transition_matrix')
-        # test shape and consistency
-        assert np.array_equal(Pmean.shape, (self.nstates, self.nstates))
-        assert msmana.is_transition_matrix(Pmean)
-        # std
-        Pstd = self.sampled_msm_lag100.sample_std('transition_matrix')
-        # test shape
-        assert np.array_equal(Pstd.shape, (self.nstates, self.nstates))
-        # conf
-        L, R = self.sampled_msm_lag100.sample_conf('transition_matrix')
-        # test shape
-        assert np.array_equal(L.shape, (self.nstates, self.nstates))
-        assert np.array_equal(R.shape, (self.nstates, self.nstates))
-        # test consistency
-        assert np.all(L <= Pmean)
-        assert np.all(R >= Pmean)
-
-    def test_eigenvalues_samples(self):
-        samples = self.sampled_msm_lag100.sample_f('eigenvalues')
-        # shape
-        self.assertEqual(np.shape(samples), (self.nsamples, self.nstates))
-        # consistency
-        for ev in samples:
-            assert np.isclose(ev[0], 1)
-            assert np.all(ev[1:] < 1.0)
-
-    def test_eigenvalues_stats(self):
-        # mean
-        mean = self.sampled_msm_lag100.sample_mean('eigenvalues')
-        # test shape and consistency
-        assert np.array_equal(mean.shape, (self.nstates,))
-        assert np.isclose(mean[0], 1)
-        assert np.all(mean[1:] < 1.0)
-        # std
-        std = self.sampled_msm_lag100.sample_std('eigenvalues')
-        # test shape
-        assert np.array_equal(std.shape, (self.nstates,))
-        # conf
-        L, R = self.sampled_msm_lag100.sample_conf('eigenvalues')
-        # test shape
-        assert np.array_equal(L.shape, (self.nstates,))
-        assert np.array_equal(R.shape, (self.nstates,))
-        # test consistency
-        assert np.all(L <= mean)
-        assert np.all(R >= mean)
-
-    def test_eigenvectors_left_samples(self):
-        samples = self.sampled_msm_lag100.sample_f('eigenvectors_left')
-        # shape
-        np.testing.assert_equal(np.shape(samples), (self.nsamples, self.nstates, self.nstates))
-        # consistency
-        for evec in samples:
-            assert np.sign(evec[0,0]) == np.sign(evec[0,1])
-            assert np.sign(evec[1,0]) != np.sign(evec[1,1])
-
-    def test_eigenvectors_left_stats(self):
-        # mean
-        mean = self.sampled_msm_lag100.sample_mean('eigenvectors_left')
-        # test shape and consistency
-        assert np.array_equal(mean.shape, (self.nstates, self.nstates))
-        assert np.sign(mean[0,0]) == np.sign(mean[0,1])
-        assert np.sign(mean[1,0]) != np.sign(mean[1,1])
-        # std
-        std = self.sampled_msm_lag100.sample_std('eigenvectors_left')
-        # test shape
-        assert np.array_equal(std.shape, (self.nstates, self.nstates))
-        # conf
-        L, R = self.sampled_msm_lag100.sample_conf('eigenvectors_left')
-        # test shape
-        assert np.array_equal(L.shape, (self.nstates, self.nstates))
-        assert np.array_equal(R.shape, (self.nstates, self.nstates))
-        # test consistency
-        assert np.all(L <= mean)
-        assert np.all(R >= mean)
-
-    def test_eigenvectors_right_samples(self):
-        samples = self.sampled_msm_lag100.sample_f('eigenvectors_right')
-        # shape
-        np.testing.assert_equal(np.shape(samples), (self.nsamples, self.nstates, self.nstates))
-        # consistency
-        for evec in samples:
-            assert np.sign(evec[0,0]) == np.sign(evec[1,0])
-            assert np.sign(evec[0,1]) != np.sign(evec[1,1])
-
-    def test_eigenvectors_right_stats(self):
-        # mean
-        mean = self.sampled_msm_lag100.sample_mean('eigenvectors_right')
-        # test shape and consistency
-        np.testing.assert_equal(mean.shape, (self.nstates, self.nstates))
-        assert np.sign(mean[0,0]) == np.sign(mean[1,0])
-        assert np.sign(mean[0,1]) != np.sign(mean[1,1])
-        # std
-        std = self.sampled_msm_lag100.sample_std('eigenvectors_right')
-        # test shape
-        assert np.array_equal(std.shape, (self.nstates, self.nstates))
-        # conf
-        L, R = self.sampled_msm_lag100.sample_conf('eigenvectors_right')
-        # test shape
-        assert np.array_equal(L.shape, (self.nstates, self.nstates))
-        assert np.array_equal(R.shape, (self.nstates, self.nstates))
-        # test consistency
-        assert np.all(L <= mean)
-        assert np.all(R >= mean)
-
-    def test_stationary_distribution_samples(self):
-        samples = self.sampled_msm_lag100.sample_f('stationary_distribution')
-        # shape
-        assert np.array_equal(np.shape(samples), (self.nsamples, self.nstates))
-        # consistency
-        for mu in samples:
-            assert np.isclose(mu.sum(), 1.0)
-            assert np.all(mu > 0.0)
-
-    def test_stationary_distribution_stats(self):
-        # mean
-        mean = self.sampled_msm_lag100.sample_mean('stationary_distribution')
-        # test shape and consistency
-        assert np.array_equal(mean.shape, (self.nstates, ))
-        assert np.isclose(mean.sum(), 1.0)
-        assert np.all(mean > 0.0)
-        assert np.max(np.abs(mean[0]-mean[1])) < 0.05
-        # std
-        std = self.sampled_msm_lag100.sample_std('stationary_distribution')
-        # test shape
-        assert np.array_equal(std.shape, (self.nstates, ))
-        # conf
-        L, R = self.sampled_msm_lag100.sample_conf('stationary_distribution')
-        # test shape
-        assert np.array_equal(L.shape, (self.nstates, ))
-        assert np.array_equal(R.shape, (self.nstates, ))
-        # test consistency
-        assert np.all(L <= mean)
-        assert np.all(R >= mean)
-
-    def test_timescales_samples(self):
-        samples = self.sampled_msm_lag100.sample_f('timescales')
-        # shape
-        np.testing.assert_equal(np.shape(samples), (self.nsamples, self.nstates-1))
-        # consistency
-        for l in samples:
-            assert np.all(l > 0.0)
-
-    def test_timescales_stats(self):
-        # mean
-        mean = self.sampled_msm_lag100.sample_mean('timescales')
-        # test shape and consistency
-        assert np.array_equal(mean.shape, (self.nstates-1, ))
-        assert np.all(mean > 0.0)
-        # std
-        std = self.sampled_msm_lag100.sample_std('timescales')
-        # test shape
-        assert np.array_equal(std.shape, (self.nstates-1, ))
-        # conf
-        L, R = self.sampled_msm_lag100.sample_conf('timescales')
-        # test shape
-        assert np.array_equal(L.shape, (self.nstates-1, ))
-        assert np.array_equal(R.shape, (self.nstates-1, ))
-        # test consistency
-        assert np.all(L <= mean)
-        assert np.all(R >= mean)
-
-    # TODO: these tests can be made compact because they are almost the same. can define general functions for testing
-    # TODO: samples and stats, only need to implement consistency check individually.
-
-class TestBMSMRevPi(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(cls):
-        # load observations
-        import pyemma.datasets
         data = pyemma.datasets.load_2well_discrete()
         obs_micro = data.dtraj_T100K_dt10
+
+        # stationary distribution
         pi_micro = data.msm.stationary_distribution
         pi_macro = np.zeros(2)
         pi_macro[0] = pi_micro[0:50].sum()
         pi_macro[1] = pi_micro[50:].sum()
+        
         # coarse-grain microstates to two metastable states
         cg = np.zeros(100, dtype=int)
         cg[50:] = 1
@@ -253,20 +51,39 @@ class TestBMSMRevPi(unittest.TestCase):
         cls.nsamples = 100
 
         cls.lag = 100
-        cls.sampled_msm_lag100 = bayesian_markov_model(obs_macro, cls.lag, reversible=True, statdist=pi_macro,
-                                                       nsamples=cls.nsamples)
+        cls.bmsm_rev = bayesian_markov_model(obs_macro, cls.lag,
+                                             reversible=True, nsamples=cls.nsamples)
+        cls.bmsm_revpi = bayesian_markov_model(obs_macro, cls.lag,
+                                               reversible=True, statdist=pi_macro,
+                                                    nsamples=cls.nsamples)
 
     def test_reversible(self):
-        assert self.sampled_msm_lag100.is_reversible
+        self._reversible(self.bmsm_rev)
+        self._reversible(self.bmsm_revpi)
+
+    def _reversible(self, msm):
+        assert msm.is_reversible
 
     def test_lag(self):
-        assert self.sampled_msm_lag100.lagtime == self.lag
+        self._lag(self.bmsm_rev)
+        self._lag(self.bmsm_revpi)
+
+    def _lag(self, msm):
+        assert msm.lagtime == self.lag
 
     def test_nstates(self):
-        assert self.sampled_msm_lag100.nstates == self.nstates
+        self._nstates(self.bmsm_rev)
+        self._nstates(self.bmsm_revpi)
+
+    def _nstates(self, msm):
+        assert msm.nstates == self.nstates
 
     def test_transition_matrix_samples(self):
-        Psamples = self.sampled_msm_lag100.sample_f('transition_matrix')
+        self._transition_matrix_samples(self.bmsm_rev)
+        self._transition_matrix_samples(self.bmsm_revpi)
+
+    def _transition_matrix_samples(self, msm):
+        Psamples = msm.sample_f('transition_matrix')
         # shape
         assert np.array_equal(np.shape(Psamples), (self.nsamples, self.nstates, self.nstates))
         # consistency
@@ -276,18 +93,22 @@ class TestBMSMRevPi(unittest.TestCase):
             assert msmana.is_reversible(P)
 
     def test_transition_matrix_stats(self):
+        self._transition_matrix_stats(self.bmsm_rev)
+        self._transition_matrix_stats(self.bmsm_revpi)
+
+    def _transition_matrix_stats(self, msm):
         import msmtools.analysis as msmana
         # mean
-        Pmean = self.sampled_msm_lag100.sample_mean('transition_matrix')
+        Pmean = msm.sample_mean('transition_matrix')
         # test shape and consistency
         assert np.array_equal(Pmean.shape, (self.nstates, self.nstates))
         assert msmana.is_transition_matrix(Pmean)
         # std
-        Pstd = self.sampled_msm_lag100.sample_std('transition_matrix')
+        Pstd = msm.sample_std('transition_matrix')
         # test shape
         assert np.array_equal(Pstd.shape, (self.nstates, self.nstates))
         # conf
-        L, R = self.sampled_msm_lag100.sample_conf('transition_matrix')
+        L, R = msm.sample_conf('transition_matrix')
         # test shape
         assert np.array_equal(L.shape, (self.nstates, self.nstates))
         assert np.array_equal(R.shape, (self.nstates, self.nstates))
@@ -296,7 +117,11 @@ class TestBMSMRevPi(unittest.TestCase):
         assert np.all(R >= Pmean)
 
     def test_eigenvalues_samples(self):
-        samples = self.sampled_msm_lag100.sample_f('eigenvalues')
+        self._eigenvalues_samples(self.bmsm_rev)
+        self._eigenvalues_samples(self.bmsm_revpi)
+
+    def _eigenvalues_samples(self, msm):
+        samples = msm.sample_f('eigenvalues')
         # shape
         self.assertEqual(np.shape(samples), (self.nsamples, self.nstates))
         # consistency
@@ -305,18 +130,22 @@ class TestBMSMRevPi(unittest.TestCase):
             assert np.all(ev[1:] < 1.0)
 
     def test_eigenvalues_stats(self):
+        self._eigenvalues_stats(self.bmsm_rev)
+        self._eigenvalues_stats(self.bmsm_revpi)
+        
+    def _eigenvalues_stats(self, msm):
         # mean
-        mean = self.sampled_msm_lag100.sample_mean('eigenvalues')
+        mean = msm.sample_mean('eigenvalues')
         # test shape and consistency
         assert np.array_equal(mean.shape, (self.nstates,))
         assert np.isclose(mean[0], 1)
         assert np.all(mean[1:] < 1.0)
         # std
-        std = self.sampled_msm_lag100.sample_std('eigenvalues')
+        std = msm.sample_std('eigenvalues')
         # test shape
         assert np.array_equal(std.shape, (self.nstates,))
         # conf
-        L, R = self.sampled_msm_lag100.sample_conf('eigenvalues')
+        L, R = msm.sample_conf('eigenvalues')
         # test shape
         assert np.array_equal(L.shape, (self.nstates,))
         assert np.array_equal(R.shape, (self.nstates,))
@@ -325,7 +154,11 @@ class TestBMSMRevPi(unittest.TestCase):
         assert np.all(R >= mean)
 
     def test_eigenvectors_left_samples(self):
-        samples = self.sampled_msm_lag100.sample_f('eigenvectors_left')
+        self._eigenvectors_left_samples(self.bmsm_rev)
+        self._eigenvectors_left_samples(self.bmsm_revpi)
+
+    def _eigenvectors_left_samples(self, msm):
+        samples = msm.sample_f('eigenvectors_left')
         # shape
         np.testing.assert_equal(np.shape(samples), (self.nsamples, self.nstates, self.nstates))
         # consistency
@@ -334,30 +167,35 @@ class TestBMSMRevPi(unittest.TestCase):
             assert np.sign(evec[1,0]) != np.sign(evec[1,1])
 
     def test_eigenvectors_left_stats(self):
+        self._eigenvectors_left_stats(self.bmsm_rev)
+        self._eigenvectors_left_stats(self.bmsm_revpi)        
+
+    def _eigenvectors_left_stats(self, msm, tol=1e-12):
         # mean
-        mean = self.sampled_msm_lag100.sample_mean('eigenvectors_left')
+        mean = msm.sample_mean('eigenvectors_left')
         # test shape and consistency
         assert np.array_equal(mean.shape, (self.nstates, self.nstates))
         assert np.sign(mean[0,0]) == np.sign(mean[0,1])
         assert np.sign(mean[1,0]) != np.sign(mean[1,1])
         # std
-        std = self.sampled_msm_lag100.sample_std('eigenvectors_left')
+        std = msm.sample_std('eigenvectors_left')
         # test shape
         assert np.array_equal(std.shape, (self.nstates, self.nstates))
         # conf
-        L, R = self.sampled_msm_lag100.sample_conf('eigenvectors_left')
+        L, R = msm.sample_conf('eigenvectors_left')
         # test shape
         assert np.array_equal(L.shape, (self.nstates, self.nstates))
         assert np.array_equal(R.shape, (self.nstates, self.nstates))
-        # Eigenvectors are constant acorss the sample, skip this test,
-        # since it can not handle the case for which L, mean, and R are
-        # numerically equal
-        # test consistency 
-        # assert np.all(L <= mean)
-        # assert np.all(R >= mean)
+        # test consistency
+        assert np.all(L-tol <= mean)
+        assert np.all(R+tol >= mean)
 
     def test_eigenvectors_right_samples(self):
-        samples = self.sampled_msm_lag100.sample_f('eigenvectors_right')
+        self._eigenvectors_right_samples(self.bmsm_rev)
+        self._eigenvectors_right_samples(self.bmsm_revpi)
+
+    def _eigenvectors_right_samples(self, msm):
+        samples = msm.sample_f('eigenvectors_right')
         # shape
         np.testing.assert_equal(np.shape(samples), (self.nsamples, self.nstates, self.nstates))
         # consistency
@@ -366,30 +204,34 @@ class TestBMSMRevPi(unittest.TestCase):
             assert np.sign(evec[0,1]) != np.sign(evec[1,1])
 
     def test_eigenvectors_right_stats(self):
+        self._eigenvectors_right_stats(self.bmsm_rev)
+        self._eigenvectors_right_stats(self.bmsm_revpi)        
+
+    def _eigenvectors_right_stats(self, msm, tol=1e-12):
         # mean
-        mean = self.sampled_msm_lag100.sample_mean('eigenvectors_right')
+        mean = msm.sample_mean('eigenvectors_right')
         # test shape and consistency
         np.testing.assert_equal(mean.shape, (self.nstates, self.nstates))
         assert np.sign(mean[0,0]) == np.sign(mean[1,0])
         assert np.sign(mean[0,1]) != np.sign(mean[1,1])
         # std
-        std = self.sampled_msm_lag100.sample_std('eigenvectors_right')
+        std = msm.sample_std('eigenvectors_right')
         # test shape
         assert np.array_equal(std.shape, (self.nstates, self.nstates))
         # conf
-        L, R = self.sampled_msm_lag100.sample_conf('eigenvectors_right')
+        L, R = msm.sample_conf('eigenvectors_right')
         # test shape
         assert np.array_equal(L.shape, (self.nstates, self.nstates))
         assert np.array_equal(R.shape, (self.nstates, self.nstates))
         # test consistency
-        # Eigenvectors are constant acorss the sample, skip this test,
-        # since it can not handle the case for which L, mean, and R are
-        # numerically equal
-        # assert np.all(L <= mean)
-        # assert np.all(R >= mean)
+        assert np.all(L-tol <= mean)
+        assert np.all(R+tol >= mean)
 
     def test_stationary_distribution_samples(self):
-        samples = self.sampled_msm_lag100.sample_f('stationary_distribution')
+        self._stationary_distribution_samples(self.bmsm_rev) 
+
+    def _stationary_distribution_samples(self, msm):
+        samples = msm.sample_f('stationary_distribution')
         # shape
         assert np.array_equal(np.shape(samples), (self.nsamples, self.nstates))
         # consistency
@@ -398,30 +240,36 @@ class TestBMSMRevPi(unittest.TestCase):
             assert np.all(mu > 0.0)
 
     def test_stationary_distribution_stats(self):
+        self._stationary_distribution_stats(self.bmsm_rev)
+        self._stationary_distribution_stats(self.bmsm_revpi)
+        
+    def _stationary_distribution_stats(self, msm, tol=1e-12):
         # mean
-        mean = self.sampled_msm_lag100.sample_mean('stationary_distribution')
+        mean = msm.sample_mean('stationary_distribution')
         # test shape and consistency
         assert np.array_equal(mean.shape, (self.nstates, ))
         assert np.isclose(mean.sum(), 1.0)
         assert np.all(mean > 0.0)
         assert np.max(np.abs(mean[0]-mean[1])) < 0.05
         # std
-        std = self.sampled_msm_lag100.sample_std('stationary_distribution')
+        std = msm.sample_std('stationary_distribution')
         # test shape
         assert np.array_equal(std.shape, (self.nstates, ))
         # conf
-        L, R = self.sampled_msm_lag100.sample_conf('stationary_distribution')
+        L, R = msm.sample_conf('stationary_distribution')
         # test shape
         assert np.array_equal(L.shape, (self.nstates, ))
         assert np.array_equal(R.shape, (self.nstates, ))
-        # test consistency, i.e. fixed stationary distribution
-        assert np.allclose(std, 0.0)
-        assert np.allclose(L-mean, 0.0)
-        assert np.allclose(R-mean, 0.0)                      
-
+        # test consistency
+        assert np.all(L-tol <= mean)
+        assert np.all(R+tol >= mean)
 
     def test_timescales_samples(self):
-        samples = self.sampled_msm_lag100.sample_f('timescales')
+        self._timescales_samples(self.bmsm_rev)
+        self._timescales_samples(self.bmsm_revpi) 
+
+    def _timescales_samples(self, msm):
+        samples = msm.sample_f('timescales')
         # shape
         np.testing.assert_equal(np.shape(samples), (self.nsamples, self.nstates-1))
         # consistency
@@ -429,17 +277,21 @@ class TestBMSMRevPi(unittest.TestCase):
             assert np.all(l > 0.0)
 
     def test_timescales_stats(self):
+        self._timescales_samples(self.bmsm_rev)
+        self._timescales_samples(self.bmsm_revpi) 
+
+    def _timescales_stats(self, msm):
         # mean
-        mean = self.sampled_msm_lag100.sample_mean('timescales')
+        mean = msm.sample_mean('timescales')
         # test shape and consistency
         assert np.array_equal(mean.shape, (self.nstates-1, ))
         assert np.all(mean > 0.0)
         # std
-        std = self.sampled_msm_lag100.sample_std('timescales')
+        std = msm.sample_std('timescales')
         # test shape
         assert np.array_equal(std.shape, (self.nstates-1, ))
         # conf
-        L, R = self.sampled_msm_lag100.sample_conf('timescales')
+        L, R = msm.sample_conf('timescales')
         # test shape
         assert np.array_equal(L.shape, (self.nstates-1, ))
         assert np.array_equal(R.shape, (self.nstates-1, ))
@@ -449,7 +301,6 @@ class TestBMSMRevPi(unittest.TestCase):
 
     # TODO: these tests can be made compact because they are almost the same. can define general functions for testing
     # TODO: samples and stats, only need to implement consistency check individually.
-
     
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/msm/tests/test_msm.py
+++ b/pyemma/msm/tests/test_msm.py
@@ -102,6 +102,37 @@ class TestMSMSimple(unittest.TestCase):
         assert_allclose(self.mu_MSM, msm.stationary_distribution)
         assert_allclose(self.ts[1:], msm.timescales(self.k - 1))
 
+class TestMSMRevPi(unittest.TestCase):
+    r"""Checks if the MLMSM correctly handles the active set computation
+    if a stationary distribution is given"""
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_valid_stationary_vector(self):
+        dtraj = np.array([0, 0, 1, 0, 1, 2])
+        pi_valid = np.array([0.1, 0.9, 0.0])
+        pi_invalid = np.array([0.1, 0.9])
+        active_set = np.array([0, 1])
+        msm = estimate_markov_model(dtraj, 1, statdist=pi_valid)
+        self.assertTrue(np.all(msm.active_set==active_set))
+        with self.assertRaises(ValueError):
+            msm = estimate_markov_model(dtraj, 1, statdist=pi_invalid)       
+        
+    def test_valid_trajectory(self):
+        pi = np.array([0.1, 0.0, 0.9])
+        dtraj_invalid = np.array([1, 1, 1, 1, 1, 1, 1])
+        dtraj_valid = np.array([0, 2, 0, 2, 2, 0, 1, 1])
+        msm = estimate_markov_model(dtraj_valid, 1, statdist=pi)
+        self.assertTrue(np.all(msm.active_set==np.array([0, 2])))
+        with self.assertRaises(ValueError):
+            msm = estimate_markov_model(dtraj_invalid, 1, statdist=pi)
+        
+        
+        
 
 class TestMSMDoubleWell(unittest.TestCase):
 

--- a/pyemma/util/statistics.py
+++ b/pyemma/util/statistics.py
@@ -30,6 +30,7 @@ import math
 import itertools
 from . import types
 from six.moves import range
+import warnings
 
 
 def _confidence_interval_1d(data, alpha):
@@ -50,6 +51,13 @@ def _confidence_interval_1d(data, alpha):
     """
     if alpha < 0 or alpha > 1:
         raise ValueError('Not a meaningful confidence level: '+str(alpha))
+      # exception: if data are constant, return three times the constant and raise a warning
+    dmin = np.min(data)
+    dmax = np.max(data)
+    # if dmin == dmax:
+    if np.isclose(dmin, dmax):
+        warnings.warn('confidence interval for constant data is not meaningful')
+        return dmin, dmin, dmin
     
     # compute mean
     m = np.mean(data)


### PR DESCRIPTION
This pull-request fixes an inconsistency and a bug. Exposes sampling with fixed stationary vector functionality in the API and exposes an additional keyword argument in two API-functions.
