### PR TITLE
[coor.datasources] Unifiy traj info determination

### DIFF
--- a/pyemma/coordinates/__init__.py
+++ b/pyemma/coordinates/__init__.py
@@ -105,3 +105,9 @@ Find here a documentation how to extract features from them.
 
 """
 from .api import *
+
+
+def setup_package():
+    # do not use traj cache for tests
+    from pyemma import config
+    config['use_trajectory_lengths_cache'] = False

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -615,7 +615,7 @@ def save_traj(traj_inp, indexes, outfile, top=None, stride = 1, chunksize=1000, 
 
     # Determine the type of input and extract necessary parameters
     if isinstance(traj_inp, _FeatureReader):
-        trajfiles = traj_inp.trajfiles
+        trajfiles = traj_inp.filenames
         top = traj_inp.topfile
         chunksize = traj_inp.chunksize
     else:
@@ -755,7 +755,7 @@ def save_trajs(traj_inp, indexes, prefix = 'set_', fmt = None, outfiles = None,
     if fmt is None:
         import os
 
-        _, fmt = os.path.splitext(traj_inp.trajfiles[0])
+        _, fmt = os.path.splitext(traj_inp.filenames[0])
     else:
         fmt = '.' + fmt
 

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -132,7 +132,7 @@ def featurizer(topfile):
 
 
 # TODO: DOC - which topology file formats does mdtraj support? Find out and complete docstring
-def load(trajfiles, features=None, top=None, stride=1, chunk_size=100):
+def load(trajfiles, features=None, top=None, stride=1, chunk_size=100, **kw):
     r""" Loads coordinate features into memory.
 
     If your memory is not big enough consider the use of **pipeline**, or use
@@ -218,7 +218,7 @@ def load(trajfiles, features=None, top=None, stride=1, chunk_size=100):
         isinstance(trajfiles, (list, tuple))
             and (any(isinstance(item, (list, tuple, string_types)) for item in trajfiles)
                  or len(trajfiles) is 0)):
-        reader = _create_file_reader(trajfiles, top, features, chunk_size=chunk_size)
+        reader = _create_file_reader(trajfiles, top, features, chunk_size=chunk_size, **kw)
         trajs = reader.get_output(stride=stride)
         if len(trajs) == 1:
             return trajs[0]
@@ -228,7 +228,7 @@ def load(trajfiles, features=None, top=None, stride=1, chunk_size=100):
         raise ValueError('unsupported type (%s) of input' % type(trajfiles))
 
 
-def source(inp, features=None, top=None, chunk_size=None):
+def source(inp, features=None, top=None, chunk_size=None, **kw):
     r""" Defines trajectory data source
 
     This function defines input trajectories without loading them. You can pass
@@ -347,7 +347,7 @@ def source(inp, features=None, top=None, chunk_size=None):
     if isinstance(inp, string_types) or (
             isinstance(inp, (list, tuple))
             and (any(isinstance(item, (list, tuple, string_types)) for item in inp) or len(inp) is 0)):
-        reader = _create_file_reader(inp, top, features, chunk_size=chunk_size if chunk_size else 100)
+        reader = _create_file_reader(inp, top, features, chunk_size=chunk_size if chunk_size else 100, **kw)
 
     elif isinstance(inp, _np.ndarray) or (isinstance(inp, (list, tuple))
                                           and (any(isinstance(item, _np.ndarray) for item in inp) or len(inp) is 0)):
@@ -357,7 +357,7 @@ def source(inp, features=None, top=None, chunk_size=None):
         # check: if single array, create a one-element list
         # check: do all arrays have compatible dimensions (*, N)? If not: raise ValueError.
         # create MemoryReader
-        reader = _DataInMemory(inp, chunksize=chunk_size if chunk_size else 5000)
+        reader = _DataInMemory(inp, chunksize=chunk_size if chunk_size else 5000, **kw)
     else:
         raise ValueError('unsupported type (%s) of input' % type(inp))
 

--- a/pyemma/coordinates/data/_base/iterable.py
+++ b/pyemma/coordinates/data/_base/iterable.py
@@ -155,7 +155,8 @@ class Iterable(six.with_metaclass(ABCMeta, ProgressReporter, Loggable)):
 
         return trajs
 
-    def write_to_csv(self, filename=None, extension='.dat', overwrite=False, stride=1, chunksize=100, **kw):
+    def write_to_csv(self, filename=None, extension='.dat', overwrite=False,
+                     stride=1, chunksize=100, **kw):
         """ write all data to csv with numpy.savetxt
 
         Parameters
@@ -216,9 +217,9 @@ class Iterable(six.with_metaclass(ABCMeta, ProgressReporter, Loggable)):
                 st = os.stat(f)
                 raise OSError(errno.EEXIST)
             except OSError as e:
-                print e.errno
                 if e.errno == errno.EEXIST:
-                    if overwrite:  continue
+                    if overwrite:
+                        continue
                 elif e.errno == errno.ENOENT:
                     continue
                 raise

--- a/pyemma/coordinates/data/_base/iterable.py
+++ b/pyemma/coordinates/data/_base/iterable.py
@@ -201,7 +201,7 @@ class Iterable(six.with_metaclass(ABCMeta, ProgressReporter, Loggable)):
             #    raise RuntimeError("could not determine filenames")
             filenames = []
             for f in self.filenames:
-                base, _ = os.path.split(f)
+                base, _ = os.path.splitext(f)
                 filenames.append(base+extension)
         elif isinstance(filename, six.string_types):
             filename = filename.replace('{stride}', str(stride))
@@ -209,7 +209,7 @@ class Iterable(six.with_metaclass(ABCMeta, ProgressReporter, Loggable)):
                          in range(self.number_of_trajectories())]
         else:
             raise TypeError("filename should be str or None")
-
+        print("filenames", filenames)
         # check files before starting to write
         import errno
         for f in filenames:

--- a/pyemma/coordinates/data/data_in_memory.py
+++ b/pyemma/coordinates/data/data_in_memory.py
@@ -43,11 +43,12 @@ class DataInMemory(DataSource):
         dimension and coordinates/features in second dimension or a list of this
         arrays.
     """
+    IN_MEMORY_FILENAME = '<in_memory_file>'
 
     def _create_iterator(self, skip=0, chunk=0, stride=1, return_trajindex=False):
         return DataInMemoryIterator(self, skip, chunk, stride, return_trajindex)
 
-    def __init__(self, data, chunksize=5000):
+    def __init__(self, data, chunksize=5000, **kw):
         super(DataInMemory, self).__init__(chunksize=chunksize)
         self._is_reader = True
         self._is_random_accessible = True
@@ -72,6 +73,7 @@ class DataInMemory(DataSource):
                              " Your input was %s" % str(data))
 
         self._set_dimensions_and_lenghts()
+        self._filenames = [DataInMemory.IN_MEMORY_FILENAME] * self._ntraj
 
     @property
     def data(self):

--- a/pyemma/coordinates/data/feature_reader.py
+++ b/pyemma/coordinates/data/feature_reader.py
@@ -89,8 +89,8 @@ class FeatureReader(DataSource):
         self.filenames = trajectories
 
         self._is_random_accessible = all(
-                [trajfile.endswith(FeatureReader.SUPPORTED_RANDOM_ACCESS_FORMATS)
-                 for trajfile in self.trajfiles]
+                [f.endswith(FeatureReader.SUPPORTED_RANDOM_ACCESS_FORMATS)
+                 for f in self.filenames]
         )
         self._ra_cuboid = FeatureReaderCuboidRandomAccessStrategy(self, 3)
         self._ra_jagged = FeatureReaderJaggedRandomAccessStrategy(self, 3)

--- a/pyemma/coordinates/data/py_csv_reader.py
+++ b/pyemma/coordinates/data/py_csv_reader.py
@@ -217,7 +217,7 @@ class PyCSVReader(DataSource):
 
     def _get_traj_info(self, filename):
         idx = self.filenames.index(filename)
-        with open(filename, 'rt') as fh:
+        with open(filename, 'r+b') as fh:
             # approx by filesize / (first line + 20%)
             size = int(os.stat(filename).st_size / len(fh.readline()) * 1.2)
             assert size > 0

--- a/pyemma/coordinates/data/py_csv_reader.py
+++ b/pyemma/coordinates/data/py_csv_reader.py
@@ -231,7 +231,7 @@ class PyCSVReader(DataSource):
                 if i >= len(offsets):
                     offsets = np.resize(offsets, int(ceil(len(offsets)*1.2)))
             offsets = offsets[:i]
-            length = len(offsets)
+            length = len(offsets) - 1
             fh.seek(0)
 
             if not self._delimiters[idx]:

--- a/pyemma/coordinates/data/py_csv_reader.py
+++ b/pyemma/coordinates/data/py_csv_reader.py
@@ -21,7 +21,6 @@ Created on 11.04.2015
 """
 
 from __future__ import absolute_import
-
 from math import ceil
 import csv
 import os

