### PR TITLE
Logging defaults

### DIFF
--- a/pyemma/_base/logging.py
+++ b/pyemma/_base/logging.py
@@ -30,9 +30,7 @@ def _clean_dead_refs():
     _refs = [r for r in _refs if r() is not None]
     
 def instance_name(self, id):
-    i = self.__module__.rfind(".")
-    j = self.__module__.find(".") + 1
-    package = self.__module__[j:i]
+    package = self.__module__
     instance_name = "%s.%s[%i]" % (package, self.__class__.__name__, id)
     return instance_name
 

--- a/pyemma/coordinates/data/data_in_memory.py
+++ b/pyemma/coordinates/data/data_in_memory.py
@@ -60,6 +60,7 @@ class DataInMemory(ReaderInterface):
 
         self.__set_dimensions_and_lenghts()
         self._parametrized = True
+        self._logger.info("hi from data in mem")
 
     @classmethod
     def load_from_files(cls, files):

--- a/pyemma/coordinates/tests/test_api_source.py
+++ b/pyemma/coordinates/tests/test_api_source.py
@@ -32,7 +32,7 @@ from pyemma.coordinates.data.py_csv_reader import PyCSVReader as CSVReader
 import shutil
 
 
-logger = getLogger('TestReaderUtils')
+logger = getLogger('pyemma.'+'TestReaderUtils')
 
 
 class TestApiSourceFileReader(unittest.TestCase):

--- a/pyemma/coordinates/tests/test_assign.py
+++ b/pyemma/coordinates/tests/test_assign.py
@@ -30,7 +30,7 @@ import pyemma.util.types as types
 from six.moves import range
 
 
-logger = getLogger('TestCluster')
+logger = getLogger('pyemma.'+'TestCluster')
 
 
 class TestCluster(unittest.TestCase):

--- a/pyemma/coordinates/tests/test_cluster.py
+++ b/pyemma/coordinates/tests/test_cluster.py
@@ -31,7 +31,7 @@ import pyemma.util.types as types
 from six.moves import range
 
 
-logger = getLogger('TestReaderUtils')
+logger = getLogger('pyemma.'+'TestReaderUtils')
 
 
 class TestCluster(unittest.TestCase):

--- a/pyemma/coordinates/tests/test_datainmemory.py
+++ b/pyemma/coordinates/tests/test_datainmemory.py
@@ -34,7 +34,7 @@ from pyemma.coordinates.data.data_in_memory import DataInMemory
 from pyemma.coordinates.transform.transformer import TransformerIteratorContext
 from pyemma.util.log import getLogger
 
-logger = getLogger('TestDataInMemory')
+logger = getLogger('pyemma.'+'TestDataInMemory')
 
 
 class TestDataInMemory(unittest.TestCase):

--- a/pyemma/coordinates/tests/test_featurereader.py
+++ b/pyemma/coordinates/tests/test_featurereader.py
@@ -36,7 +36,7 @@ import numpy as np
 from pyemma.coordinates.api import discretizer, tica, source
 from six.moves import range
 
-log = getLogger('TestFeatureReader')
+log = getLogger('pyemma.'+'TestFeatureReader')
 
 def create_traj(top, format='.xtc', dir=None):
     trajfile = tempfile.mktemp(suffix=format, dir=dir)

--- a/pyemma/coordinates/tests/test_featurereader_and_tica.py
+++ b/pyemma/coordinates/tests/test_featurereader_and_tica.py
@@ -35,7 +35,7 @@ from pyemma.coordinates.data.feature_reader import FeatureReader
 from pyemma.util.log import getLogger
 from six.moves import range
 
-log = getLogger('TestFeatureReaderAndTICA')
+log = getLogger('pyemma.'+'TestFeatureReaderAndTICA')
 
 
 class TestFeatureReaderAndTICA(unittest.TestCase):

--- a/pyemma/coordinates/tests/test_featurereader_and_tica_projection.py
+++ b/pyemma/coordinates/tests/test_featurereader_and_tica_projection.py
@@ -36,7 +36,7 @@ from pyemma.coordinates.data.feature_reader import FeatureReader
 from pyemma.util.log import getLogger
 from six.moves import range
 
-log = getLogger('TestFeatureReaderAndTICAProjection')
+log = getLogger('pyemma.'+'TestFeatureReaderAndTICAProjection')
 
 def random_invertible(n, eps=0.01):
     'generate real random invertible matrix'

