### PR TITLE
[coor/featurizer] add_contacts gets argument count_contacts

### DIFF
--- a/pyemma/coordinates/tests/test_featurizer.py
+++ b/pyemma/coordinates/tests/test_featurizer.py
@@ -201,6 +201,25 @@ class TestFeaturizer(unittest.TestCase):
         C[I[:, 0], I[:, 1]] = 1.0
         assert(np.allclose(C, self.feat.transform(self.traj)))
 
+    def test_contacts_count_contacts(self):
+        sel = np.array([1, 2, 5, 20], dtype=int)
+        pairs_expected = np.array([[1, 5], [1, 20], [2, 5], [2, 20], [5, 20]])
+        pairs = self.feat.pairs(sel, excluded_neighbors=2)
+        assert(pairs.shape == pairs_expected.shape)
+        assert(np.all(pairs == pairs_expected))
+        self.feat.add_contacts(pairs, threshold=0.5, periodic=False, count_contacts=True)  # unperiodic distances such that we can compare
+        # The dimensionality of the feature is now one
+        assert(self.feat.dimension() == 1)
+        X = self.traj.xyz[:, pairs_expected[:, 0], :]
+        Y = self.traj.xyz[:, pairs_expected[:, 1], :]
+        D = np.sqrt(np.sum((X - Y) ** 2, axis=2))
+        C = np.zeros(D.shape)
+        I = np.argwhere(D <= 0.5)
+        C[I[:, 0], I[:, 1]] = 1.0
+        # Count the contacts
+        C = C.sum(1, keepdims=True)
+        assert(np.allclose(C, self.feat.transform(self.traj)))
+
     def test_angles(self):
         sel = np.array([[1, 2, 5],
                         [1, 3, 8],


### PR DESCRIPTION
Extends the functionality so that, instead of returning an array of zeroes and ones for each frame, a single value per frame is returned: the total number of formed contacts. Think of a situation in which the feature of interest is the number molecules solvating a solute over time (and not which one of them at what moment). Two ideas:
- if we like this, perhaps it should be extended all features that return zeroes and ones (or booleans). I'm thinking of add_group_mindist and add_residue_mindist
- Should we force it to return integers instead of floats? 