--- a/pyemma/coordinates/data/py_csv_reader.py
+++ b/pyemma/coordinates/data/py_csv_reader.py
@@ -14,8 +14,6 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-
 """
 Created on 11.04.2015
 
@@ -24,12 +22,14 @@ Created on 11.04.2015
 
 from __future__ import absolute_import
 
+from math import ceil
 import csv
-
-import numpy as np
-from six.moves import range
+import os
 
 from pyemma.coordinates.data._base.datasource import DataSourceIterator, DataSource
+from pyemma.coordinates.data.util.traj_info_cache import TrajInfo
+from six.moves import range
+import numpy as np
 
 
 class PyCSVIterator(DataSourceIterator):
@@ -44,7 +44,7 @@ class PyCSVIterator(DataSourceIterator):
                            else np.unique(self._skip_rows))
         self.line = 0
         self._reader = csv.reader(self._file_handle,
-                                  dialect=self._data_source._dialects[self._itraj])
+                                  dialect=self._data_source._get_dialect(self._itraj))
 
     def close(self):
         if self._file_handle is not None:
@@ -54,7 +54,8 @@ class PyCSVIterator(DataSourceIterator):
         if not self._file_handle or self._itraj >= self.number_of_trajectories():
             self.close()
             raise StopIteration()
-        traj_len = self.trajectory_lengths()[self._itraj]
+
+        traj_len = self.trajectory_length()
         lines = []
         for row in self._reader:
             if self.line in self._skip_rows:
@@ -67,9 +68,8 @@ class PyCSVIterator(DataSourceIterator):
                     lines.append(row)
             else:
                 lines.append(row)
-            if self.chunksize != 0 and self.line % self.chunksize == 0:
+            if self.chunksize != 0 and len(lines) % self.chunksize == 0:
                 result = self._convert_to_np_chunk(lines)
-                del lines[:]
                 if self._t >= traj_len:
                     self._next_traj()
                 return result
@@ -78,7 +78,6 @@ class PyCSVIterator(DataSourceIterator):
         # last chunk
         if len(lines) > 0:
             result = self._convert_to_np_chunk(lines)
-            del lines[:]
             return result
 
         self.close()
@@ -98,27 +97,33 @@ class PyCSVIterator(DataSourceIterator):
             # reset time counter
             self._t = 0
             # get new reader
-            self._reader = csv.reader(self._file_handle, dialect=self._data_source._dialects[self._itraj])
+            self._reader = csv.reader(self._file_handle,
+                                      dialect=self._data_source._get_dialect(self._itraj))
 
     def _convert_to_np_chunk(self, list_of_strings):
-        self._t += len(list_of_strings)
         stack_of_strings = np.vstack(list_of_strings)
-        result = stack_of_strings.astype(float)
+        del list_of_strings[:]
+        try:
+            result = stack_of_strings.astype(float)
+        except ValueError:
+            fn = self._data_source.filenames[self._itraj]
+            for idx, line in enumerate(list_of_strings):
+                for value in line:
+                    try:
+                        float(value)
+                    except ValueError as ve:
+                        s = "Invalid entry in file %s, line %s: %s" % (fn, self._t+idx, repr(ve))
+                        raise ValueError(s)
+        self._t += len(list_of_strings)
         return result
 
     def _open_file(self):
-        fn = self._data_source._filenames[self._itraj]
-
         # only apply _skip property at the beginning of the trajectory
-        skip = self._data_source._skip + self.skip if self._t == 0 else 0
-        nt = self._data_source._lengths[self._itraj]
-
-        if self._data_source._has_header[self._itraj]:
-            nt += 1
-            skip += 1
+        skip = self._data_source._skip[self._itraj] + self.skip if self._t == 0 else 0
+        nt = self._data_source._skip[self._itraj] + self._data_source._lengths[self._itraj]
 
         # calculate an index set, which rows to skip (includes stride)
-        skip_rows = []
+        skip_rows = np.empty(0)
 
         if skip > 0:
             skip_rows = np.zeros(nt)
@@ -138,7 +143,7 @@ class PyCSVIterator(DataSourceIterator):
 
         self._skip_rows = skip_rows
         try:
-            fh = open(fn)
+            fh = open(self._data_source.filenames[self._itraj])
             self._file_handle = fh
         except EnvironmentError:
             self._logger.exception()
@@ -146,58 +151,133 @@ class PyCSVIterator(DataSourceIterator):
 
 
 class PyCSVReader(DataSource):
+    r""" reads tabulated ASCII data
+
+    Parameters
+    ----------
+    filenames: str or list of str
+        files to be read
+
+    chunksize: int, optional
+        how much lines to process at once
+
+    delimiters: str, list of str or None
+
+        1. if str (eg. '\t'), then this delimiter is used for all filenames.
+        2. list of delimiter strings, the length has to match the length of filenames.
+        3. if not given, it will be guessed (may fail eg. for 1 dimensional data).
+
+    comments: str, list of str or None, default='#'
+        Lines starting with this char will be ignored, except for first line (header)
+
+    converters : dict, optional
+        A dictionary mapping column number to a function that will convert
+        that column to a float.  E.g., if column 0 is a date string:
+        ``converters = {0: datestr2num}``.  Converters can also be used to
+        provide a default value for missing data:
+        ``converters = {3: lambda s: float(s.strip() or 0)}``.
+
+    """
+    def __init__(self, filenames, chunksize=1000, delimiters=None, comments='#',
+                 converters=None, **kwargs):
+        super(PyCSVReader, self).__init__(chunksize=chunksize)
+        self._is_reader = True
+
+        n = len(filenames)
+        self._comments = self.__parse_args(comments, '#', n)
+        self._delimiters = self.__parse_args(delimiters, None, n)
+        self._converters = converters
+
+        # mapping of boolean to indicate if file has an header and csv dialect
+        # self._has_headers = [False] * n
+        self._dialects = [None] * n
+
+        self._skip = np.zeros(n, dtype=int)
+        # invoke filename setter
+        self.filenames = filenames
+
+    def __parse_args(self, arg, default, n):
+        if arg is None:
+            return [default]*n
+        if isinstance(arg, (list, tuple)):
+            assert len(arg) == n
+            return arg
+        return [arg]*n
+
     def _create_iterator(self, skip=0, chunk=0, stride=1, return_trajindex=True):
         return PyCSVIterator(self, skip=skip, chunk=chunk, stride=stride,
                              return_trajindex=return_trajindex)
 
-    def __init__(self, filenames, chunksize=1000, **kwargs):
-        super(PyCSVReader, self).__init__(chunksize=chunksize)
-        self._is_reader = True
-
-        if not isinstance(filenames, (tuple, list)):
-            filenames = [filenames]
-        self._filenames = filenames
-        # list of boolean to indicate if file
-        self._has_header = [False] * len(self._filenames)
-
-        self._dialects = [None] * len(self._filenames)
-
-        # user wants to skip lines, so we need to remember this for lagged
-        # access
-        if kwargs.get('skip'):
-            self._skip = kwargs.pop('skip')
-        else:
-            self._skip = 0
-
-        self.__set_dimensions_and_lenghts()
+    def _get_dialect(self, itraj):
+        fn_idx = self.filenames.index(self.filenames[itraj])
+        return self._dialects[fn_idx]
 
     def describe(self):
         return "[CSVReader files=%s]" % self._filenames
 
-    def __set_dimensions_and_lenghts(self):
-        # number of trajectories/data sets
-        self._ntraj = len(self._filenames)
-        if self._ntraj == 0:
-            raise ValueError("empty file list")
+    def _get_traj_info(self, filename):
+        idx = self.filenames.index(filename)
+        with open(filename, 'rt') as fh:
+            # approx by filesize / (first line + 20%)
+            size = int(os.stat(filename).st_size / len(fh.readline()) * 1.2)
+            assert size > 0
+            fh.seek(0)
+            offsets = np.empty(size, dtype=np.int64)
+            offsets[0] = 0
+            i = 1
+            while fh.readline():
+                offsets[i] = fh.tell()
+                i += 1
+                if i >= len(offsets):
+                    offsets = np.resize(offsets, int(ceil(len(offsets)*1.2)))
+            offsets = offsets[:i]
+            length = len(offsets)
+            fh.seek(0)
 
-        ndims = []
+            if not self._delimiters[idx]:
+                # determine delimiter
+                sample = fh.read(2048)
+                sniffer = csv.Sniffer()
+                self._dialects[idx] = sniffer.sniff(sample)
+                if sniffer.has_header(sample):
+                    self._skip[idx] += 1
+                    length -= 1
+            else:
+                class custom_dialect(csv.Dialect):
+                    delimiter = self._delimiters[idx]
+                    quotechar = '"'
+                    lineterminator = '\r\n'
+                    quoting = csv.QUOTE_MINIMAL
+                d = custom_dialect()
+                d.delimiter = self._delimiters[idx]
 
-        for ii, f in enumerate(self._filenames):
+                # determine header
+                hdr = False
+                while True:
+                    line = fh.readline()
+                    if line == '':
+                        break
+                    if line[0] == self._comments[idx]:
+                        hdr += 1
+                        continue
+
+                self._skip[idx] += hdr
+                length -= hdr
+
+                self._dialects[idx] = d
+            # if we have a header subtract it from total length
+            fh.seek(0)
+            r = csv.reader(fh, dialect=self._dialects[idx])
+            for _ in range(self._skip[idx]+1):
+                line = next(r)
             try:
                 # determine file length
                 with open(f) as fh:
                     # count rows
                     self._lengths.append(sum(1 for _ in fh))
                     fh.seek(0)
-                    # determine if file has header here, assuming we can read at
-                    # least two lines
-
-                    sample = fh.readline()
-                    len_sample = len(sample)
-                    sample += fh.readline()
-                    if len(sample) == len_sample:
-                        raise RuntimeError('file "%i" only contains one line.'
-                                           'Could not determine dimensions')
+                    # determine if file has header here:
+                    sample = fh.read(2048)
                     self._dialects[ii] = csv.Sniffer().sniff(sample)
                     self._has_header[ii] = csv.Sniffer().has_header(sample)
                     # if we have a header subtract it from total length
@@ -208,22 +288,19 @@ class PyCSVReader(DataSource):
                     if self._has_header[ii]:
                         next(r)
                     line = next(r)
-                    # filter empty strings
-                    line = [x for x in line if len(x) > 0]
                     arr = np.array(line).astype(float)
                     dim = arr.squeeze().shape[0]
                     ndims.append(dim)
 
-            # parent of IOError, OSError *and* WindowsError where available
-            except EnvironmentError:
-                self._logger.exception()
-                self._logger.error(
-                        "removing %s from list, since it caused an error" % f)
-                self._filenames.remove(f)
+            try:
+                arr = np.array(line).astype(float)
+            except ValueError as ve:
+                s = 'could not parse first line of data in file "%s"' % filename
+                raise ValueError(s, ve)
+            s = arr.squeeze().shape
+            if len(s) == 1:
+                ndim = s[0]
+            else:
+                ndim = 1
 
-        # check all files have same dimensions
-        if not len(np.unique(ndims)) == 1:
-            self._logger.error("got different dims: %s" % ndims)
-            raise ValueError("input files have different dims")
-        else:
-            self._ndim = ndims[0]
+        return TrajInfo(ndim, length, offsets)

--- a/pyemma/coordinates/data/util/reader_utils.py
+++ b/pyemma/coordinates/data/util/reader_utils.py
@@ -26,7 +26,7 @@ import os
 from six import string_types
 
 
-def create_file_reader(input_files, topology, featurizer, chunk_size=100):
+def create_file_reader(input_files, topology, featurizer, chunk_size=100, **kw):
     r"""
     Creates a (possibly featured) file reader by a number of input files and either a topology file or a featurizer.
     Parameters