--- a/pyemma/coordinates/tests/test_numpyfilereader.py
+++ b/pyemma/coordinates/tests/test_numpyfilereader.py
@@ -41,7 +41,7 @@ class TestNumPyFileReader(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
 
-        cls.logger = getLogger(cls.__class__.__name__)
+        cls.logger = getLogger('pyemma.'+cls.__class__.__name__)
 
         d = np.arange(3 * 100).reshape((100, 3))
         d2 = np.arange(300, 900).reshape((200,3))

--- a/pyemma/coordinates/tests/test_pca.py
+++ b/pyemma/coordinates/tests/test_pca.py
@@ -34,7 +34,7 @@ import pyemma.util.types as types
 from six.moves import range
 
 
-logger = getLogger('TestPCA')
+logger = getLogger('pyemma.'+'TestPCA')
 
 
 class TestPCAExtensive(unittest.TestCase):

--- a/pyemma/coordinates/tests/test_source.py
+++ b/pyemma/coordinates/tests/test_source.py
@@ -29,7 +29,7 @@ import pyemma.coordinates.api as api
 import pyemma.util.types as types
 import pkg_resources
 
-logger = getLogger('TestReaderUtils')
+logger = getLogger('pyemma.'+'TestReaderUtils')
 
 
 class TestSource(unittest.TestCase):

--- a/pyemma/coordinates/tests/test_tica.py
+++ b/pyemma/coordinates/tests/test_tica.py
@@ -37,7 +37,7 @@ from pyemma.util.log import getLogger
 import pyemma.util.types as types
 from six.moves import range
 
-logger = getLogger('TestTICA')
+logger = getLogger('pyemma.'+'TestTICA')
 
 
 class TestTICA_Basic(unittest.TestCase):

--- a/pyemma/logging.yml
+++ b/pyemma/logging.yml
@@ -5,6 +5,9 @@
 # do not disable other loggers by default.
 disable_existing_loggers: False
 
+# please do not change version, it is an internal variable used by Python.
+version: 1
+
 formatters:
     simpleFormater:
         format: '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
@@ -14,23 +17,16 @@ handlers:
     console:
         class: logging.StreamHandler
         formatter: simpleFormater
-        level: INFO 
         stream: ext://sys.stdout
-#    file:
-#        class : logging.FileHandler
-#        formatter: simpleFormater
-#        level: INFO
-#        filename: pyemma.log
+    rotating_files:
+        class: logging.handlers.RotatingFileHandler
+        formatter: simpleFormater
+        filename: pyemma.log
+        maxBytes: 1048576 # 1 MB
+        backupCount: 3
 
 loggers:
-    clogger:
+    pyemma:
         level: INFO
-        handlers: [console]
-    #flogger:
-    #    level: INFO
-    #    handlers: [file]
+        handlers: [console, rotating_files]
 
-root:
-# global log level
-    level: INFO
-    handlers: [console] #, file]

--- a/pyemma/logging.yml
+++ b/pyemma/logging.yml
@@ -1,6 +1,10 @@
 # PyEMMA's default logging settings
 # If you want to enable file logging, uncomment the file related handlers and handlers
 # 
+
+# do not disable other loggers by default.
+disable_existing_loggers: False
+
 formatters:
     simpleFormater:
         format: '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'

--- a/pyemma/util/log.py
+++ b/pyemma/util/log.py
@@ -78,12 +78,18 @@ def setupLogging():
         else:
             raise LoggingConfigurationError('could not handle default logging '
                                             'configuration file\n%s' % ee2)
-            
+
     if D is None:
         raise LoggingConfigurationError('Empty logging config! Try using default config by'
                                         ' setting logging_conf=DEFAULT in pyemma.cfg')
 
+    # this has not been set in PyEMMA version prior 2.0.2+
     D.setdefault('version', 1)
+    # if the user has not explicitly disabled other loggers, we (contrary to Pythons
+    # default value) do not want to override them.
+    D.setdefault('disable_existing_loggers', False)
+
+    # configure using the dict
     dictConfig(D)
 
 

--- a/pyemma/util/log.py
+++ b/pyemma/util/log.py
@@ -100,6 +100,7 @@ def getLogger(name=None):
         t = traceback.extract_stack(limit=2)
         path = t[0][0]
         pos = path.rfind('pyemma')
+        pos = pos if pos > 0 else 0
         name = path[pos:]
 
     return logging.getLogger(name)


### PR DESCRIPTION
see discussion in #639 

This now changes the default to not override existing loggers. It does not even configure the root logger and uses the hierarchical package pattern everywhere.
