### PR TITLE
[base|coor|msm] added Loggable interface and use it in Estimators and Transformers

### DIFF
--- a/pyemma/_base/estimator.py
+++ b/pyemma/_base/estimator.py
@@ -27,8 +27,7 @@ from pyemma.util import types as _types
 
 # imports for external usage
 from pyemma._ext.sklearn.base import clone as clone_estimator
-from pyemma._base.logging import create_logger, instance_name
-from itertools import count
+from pyemma._base.logging import Loggable
 
 __author__ = 'noe, marscher'
 
@@ -294,41 +293,12 @@ def estimate_param_scan(estimator, X, param_sets, evaluate=None, evaluate_args=N
         return res
 
 
-class Estimator(_BaseEstimator):
+class Estimator(_BaseEstimator, Loggable):
     """ Base class for pyEMMA estimators
 
     """
-    # counting estimator instances, incremented by name property.
-    _ids = count(0)
     # flag indicating if estimator's estimate method has been called
     _estimated = False
-
-    @property
-    def name(self):
-        """The name of this estimator"""
-        try:
-            return self._name
-        except AttributeError:
-            self._name = instance_name(self, next(self._ids))
-            return self._name
-
-    @property
-    def logger(self):
-        """The logger for this Estimator """
-        try:
-            return self._logger_instance
-        except AttributeError:
-            create_logger(self)
-            return self._logger_instance
-
-    def __getstate__(self):
-        # do not pickle the logger instance
-        d = dict(self.__dict__)
-        try:
-            del d['_logger_instance']
-        except KeyError:
-            pass
-        return d
 
     def estimate(self, X, **params):
         """ Estimates the model given the data X

--- a/pyemma/_base/logging.py
+++ b/pyemma/_base/logging.py
@@ -1,42 +1,91 @@
+
+# This file is part of PyEMMA.
+#
+# Copyright (c) 2015, 2014 Computational Molecular Biology Group, Freie Universitaet Berlin (GER)
+#
+# PyEMMA is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 '''
 Created on 30.08.2015
 
 @author: marscher
 '''
-import logging
+from __future__ import absolute_import
+
+from logging import getLogger
 import weakref
-from pyemma.util.log import getLogger
+from itertools import count
 
-__all__ = ['create_logger', 'instance_name']
+__all__ = ['Loggable']
 
-_refs = {}
 
-def _cleanup_logger(obj):
-    # callback function used in conjunction with weakref.ref to remove logger for transformer instance
-    key = obj._logger_instance.name
+class Loggable(object):
+    # counting instances of Loggable, incremented by name property.
+    __ids = count(0)
+    # holds weak references to instances of this, to clean up logger instances.
+    __refs = {}
 
-    def remove_logger(weak):
-        d = logging.getLogger().manager.loggerDict
-        del d[key]
-        del _refs[key]
-    return remove_logger
+    @property
+    def name(self):
+        """The name of this instance"""
+        try:
+            return self._name
+        except AttributeError:
+            self._name = "%s.%s[%i]" % (self.__module__,
+                                        self.__class__.__name__,
+                                        next(Loggable.__ids))
+            return self._name
 
-def _clean_dead_refs():
-    # cleans dead weakrefs
-    global _refs
-     
-    if len(_refs) == 0:
-        return
-    _refs = [r for r in _refs if r() is not None]
-    
-def instance_name(self, id):
-    package = self.__module__
-    instance_name = "%s.%s[%i]" % (package, self.__class__.__name__, id)
-    return instance_name
+    @property
+    def logger(self):
+        """The logger for this class instance """
+        try:
+            return self._logger_instance
+        except AttributeError:
+            self.__create_logger()
+            return self._logger_instance
 
-def create_logger(self):
-    # creates a logger based on the the attribe "name" of self
-    self._logger_instance = getLogger(self.name)
-    r = weakref.ref(self, _cleanup_logger(self))
-    _refs[self.name] = r
-    return self._logger_instance
+    @property
+    def _logger(self):
+        return self.logger
+
+    def __create_logger(self):
+        _weak_logger_refs = Loggable.__refs
+        # creates a logger based on the the attribe "name" of self
+        self._logger_instance = getLogger(self.name)
+
+        # store a weakref to this instance to clean the logger instance.
+        logger_id = id(self._logger_instance)
+        r = weakref.ref(self, Loggable._cleanup_logger(logger_id, self.name))
+        _weak_logger_refs[logger_id] = r
+
+    @staticmethod
+    def _cleanup_logger(logger_id, logger_name):
+        # callback function used in conjunction with weakref.ref
+        # removes logger from root manager
+
+        def remove_logger(weak):
+            d = getLogger().manager.loggerDict
+            del d[logger_name]
+            del Loggable.__refs[logger_id]
+        return remove_logger
+
+    def __getstate__(self):
+        # do not pickle the logger instance
+        d = dict(self.__dict__)
+        try:
+            del d['_logger_instance']
+        except KeyError:
+            pass
+        return d

--- a/pyemma/coordinates/data/featurizer.py
+++ b/pyemma/coordinates/data/featurizer.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import
 
 import numpy as np
 import warnings
-from itertools import count
 import functools
 
 import mdtraj
@@ -38,7 +37,7 @@ from pyemma.util.types import is_iterable_of_int as _is_iterable_of_int
 from six import PY3
 from six.moves import map, range, zip
 
-from pyemma._base.logging import instance_name, create_logger
+from pyemma._base.logging import Loggable
 from pyemma.util.annotators import deprecated
 
 
@@ -814,11 +813,8 @@ class MinRmsdFeature(object):
         return self.__hash__() == other.__hash__()
 
 
-class MDFeaturizer(object):
+class MDFeaturizer(Loggable):
     r"""Extracts features from MD trajectories."""
-
-    # counting instances, incremented by name property.
-    _ids = count(0)
 
     def __init__(self, topfile):
         """extracts features from MD trajectories.
@@ -837,23 +833,6 @@ class MDFeaturizer(object):
             self.topology = topfile
         self.active_features = []
         self._dim = 0
-
-    @property
-    def name(self):
-        try:
-            return self._name
-        except AttributeError:
-            self._name = instance_name(self, next(self._ids))
-            return self._name
-
-    @property
-    def _logger(self):
-        """ The logger for this Estimator """
-        try:
-            return self._logger_instance
-        except AttributeError:
-            create_logger(self)
-            return self._logger_instance
 
     def __add_feature(self, f):
         # perform sanity checks


### PR DESCRIPTION
- Derive from "Loggable" to lazily (upon first access) create a logger instance for each instance of the class.
- Unused loggers (eg. the instance from which the logger was used, is about to be garbage collected) are removed automatically.