@@ -104,7 +104,7 @@ def create_file_reader(input_files, topology, featurizer, chunk_size=100):
                         reader = NumPyFileReader(input_list, chunksize=chunk_size)
                     # otherwise we assume that given files are ascii tabulated data
                     else:
-                        reader = PyCSVReader(input_list, chunksize=chunk_size)
+                        reader = PyCSVReader(input_list, chunksize=chunk_size, **kw)
         else:
             raise ValueError("Not all elements in the input list were of the type %s!" % suffix)
     else:

--- a/pyemma/coordinates/data/util/reader_utils.py
+++ b/pyemma/coordinates/data/util/reader_utils.py
@@ -41,20 +41,21 @@ def create_file_reader(input_files, topology, featurizer, chunk_size=100):
         The chunk size with which the corresponding reader gets initialized.
     :return: Returns the reader.
     """
-    from pyemma.coordinates.data.numpy_filereader import NumPyFileReader as _NumPyFileReader
-    from pyemma.coordinates.data.py_csv_reader import PyCSVReader as _CSVReader
-    from pyemma.coordinates.data import FeatureReader as _FeatureReader
-    from pyemma.coordinates.data.fragmented_trajectory_reader import FragmentedTrajectoryReader as _FragmentedReader
+    from pyemma.coordinates.data.numpy_filereader import NumPyFileReader
+    from pyemma.coordinates.data.py_csv_reader import PyCSVReader
+    from pyemma.coordinates.data import FeatureReader
+    from pyemma.coordinates.data.fragmented_trajectory_reader import FragmentedTrajectoryReader
 
     # fragmented trajectories
-    if isinstance(input_files, (list, tuple)) and len(input_files) > 0 and \
-            any(isinstance(item, (list, tuple)) for item in input_files):
-        return _FragmentedReader(input_files, topology, chunk_size, featurizer)
+    if (isinstance(input_files, (list, tuple)) and len(input_files) > 0 and
+            any(isinstance(item, (list, tuple)) for item in input_files)):
+        return FragmentedTrajectoryReader(input_files, topology, chunk_size, featurizer)
 
     # normal trajectories
-    if isinstance(input_files, string_types) \
+    if (isinstance(input_files, string_types)
             or (isinstance(input_files, (list, tuple))
-                and (any(isinstance(item, string_types) for item in input_files) or len(input_files) is 0)):
+                and (any(isinstance(item, string_types) for item in input_files) 
+                     or len(input_files) is 0))):
         reader = None
         # check: if single string create a one-element list
         if isinstance(input_files, string_types):
@@ -96,14 +97,14 @@ def create_file_reader(input_files, topology, featurizer, chunk_size=100):
                         raise ValueError("The input files were MD files which makes it mandatory to have either a "
                                          "featurizer or a topology file.")
 
-                    reader = _FeatureReader(input_list, featurizer=featurizer, topologyfile=topology,
-                                            chunksize=chunk_size)
+                    reader = FeatureReader(input_list, featurizer=featurizer, topologyfile=topology,
+                                           chunksize=chunk_size)
                 else:
                     if suffix in ['.npy', '.npz']:
-                        reader = _NumPyFileReader(input_list, chunksize=chunk_size)
+                        reader = NumPyFileReader(input_list, chunksize=chunk_size)
                     # otherwise we assume that given files are ascii tabulated data
                     else:
-                        reader = _CSVReader(input_list, chunksize=chunk_size)
+                        reader = PyCSVReader(input_list, chunksize=chunk_size)
         else:
             raise ValueError("Not all elements in the input list were of the type %s!" % suffix)
     else:
@@ -160,7 +161,7 @@ def preallocate_empty_trajectory(top, n_frames=1):
 
 
 def enforce_top(top):
-    if isinstance(top,str):
+    if isinstance(top, string_types):
         top = md.load(top).top
     elif isinstance(top, md.Trajectory):
         top = top.top
@@ -177,13 +178,13 @@ def save_traj_w_md_load_frame(reader, sets):
     traj = None
     for file_idx, frame_idx in vstack(sets):
         if traj is None:
-            traj = md.load_frame(reader.trajfiles[file_idx], frame_idx, reader.topfile)
+            traj = md.load_frame(reader.filenames[file_idx], frame_idx, reader.topfile)
         else:
-            traj = traj.join(md.load_frame(reader.trajfiles[file_idx], frame_idx, reader.topfile))
+            traj = traj.join(md.load_frame(reader.filenames[file_idx], frame_idx, reader.topfile))
     return traj
 
 
-def compare_coords_md_trajectory_objects(traj1, traj2, atom = None, eps = 1e-6, mess = False ):
+def compare_coords_md_trajectory_objects(traj1, traj2, atom=None, eps=1e-6, mess=False):
     # Compares the coordinates of "atom" for all frames in traj1 and traj2
     # Returns a boolean found_diff and an errmsg informing where
     assert isinstance(traj1, md.Trajectory)

--- a/pyemma/coordinates/pipelines.py
+++ b/pyemma/coordinates/pipelines.py
@@ -250,7 +250,7 @@ class Discretizer(Pipeline):
 
         trajfiles = None
         if isinstance(reader, FeatureReader):
-            trajfiles = reader.trajfiles
+            trajfiles = reader.filenames
 
         clustering.save_dtrajs(
             trajfiles, prefix, output_dir, output_format, extension)

--- a/pyemma/coordinates/tests/test_api_source.py
+++ b/pyemma/coordinates/tests/test_api_source.py
@@ -112,7 +112,7 @@ class TestApiSourceFeatureReader(unittest.TestCase):
         self.assertIsNotNone(reader, "The reader should not be none.")
         self.assertEqual(reader.topfile, self.pdb_file,
                          "Reader topology file and input topology file should coincide.")
-        self.assertListEqual(reader.trajfiles, self.traj_files, "Reader trajectories and input"
+        self.assertListEqual(reader.filenames, self.traj_files, "Reader trajectories and input"
                                                                 " trajectories should coincide.")
         self.assertEqual(reader.featurizer.topologyfile, self.pdb_file, "Featurizers topology file and input "
                                                                         "topology file should coincide.")
@@ -123,7 +123,7 @@ class TestApiSourceFeatureReader(unittest.TestCase):
         self.assertIsNotNone(reader, "The reader should not be none.")
         self.assertEqual(reader.topfile, self.pdb_file,
                          "Reader topology file and input topology file should coincide.")
-        self.assertListEqual(reader.trajfiles, self.traj_files, "Reader trajectories and input"
+        self.assertListEqual(reader.filenames, self.traj_files, "Reader trajectories and input"
                                                                 " trajectories should coincide.")
         self.assertEqual(reader.featurizer.topologyfile, self.pdb_file, "Featurizers topology file and input "
                                                                         "topology file should coincide.")
@@ -133,7 +133,7 @@ class TestApiSourceFeatureReader(unittest.TestCase):
         self.assertIsNotNone(reader, "The reader should not be none.")
         self.assertEqual(reader.topfile, self.pdb_file,
                          "Reader topology file and input topology file should coincide.")
-        self.assertListEqual(reader.trajfiles, [self.traj_files[0]], "Reader trajectories and input"
+        self.assertListEqual(reader.filenames, [self.traj_files[0]], "Reader trajectories and input"
                                                                      " trajectories should coincide.")
         self.assertEqual(reader.featurizer.topologyfile, self.pdb_file, "Featurizers topology file and input "
                                                                         "topology file should coincide.")
@@ -144,7 +144,7 @@ class TestApiSourceFeatureReader(unittest.TestCase):
         self.assertIsNotNone(reader, "The reader should not be none.")
         self.assertEqual(reader.topfile, self.pdb_file,
                          "Reader topology file and input topology file should coincide.")
-        self.assertListEqual(reader.trajfiles, [self.traj_files[0]], "Reader trajectories and input"
+        self.assertListEqual(reader.filenames, [self.traj_files[0]], "Reader trajectories and input"
                                                                      " trajectories should coincide.")
         self.assertEqual(reader.featurizer.topologyfile, self.pdb_file, "Featurizers topology file and input "
                                                                         "topology file should coincide.")

--- a/pyemma/coordinates/tests/test_coordinates_iterator.py
+++ b/pyemma/coordinates/tests/test_coordinates_iterator.py
@@ -4,6 +4,7 @@ import numpy as np
 from pyemma.coordinates.data import DataInMemory
 from pyemma.util.files import TemporaryDirectory
 import os
+from glob import glob
 
 
 class TestCoordinatesIterator(unittest.TestCase):
@@ -141,16 +142,18 @@ class TestCoordinatesIterator(unittest.TestCase):
     def test_write_to_csv_propagate_filenames(self):
         from pyemma.coordinates import source, tica
         with TemporaryDirectory() as td:
-            data = [np.random.random((20, 3))]*3
-            fns = [os.path.join(td, f) for f in ('blah.npy', 'blub.npy', 'foo.npy')]
+            data = [np.random.random((20, 3))] * 3
+            fns = [os.path.join(td, f)
+                   for f in ('blah.npy', 'blub.npy', 'foo.npy')]
             for x, fn in zip(data, fns):
                 np.save(fn, x)
             reader = source(fns)
+            assert reader.filenames == fns
             tica_obj = tica(reader, lag=1)
             tica_obj.write_to_csv(extension=".exotic")
-            res = os.listdir(td)
-            assert len(res) == len(fns)
-            desired_fns = [s.replace('.npy', '.exotic') for s in fns]
+            res = sorted([os.path.abspath(x) for x in glob(td + os.path.sep + '*.exotic')])
+            self.assertEqual(len(res), len(fns))
+            desired_fns = sorted([s.replace('.npy', '.exotic') for s in fns])
             self.assertEqual(res, desired_fns)
 
 if __name__ == '__main__':

--- a/pyemma/coordinates/tests/test_coordinates_iterator.py
+++ b/pyemma/coordinates/tests/test_coordinates_iterator.py
@@ -145,14 +145,12 @@ class TestCoordinatesIterator(unittest.TestCase):
             fns = [os.path.join(td, f) for f in ('blah.npy', 'blub.npy', 'foo.npy')]
             for x, fn in zip(data, fns):
                 np.save(fn, x)
-            reader = source(fn)
+            reader = source(fns)
             tica_obj = tica(reader, lag=1)
             tica_obj.write_to_csv(extension=".exotic")
             res = os.listdir(td)
-            print (res)
             assert len(res) == len(fns)
             desired_fns = [s.replace('.npy', '.exotic') for s in fns]
-            print "des",desired_fns
             self.assertEqual(res, desired_fns)
 
 if __name__ == '__main__':

--- a/pyemma/coordinates/tests/test_csvreader.py
+++ b/pyemma/coordinates/tests/test_csvreader.py
@@ -155,6 +155,14 @@ class TestCSVReader(unittest.TestCase):
             output = reader.get_output(stride=s)[0]
             np.testing.assert_almost_equal(output, self.data[::s], err_msg="stride=%s"%s)
 
+    def test_with_binary_written_file(self):
+        data = np.arange(9).reshape(3, 3)
+        with tempfile.NamedTemporaryFile('w+b',delete=False) as tmp:
+            np.savetxt(tmp.name, data)
+            tmp.close()
+            out = CSVReader(tmp.name).get_output()[0]
+        np.testing.assert_allclose(out, data)
+
     def test_with_lag(self):
         reader = CSVReader(self.filename1)
 

--- a/pyemma/coordinates/tests/test_csvreader.py
+++ b/pyemma/coordinates/tests/test_csvreader.py
@@ -69,10 +69,12 @@ class TestCSVReader(unittest.TestCase):
         np.testing.assert_almost_equal(output[0], self.data)
 
     def test_read_1file_oneline(self):
-        with tempfile.NamedTemporaryFile(suffix='.dat', delete=False) as f:
-            np.savetxt(f, [1,2,3])
+        tiny = np.array([1, 2, 3])
+        with tempfile.NamedTemporaryFile(mode='wb', suffix='.dat', delete=False) as f:
+            np.savetxt(f, tiny)
             f.close()
-            CSVReader(f.name, delimiters=" ")
+            reader = CSVReader(f.name, delimiters=" ")
+            np.testing.assert_equal(reader.get_output()[0], np.atleast_2d(tiny).T)
 
     def test_read_1file_with_header(self):
         reader = CSVReader(self.file_with_header)

--- a/pyemma/coordinates/tests/test_csvreader.py
+++ b/pyemma/coordinates/tests/test_csvreader.py
@@ -228,7 +228,7 @@ class TestCSVReader(unittest.TestCase):
 
     def test_compare_readline(self):
         data = np.arange(99*3).reshape(-1, 3)
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as fh:
+        with tempfile.NamedTemporaryFile(mode='wb', delete=False) as fh:
             np.savetxt(fh, data)
             # calc offsets
         reader = CSVReader(fh.name)

--- a/pyemma/coordinates/tests/test_source.py
+++ b/pyemma/coordinates/tests/test_source.py
@@ -48,7 +48,7 @@ class TestSource(unittest.TestCase):
         reader = api.source(self.traj_files, top=self.pdb_file)
         self.assertIsNotNone(reader, "The reader should not be none.")
         self.assertEqual(reader.topfile, self.pdb_file, "Reader topology file and input topology file should coincide.")
-        self.assertListEqual(reader.trajfiles, self.traj_files, "Reader trajectories and input"
+        self.assertListEqual(reader.filenames, self.traj_files, "Reader trajectories and input"
                                                                 " trajectories should coincide.")
         self.assertEqual(reader.featurizer.topologyfile, self.pdb_file, "Featurizers topology file and input "
                                                                         "topology file should coincide.")
@@ -58,7 +58,7 @@ class TestSource(unittest.TestCase):
         reader = api.source(self.traj_files, features=featurizer)
         self.assertIsNotNone(reader, "The reader should not be none.")
         self.assertEqual(reader.topfile, self.pdb_file, "Reader topology file and input topology file should coincide.")
-        self.assertListEqual(reader.trajfiles, self.traj_files, "Reader trajectories and input"
+        self.assertListEqual(reader.filenames, self.traj_files, "Reader trajectories and input"
                                                                 " trajectories should coincide.")
         self.assertEqual(reader.featurizer.topologyfile, self.pdb_file, "Featurizers topology file and input "
                                                                         "topology file should coincide.")
@@ -67,7 +67,7 @@ class TestSource(unittest.TestCase):
         reader = api.source(self.traj_files[0], top=self.pdb_file)
         self.assertIsNotNone(reader, "The reader should not be none.")
         self.assertEqual(reader.topfile, self.pdb_file, "Reader topology file and input topology file should coincide.")
-        self.assertListEqual(reader.trajfiles, [self.traj_files[0]], "Reader trajectories and input"
+        self.assertListEqual(reader.filenames, [self.traj_files[0]], "Reader trajectories and input"
                                                                      " trajectories should coincide.")
         self.assertEqual(reader.featurizer.topologyfile, self.pdb_file, "Featurizers topology file and input "
                                                                         "topology file should coincide.")
@@ -77,7 +77,7 @@ class TestSource(unittest.TestCase):
         reader = api.source(self.traj_files[0], features=featurizer)
         self.assertIsNotNone(reader, "The reader should not be none.")
         self.assertEqual(reader.topfile, self.pdb_file, "Reader topology file and input topology file should coincide.")
-        self.assertListEqual(reader.trajfiles, [self.traj_files[0]], "Reader trajectories and input"
+        self.assertListEqual(reader.filenames, [self.traj_files[0]], "Reader trajectories and input"
                                                                      " trajectories should coincide.")
         self.assertEqual(reader.featurizer.topologyfile, self.pdb_file, "Featurizers topology file and input "
                                                                         "topology file should coincide.")
@@ -172,7 +172,7 @@ class TestSourceCallAll(unittest.TestCase):
         assert self.inp.trajectory_lengths()[0] == self.inp.trajectory_length(0)
 
     def test_trajfiles(self):
-        assert types.is_list_of_string(self.inp.trajfiles)
+        assert types.is_list_of_string(self.inp.filenames)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/tests/test_traj_info_cache.py
+++ b/pyemma/coordinates/tests/test_traj_info_cache.py
@@ -130,14 +130,14 @@ class TestTrajectoryInfoCache(unittest.TestCase):
 
     def test_csvreader(self):
         data = np.random.random((101, 3))
-        with tempfile.NamedTemporaryFile(delete=False) as fh:
+        with tempfile.NamedTemporaryFile(mode='wb', delete=False) as fh:
             np.savetxt(fh, data)
             # calc offsets
             fh.seek(0)
             offsets = [0]
-            while fh.readline():
-                offsets.append(fh.tell())
-            fh.close()
+            with open(fh.name, 'rb') as new_fh:
+                for _ in new_fh:
+                    offsets.append(new_fh.tell())
             reader = PyCSVReader(fh.name)
             assert reader.dimension() == 3
             trajinfo = reader._get_traj_info(fh.name)
@@ -165,7 +165,7 @@ class TestTrajectoryInfoCache(unittest.TestCase):
         import warnings
         from pyemma.util.exceptions import EfficiencyWarning
 
-        with NamedTemporaryFile(suffix='.xyz', delete=False) as f:
+        with NamedTemporaryFile(mode='wb', suffix='.xyz', delete=False) as f:
             fn = f.name
             traj.save_xyz(fn)
             f.close()

--- a/pyemma/coordinates/tests/test_traj_info_cache.py
+++ b/pyemma/coordinates/tests/test_traj_info_cache.py
@@ -130,18 +130,17 @@ class TestTrajectoryInfoCache(unittest.TestCase):
 
     def test_csvreader(self):
         data = np.random.random((101, 3))
-        with tempfile.NamedTemporaryFile(mode='wb', delete=False) as fh:
+        with tempfile.NamedTemporaryFile(mode='w', delete=False) as fh:
             np.savetxt(fh, data)
             # calc offsets
-            fh.close()
-            offsets = [0]
-            with open(fh.name, PyCSVReader.DEFAULT_OPEN_MODE) as new_fh:
-                while new_fh.readline():
-                    offsets.append(new_fh.tell())
-            reader = PyCSVReader(fh.name)
-            assert reader.dimension() == 3
-            trajinfo = reader._get_traj_info(fh.name)
-            np.testing.assert_equal(offsets, trajinfo.offsets)
+        offsets = [0]
+        with open(fh.name, PyCSVReader.DEFAULT_OPEN_MODE) as new_fh:
+            while new_fh.readline():
+                offsets.append(new_fh.tell())
+        reader = PyCSVReader(fh.name)
+        assert reader.dimension() == 3
+        trajinfo = reader._get_traj_info(fh.name)
+        np.testing.assert_equal(offsets, trajinfo.offsets)
 
     def test_fragmented_reader(self):
         top_file = pkg_resources.resource_filename(__name__, 'data/test.pdb')

--- a/pyemma/coordinates/tests/test_traj_info_cache.py
+++ b/pyemma/coordinates/tests/test_traj_info_cache.py
@@ -130,17 +130,20 @@ class TestTrajectoryInfoCache(unittest.TestCase):
 
     def test_csvreader(self):
         data = np.random.random((101, 3))
-        with tempfile.NamedTemporaryFile(mode='w', delete=False) as fh:
-            np.savetxt(fh, data)
+        fn = tempfile.mktemp()
+        try:
+            np.savetxt(fn, data)
             # calc offsets
-        offsets = [0]
-        with open(fh.name, PyCSVReader.DEFAULT_OPEN_MODE) as new_fh:
-            while new_fh.readline():
-                offsets.append(new_fh.tell())
-        reader = PyCSVReader(fh.name)
-        assert reader.dimension() == 3
-        trajinfo = reader._get_traj_info(fh.name)
-        np.testing.assert_equal(offsets, trajinfo.offsets)
+            offsets = [0]
+            with open(fn, PyCSVReader.DEFAULT_OPEN_MODE) as new_fh:
+                while new_fh.readline():
+                    offsets.append(new_fh.tell())
+            reader = PyCSVReader(fn)
+            assert reader.dimension() == 3
+            trajinfo = reader._get_traj_info(fn)
+            np.testing.assert_equal(offsets, trajinfo.offsets)
+        finally:
+            os.unlink(fn)
 
     def test_fragmented_reader(self):
         top_file = pkg_resources.resource_filename(__name__, 'data/test.pdb')

--- a/pyemma/coordinates/tests/test_traj_info_cache.py
+++ b/pyemma/coordinates/tests/test_traj_info_cache.py
@@ -136,7 +136,7 @@ class TestTrajectoryInfoCache(unittest.TestCase):
             fh.close()
             offsets = [0]
             with open(fh.name, PyCSVReader.DEFAULT_OPEN_MODE) as new_fh:
-                for _ in new_fh:
+                while new_fh.readline():
                     offsets.append(new_fh.tell())
             reader = PyCSVReader(fh.name)
             assert reader.dimension() == 3

--- a/pyemma/coordinates/tests/test_traj_info_cache.py
+++ b/pyemma/coordinates/tests/test_traj_info_cache.py
@@ -133,9 +133,9 @@ class TestTrajectoryInfoCache(unittest.TestCase):
         with tempfile.NamedTemporaryFile(mode='wb', delete=False) as fh:
             np.savetxt(fh, data)
             # calc offsets
-            fh.seek(0)
+            fh.close()
             offsets = [0]
-            with open(fh.name, 'rb') as new_fh:
+            with open(fh.name, PyCSVReader.DEFAULT_OPEN_MODE) as new_fh:
                 for _ in new_fh:
                     offsets.append(new_fh.tell())
             reader = PyCSVReader(fh.name)

--- a/pyemma/coordinates/tests/test_traj_info_cache.py
+++ b/pyemma/coordinates/tests/test_traj_info_cache.py
@@ -1,4 +1,3 @@
-
 # This file is part of PyEMMA.
 #
 # Copyright (c) 2015, 2014 Computational Molecular Biology Group, Freie Universitaet Berlin (GER)
@@ -15,7 +14,6 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
 '''
 Created on 30.04.2015
 
@@ -24,20 +22,27 @@ Created on 30.04.2015
 
 from __future__ import absolute_import
 
+from tempfile import NamedTemporaryFile
 import os
 import tempfile
 import unittest
 
-import mdtraj
-import pyemma
-from pyemma.coordinates.data.util.traj_info_cache import _TrajectoryInfoCache as TrajectoryInfoCache
-from pyemma.util.files import TemporaryDirectory
+from pyemma.coordinates import api
+from pyemma.coordinates.data.feature_reader import FeatureReader
+from pyemma.coordinates.data.numpy_filereader import NumPyFileReader
+from pyemma.coordinates.data.py_csv_reader import PyCSVReader
+from pyemma.coordinates.tests.test_featurereader import create_traj
 from pyemma.datasets import get_bpti_test_data
+from pyemma.util import config
+from pyemma.util.files import TemporaryDirectory
+import mdtraj
+import pkg_resources
+import pyemma
 
+from pyemma.coordinates.data.util.traj_info_cache import TrajectoryInfoCache
 import numpy as np
 
 
-# os.path.join(path, 'bpti_mini.xtc')
 xtcfiles = get_bpti_test_data()['trajs']
 pdbfile = get_bpti_test_data()['top']
 
@@ -53,6 +58,10 @@ class TestTrajectoryInfoCache(unittest.TestCase):
         self.tmpfile = tempfile.mktemp(dir=self.work_dir)
         self.db = TrajectoryInfoCache(self.tmpfile)
 
+        assert len(self.db._database) == 1, len(self.db._database)
+        assert 'db_version' in self.db._database
+        assert int(self.db._database['db_version']) >= 1
+
     def tearDown(self):
         del self.db
 
@@ -62,54 +71,133 @@ class TestTrajectoryInfoCache(unittest.TestCase):
         import shutil
         shutil.rmtree(cls.work_dir, ignore_errors=True)
 
-    def testCacheResults(self):
+    def test_exceptions(self):
+        # in accessible files
+        not_existant = ''.join(
+            chr(i) for i in np.random.random_integers(65, 90, size=10)) + '.npy'
+        bad = [not_existant]  # should be unaccessible or non existant
+        with self.assertRaises(ValueError) as cm:
+            api.source(bad)
+            assert bad[0] in cm.exception.message
+
+        # empty files
+        with NamedTemporaryFile(delete=False) as f:
+            f.close()
+            with self.assertRaises(ValueError) as cm:
+                api.source(f.name)
+                assert f.name in cm.exception.message
+
+    def test_featurereader_xtc(self):
         # cause cache failures
+        config['use_trajectory_lengths_cache'] = False
+        reader = FeatureReader(xtcfiles, pdbfile)
+        config['use_trajectory_lengths_cache'] = True
+
         results = {}
         for f in xtcfiles:
-            results[f] = self.db[f]
+            traj_info = self.db[f, reader]
+            results[f] = traj_info.ndim, traj_info.length, traj_info.offsets
 
-        desired = {}
+        expected = {}
         for f in xtcfiles:
             with mdtraj.open(f) as fh:
-                desired[f] = len(fh)
+                length = len(fh)
+                ndim = fh.read(1)[0].shape[1]
+                offsets = fh.offsets if hasattr(fh, 'offsets') else []
+                expected[f] = ndim, length, offsets
 
-        self.assertEqual(results, desired)
+        np.testing.assert_equal(results, expected)
 
-    def test_with_npy_file(self):
-        from pyemma.util.files import TemporaryDirectory
-        lengths = [1, 23, 27, ]
-        different_lengths_array = [np.empty((n, 3)) for n in lengths]
+    def test_npy_reader(self):
+        lengths_and_dims = [(7, 3), (23, 3), (27, 3)]
+        data = [
+            np.empty((n, dim)) for n, dim in lengths_and_dims]
         files = []
         with TemporaryDirectory() as td:
-            for i, x in enumerate(different_lengths_array):
+            for i, x in enumerate(data):
                 fn = os.path.join(td, "%i.npy" % i)
                 np.save(fn, x)
                 files.append(fn)
 
+            reader = NumPyFileReader(files)
+
             # cache it and compare
-            results = {f: self.db[f] for f in files}
-            expected = {
-                fn: len(different_lengths_array[i]) for i, fn in enumerate(files)}
+            results = {f: (self.db[f, reader].length, self.db[f, reader].ndim,
+                           self.db[f, reader].offsets) for f in files}
+            expected = {f: (len(data[i]), data[i].shape[1], [])
+                        for i, f in enumerate(files)}
+            np.testing.assert_equal(results, expected)
 
-            self.assertEqual(results, expected)
+    def test_csvreader(self):
+        data = np.random.random((101, 3))
+        with tempfile.NamedTemporaryFile(delete=False) as fh:
+            np.savetxt(fh, data)
+            # calc offsets
+            fh.seek(0)
+            offsets = [0]
+            while fh.readline():
+                offsets.append(fh.tell())
+            fh.close()
+            reader = PyCSVReader(fh.name)
+            assert reader.dimension() == 3
+            trajinfo = reader._get_traj_info(fh.name)
+            np.testing.assert_equal(offsets, trajinfo.offsets)
 
-    def test_xyz(self):
+    def test_fragmented_reader(self):
+        top_file = pkg_resources.resource_filename(__name__, 'data/test.pdb')
+        trajfiles = []
+        nframes = []
+        with TemporaryDirectory() as wd:
+            for _ in range(3):
+                f, _, l = create_traj(top_file, dir=wd)
+                trajfiles.append(f)
+                nframes.append(l)
+            # three trajectories: one consisting of all three, one consisting of the first,
+            # one consisting of the first and the last
+            reader = api.source(
+                [trajfiles, [trajfiles[0]], [trajfiles[0], trajfiles[2]]], top=top_file)
+            np.testing.assert_equal(reader.trajectory_lengths(),
+                                    [sum(nframes), nframes[0], nframes[0] + nframes[2]])
+
+    def test_feature_reader_xyz(self):
         traj = mdtraj.load(xtcfiles, top=pdbfile)
-        expected = len(traj)
+        length = len(traj)
         import warnings
         from pyemma.util.exceptions import EfficiencyWarning
 
-        with TemporaryDirectory() as td:
-            fn = os.path.join(td, 'test.xyz')
+        with NamedTemporaryFile(suffix='.xyz', delete=False) as f:
+            fn = f.name
             traj.save_xyz(fn)
+            f.close()
             with warnings.catch_warnings(record=True) as w:
                 reader = pyemma.coordinates.source(fn, top=pdbfile)
 
-                self.assertEqual(len(w), 1)
                 self.assertEqual(w[0].category, EfficiencyWarning)
 
-            self.assertEqual(reader.trajectory_length(0), expected)
+            self.assertEqual(reader.trajectory_length(0), length)
 
+    def test_data_in_mem(self):
+        # make sure cache is not used for data in memory!
+        data = [np.empty((3, 3))] * 3
+        api.source(data)
+        assert len(self.db._database) == 1
+
+    def test_old_db_conversion(self):
+        # prior 2.1, database only contained lengths (int as string) entries
+        # check conversion is happening
+        with NamedTemporaryFile(suffix='.npy', delete=False) as f:
+            db = TrajectoryInfoCache(None)
+            fn = f.name
+            np.save(fn, [1, 2, 3])
+            f.close() # windows sucks
+            reader = api.source(fn)
+            hash = db._get_file_hash(fn)
+            db._database = {hash: str(3)}
+
+            info = db[fn, reader]
+            assert info.length == 3
+            assert info.ndim == 1
+            assert info.offsets == []
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/util/patches.py
+++ b/pyemma/coordinates/util/patches.py
@@ -114,11 +114,17 @@ class iterload(object):
                 if self._extension in ('.crd', '.mdcrd')
                 else open(self._filename)
             )(self._filename)
+
+            # offset array handling
+            offsets = kwargs.pop('offsets', None)
+            if hasattr(self._f, 'offsets') and offsets is not None:
+                self._f.offsets = offsets
+
             if self._skip > 0:
                 self._f.seek(self._skip)
 
     def __iter__(self):
-            return self
+        return self
 
     def close(self):
         if hasattr(self, '_t'):


### PR DESCRIPTION
- Unify setting of filenames avoids a lot of redundant code.
- Expensive properties (byte offsets, lengths for csv files, XTC, etc.) are cached
