### PR TITLE
Merge hmm in devel

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,19 +17,30 @@ EMMA (Emma's Markov Model Algorithms)
 
 What is it?
 -----------
-EMMA is an open source collection of algorithms implemented mostly in
-`NumPy <http://www.numpy.org/>`_ and `SciPy <http://www.scipy.org>`_ to analyze
-trajectories generated from any kind of simulation (e.g. molecular
-trajectories) via Markov state models (MSM).
+PyEMMA (EMMA = Emma's Markov Model Algorithms) is an open source
+Python/C package for analysis of extensive molecular dynamics simulations.
+In particular, it includes algorithms for estimation, validation and analysis
+of:
 
-It provides APIs for estimation and analyzing MSM and various utilities to
-process input data (clustering, coordinate transformations etc). For
-documentation of the API, please have a look at the sphinx docs in doc
-directory or `online <http://www.emma-project.org/>`__.
+  * Markov state models (MSMs)
+  * Hidden Markov models (HMMs)
+  * multi-ensemble Markov models (MEMMs)
+  * Time-lagged independent component analysis (TICA)
+  * Clustering and Featurization.
 
-For some examples on how to apply the software, please have a look in the
-ipython directory, which shows the most common use cases as documentated
-IPython notebooks.
+PyEMMA can be used from Jupyther (former IPython, recommended), or by
+writing Python scripts. The docs, can be found at
+`http://pyemma.org <http://www.pyemma.org/>`__.
+
+Citation
+--------
+If you use PyEMMA in scientific work, please cite:
+
+    M. K. Scherer, B. Trendelkamp-Schroer, F. Paul, G. Pérez-Hernández,
+    M. Hoffmann, N. Plattner, C. Wehmeyer, J.-H. Prinz and F. Noé:
+    PyEMMA 2: A Software Package for Estimation, Validation, and Analysis of Markov Models,
+	J. Chem. Theory Comput. 11, 5525-5542 (2015)
+
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -22,11 +22,12 @@ Python/C package for analysis of extensive molecular dynamics simulations.
 In particular, it includes algorithms for estimation, validation and analysis
 of:
 
+  * Clustering and Featurization
   * Markov state models (MSMs)
   * Hidden Markov models (HMMs)
   * multi-ensemble Markov models (MEMMs)
   * Time-lagged independent component analysis (TICA)
-  * Clustering and Featurization.
+  * Transition Path Theory (TPT)
 
 PyEMMA can be used from Jupyther (former IPython, recommended), or by
 writing Python scripts. The docs, can be found at

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -35,23 +35,24 @@ Technical features:
 Citation |DOI for Citing PyEMMA|
 --------------------------------
 
-PyEMMA is scientific software, if you use it in your scientific work, please
-consider citing this paper: ::
+If you use PyEMMA in scientific software, please cite the following paper: ::
 
 	@article{scherer_pyemma_2015,
+		author = {Scherer, Martin K. and Trendelkamp-Schroer, Benjamin
+                          and Paul, Fabian and Pérez-Hernández, Guillermo and Hoffmann, Moritz and
+                          Plattner, Nuria and Wehmeyer, Christoph and Prinz, Jan-Hendrik and Noé, Frank},
 		title = {{PyEMMA} 2: {A} {Software} {Package} for {Estimation},
                          {Validation}, and {Analysis} of {Markov} {Models}},
+		journal = {Journal of Chemical Theory and Computation},
+		volume = {11},
+		pages = {5525-5542},
+		year = {2015},
 		issn = {1549-9618},
 		shorttitle = {{PyEMMA} 2},
 		url = {http://dx.doi.org/10.1021/acs.jctc.5b00743},
 		doi = {10.1021/acs.jctc.5b00743},
 		urldate = {2015-10-19},
-		journal = {Journal of Chemical Theory and Computation},
-		author = {Scherer, Martin K. and Trendelkamp-Schroer, Benjamin
-                          and Paul, Fabian and Pérez-Hernández, Guillermo and Hoffmann, Moritz and
-                          Plattner, Nuria and Wehmeyer, Christoph and Prinz, Jan-Hendrik and Noé, Frank},
 		month = oct,
-		year = {2015},
 	}
 
 .. |DOI for Citing PyEMMA| image:: _static/pyemma_paper_doi.svg

--- a/pyemma/_base/estimator.py
+++ b/pyemma/_base/estimator.py
@@ -133,7 +133,7 @@ def _estimate_param_scan_worker(estimator, params, X, evaluate, evaluate_args,
     except:
         e = sys.exc_info()[0]
         if failfast:
-            raise e
+            raise  # re-raise
         else:
             pass  # just return model=None
 

--- a/pyemma/msm/__init__.py
+++ b/pyemma/msm/__init__.py
@@ -99,7 +99,6 @@ io = dtraj
 from .estimators import MaximumLikelihoodMSM, BayesianMSM
 from .estimators import MaximumLikelihoodHMSM, BayesianHMSM
 from .estimators import ImpliedTimescales
-from .estimators import EstimatedMSM, EstimatedHMSM
 from .estimators import ChapmanKolmogorovValidator
 
 from .models import MSM, HMSM, SampledMSM, SampledHMSM

--- a/pyemma/msm/api.py
+++ b/pyemma/msm/api.py
@@ -1007,7 +1007,7 @@ def bayesian_markov_model(dtrajs, lag, reversible=True, statdist=None,
 
 
 def bayesian_hidden_markov_model(dtrajs, nstates, lag, nsamples=100, reversible=True, connectivity='largest',
-                                 observe_active=True, conf=0.95, dt_traj='1 step',
+                                 observe_active=True, conf=0.95, dt_traj='1 step', store_hidden=False,
                                  show_progress=True):
     r""" Bayesian Hidden Markov model estimate using Gibbs sampling of the posterior
 
@@ -1064,6 +1064,8 @@ def bayesian_hidden_markov_model(dtrajs, nstates, lag, nsamples=100, reversible=
         |  'us',  'microsecond*'
         |  'ms',  'millisecond*'
         |  's',   'second*'
+    store_hidden : bool, optional, default=False
+        store hidden trajectories in sampled HMMs
     show_progress : bool, default=True
         Show progressbars for calculation?
 
@@ -1140,7 +1142,7 @@ def bayesian_hidden_markov_model(dtrajs, nstates, lag, nsamples=100, reversible=
     """
     bhmsm_estimator = _Bayes_HMSM(lag=lag, nstates=nstates, nsamples=nsamples, reversible=reversible,
                                   connectivity=connectivity, observe_active=observe_active,
-                                  dt_traj=dt_traj, conf=conf, show_progress=show_progress)
+                                  dt_traj=dt_traj, conf=conf, store_hidden=store_hidden, show_progress=show_progress)
     return bhmsm_estimator.estimate(dtrajs)
 
 # TODO: need code examples

--- a/pyemma/msm/api.py
+++ b/pyemma/msm/api.py
@@ -49,6 +49,10 @@ __all__ = ['markov_model',
            'bayesian_hidden_markov_model',
            'tpt']
 
+# =============================================================================
+# MARKOV STATE MODELS - flat Markov chains on discrete observation space
+# =============================================================================
+
 
 @shortcut('its')
 def timescales_msm(dtrajs, lags=None, nits=None, reversible=True, connected=True,
@@ -503,318 +507,9 @@ def estimate_markov_model(dtrajs, lag, reversible=True, statdist=None,
     return mlmsm.estimate(dtrajs)
 
 
-def timescales_hmsm(dtrajs, nstates, lags=None, nits=None, reversible=True, stationary=False,
-                    connectivity=None, errors=None, nsamples=100, n_jobs=1,
-                    show_progress=True):
-    r""" Calculate implied timescales from Hidden Markov state models estimated at a series of lag times.
-
-    Warning: this can be slow!
-
-    Parameters
-    ----------
-    dtrajs : array-like or list of array-likes
-        discrete trajectories
-    nstates : int
-        number of hidden states
-    lags : array-like of integers (optional)
-        integer lag times at which the implied timescales will be calculated
-    nits : int (optional)
-        number of implied timescales to be computed. Will compute less if the
-        number of states are smaller. None means the number of timescales will
-        be determined automatically.
-    connectivity : str, optional, default = None
-        Defines if the resulting HMM will be defined on all hidden states or on
-        a connected subset. Connectivity is defined by counting only
-        transitions with at least mincount_connectivity counts.
-        If a subset of states is used, all estimated quantities (transition
-        matrix, stationary distribution, etc) are only defined on this subset
-        and are correspondingly smaller than nstates.
-        Following modes are available:
-        * None or 'all' : The active set is the full set of states.
-          Estimation is done on all weakly connected subsets separately. The
-          resulting transition matrix may be disconnected.
-        * 'largest' : The active set is the largest reversibly connected set.
-        * 'populous' : The active set is the reversibly connected set with
-           most counts.
-    reversible : boolean (optional)
-        Estimate transition matrix reversibly (True) or nonreversibly (False)
-    stationary : bool, optional, default=False
-        If True, the initial distribution of hidden states is self-consistently
-        computed as the stationary distribution of the transition matrix. If False,
-        it will be estimated from the starting states. Only set this to true if
-        you're sure that the observation trajectories are initiated from a global
-        equilibrium distribution.
-    errors : None | 'bayes'
-        Specifies whether to compute statistical uncertainties (by default not),
-        an which algorithm to use if yes. The only option is currently 'bayes'.
-        This algorithm is much faster than MSM-based error calculation because
-        the involved matrices are much smaller.
-    nsamples : int
-        Number of approximately independent HMSM samples generated for each lag
-        time for uncertainty quantification. Only used if errors is not None.
-    n_jobs = 1 : int
-        how many subprocesses to start to estimate the models for each lag time.
-    show_progress : bool, default=True
-        Show progressbars for calculation?
-
-    Returns
-    -------
-    itsobj : :class:`ImpliedTimescales <pyemma.msm.ImpliedTimescales>` object
-
-    See also
-    --------
-    ImpliedTimescales
-        The object returned by this function.
-    pyemma.plots.plot_implied_timescales
-        Plotting function for the :class:`ImpliedTimescales <pyemma.msm.ImpliedTimescales>` object
-
-    Example
-    -------
-    >>> from pyemma import msm
-    >>> import numpy as np
-    >>> np.set_printoptions(precision=3)
-    >>> dtraj = [0,1,1,0,0,0,1,1,0,0,0,1,2,2,2,2,2,2,2,2,2,1,1,0,0,0,1,1,0,1,0]   # mini-trajectory
-    >>> ts = msm.timescales_hmsm(dtraj, 2, [1,2,3,4])
-    >>> print(ts.timescales) # doctest: +ELLIPSIS
-    [[ 5.786]
-     [ 5.143]
-     [ 4.44 ]
-     [ 3.677]]
-
-    .. autoclass:: pyemma.msm.estimators.implied_timescales.ImpliedTimescales
-        :members:
-        :undoc-members:
-
-        .. rubric:: Methods
-
-        .. autoautosummary:: pyemma.msm.estimators.implied_timescales.ImpliedTimescales
-           :methods:
-
-        .. rubric:: Attributes
-
-        .. autoautosummary:: pyemma.msm.estimators.implied_timescales.ImpliedTimescales
-            :attributes:
-
-    References
-    ----------
-    Implied timescales as a lagtime-selection and MSM-validation approach were
-    suggested in [1]_. Hidden Markov state model estimation is done here as
-    described in [2]_. For uncertainty quantification we employ the Bayesian
-    sampling algorithm described in [3]_.
-
-    .. [1] Swope, W. C. and J. W. Pitera and F. Suits: Describing protein
-        folding kinetics by molecular dynamics simulations:  1. Theory.
-        J. Phys. Chem. B 108: 6571-6581 (2004)
-
-    .. [2] F. Noe, H. Wu, J.-H. Prinz and N. Plattner: Projected and hidden
-        Markov models for calculating kinetics and metastable states of
-        complex molecules. J. Chem. Phys. 139, 184114 (2013)
-
-    .. [3] J. D. Chodera et al:
-        Bayesian hidden Markov model analysis of single-molecule force
-        spectroscopy: Characterizing kinetics under measurement uncertainty
-        arXiv:1108.1430 (2011)
-
-    """
-    # format data
-    dtrajs = _types.ensure_dtraj_list(dtrajs)
-
-    # MLE or error estimation?
-    if errors is None:
-        estimator = _ML_HMSM(nstates=nstates, reversible=reversible, stationary=stationary, connectivity=connectivity)
-    elif errors == 'bayes':
-        estimator = _Bayes_HMSM(nstates=nstates, reversible=reversible, stationary=stationary,
-                                connectivity=connectivity, show_progress=show_progress, nsamples=nsamples)
-    else:
-        raise NotImplementedError('Error estimation method'+str(errors)+'currently not implemented')
-
-    # go
-    itsobj = _ImpliedTimescales(estimator, lags=lags, nits=nits, n_jobs=n_jobs,
-                                show_progress=show_progress)
-    itsobj.estimate(dtrajs)
-    return itsobj
-
-
-def estimate_hidden_markov_model(dtrajs, nstates, lag, reversible=True, stationary=False,
-                                 connectivity=None, separate=None,
-                                 dt_traj='1 step', accuracy=1e-3, maxit=1000):
-    r""" Estimates a Hidden Markov state model from discrete trajectories
-
-    Returns a :class:`MaximumLikelihoodHMSM` that contains a transition
-    matrix between a few (hidden) metastable states. Each metastable state has
-    a probability distribution of visiting the discrete 'microstates' contained
-    in the input trajectories. The resulting object is a hidden Markov model
-    that allows to compute a large number of quantities.
-
-    Parameters
-    ----------
-    dtrajs : list containing ndarrays(dtype=int) or ndarray(n, dtype=int)
-        discrete trajectories, stored as integer ndarrays (arbitrary size)
-        or a single ndarray for only one trajectory.
-    lag : int
-        lagtime for the MSM estimation in multiples of trajectory steps
-    nstates : int
-        the number of metastable states in the resulting HMM
-    reversible : bool, optional, default = True
-        If true compute reversible MSM, else non-reversible MSM
-    stationary : bool, optional, default=False
-        If True, the initial distribution of hidden states is self-consistently
-        computed as the stationary distribution of the transition matrix. If False,
-        it will be estimated from the starting states. Only set this to true if
-        you're sure that the observation trajectories are initiated from a global
-        equilibrium distribution.
-    connectivity : str, optional, default = None
-        Defines if the resulting HMM will be defined on all hidden states or on
-        a connected subset. Connectivity is defined by counting only
-        transitions with at least mincount_connectivity counts.
-        If a subset of states is used, all estimated quantities (transition
-        matrix, stationary distribution, etc) are only defined on this subset
-        and are correspondingly smaller than nstates.
-        Following modes are available:
-        * None or 'all' : The active set is the full set of states.
-          Estimation is done on all weakly connected subsets separately. The
-          resulting transition matrix may be disconnected.
-        * 'largest' : The active set is the largest reversibly connected set.
-        * 'populous' : The active set is the reversibly connected set with
-           most counts.
-    separate : None or iterable of int
-        Force the given set of observed states to stay in a separate hidden state.
-        The remaining nstates-1 states will be assigned by a metastable decomposition.
-    dt_traj : str, optional, default='1 step'
-        Description of the physical time corresponding to the trajectory time
-        step. May be used by analysis algorithms such as plotting tools to
-        pretty-print the axes. By default '1 step', i.e. there is no physical
-        time unit. Specify by a number, whitespace and unit. Permitted units
-        are (* is an arbitrary string):
-
-        |  'fs',  'femtosecond*'
-        |  'ps',  'picosecond*'
-        |  'ns',  'nanosecond*'
-        |  'us',  'microsecond*'
-        |  'ms',  'millisecond*'
-        |  's',   'second*'
-    accuracy : float
-        convergence threshold for EM iteration. When two the likelihood does
-        not increase by more than accuracy, the iteration is stopped
-        successfully.
-    maxit : int
-        stopping criterion for EM iteration. When so many iterations are
-        performed without reaching the requested accuracy, the iteration is
-        stopped without convergence (a warning is given)
-
-    Returns
-    -------
-    hmsm : :class:`MaximumLikelihoodHMSM <pyemma.msm.MaximumLikelihoodHMSM>`
-        Estimator object containing the HMSM and estimation information.
-
-    Example
-    -------
-    >>> from pyemma import msm
-    >>> import numpy as np
-    >>> np.set_printoptions(precision=3)
-    >>> dtrajs = [[0,1,2,2,2,2,1,2,2,2,1,0,0,0,0,0,0,0], [0,0,0,0,1,1,2,2,2,2,2,2,2,1,0,0]]  # two trajectories
-    >>> mm = msm.estimate_hidden_markov_model(dtrajs, 2, 2)
-
-    We have estimated a 2x2 hidden transition matrix between the metastable
-    states:
-
-    >>> print(mm.transition_matrix)
-    [[ 0.684  0.316]
-     [ 0.242  0.758]]
-
-    With the equilibrium distribution:
-
-    >>> print(mm.stationary_distribution) # doctest: +ELLIPSIS
-    [ 0.43...  0.56...]
-
-    The observed states are the three discrete clusters that we have in our
-    discrete trajectory:
-
-    >>> print(mm.observable_set)
-    [0 1 2]
-
-    The metastable distributions (mm.metastable_distributions), or equivalently
-    the observation probabilities are the probability to be in a given cluster
-    ('microstate') if we are in one of the hidden metastable states.
-    So it's a 2 x 3 matrix:
-
-    >>> print(mm.observation_probabilities) # doctest: +SKIP
-    [[ 0.9620883   0.0379117   0.        ]
-     [ 0.          0.28014352  0.71985648]]
-
-    The first metastable state ist mostly in cluster 0, and a little bit in the
-    transition state cluster 1. The second metastable state is less well
-    defined, but mostly in cluster 2 and less prominently in the transition
-    state cluster 1.
-
-    We can print the lifetimes of the metastable states:
-
-    >>> print(mm.lifetimes) # doctest: +ELLIPSIS
-    [ 5...  7...]
-
-    And the timescale of the hidden transition matrix - now we only have one
-    relaxation timescale:
-
-    >>> print(mm.timescales())  # doctest: +ELLIPSIS
-    [ 2.4...]
-
-    The mean first passage times can also be computed between metastable states:
-
-    >>> print(mm.mfpt(0, 1))  # doctest: +ELLIPSIS
-    6.3...
-
-    See also
-    --------
-    EstimatedHMSM : A discrete HMM object that has been estimated from data
-
-
-    .. autoclass:: pyemma.msm.estimators.maximum_likelihood_hmsm.MaximumLikelihoodHMSM
-        :members:
-        :undoc-members:
-
-        .. rubric:: Methods
-
-        .. autoautosummary:: pyemma.msm.estimators.maximum_likelihood_hmsm.MaximumLikelihoodHMSM
-           :methods:
-
-        .. rubric:: Attributes
-
-        .. autoautosummary:: pyemma.msm.estimators.maximum_likelihood_hmsm.MaximumLikelihoodHMSM
-            :attributes:
-
-
-    References
-    ----------
-    [1]_ is an excellent review of estimation algorithms for discrete Hidden
-    Markov Models. This function estimates a discrete HMM on the discrete
-    input states using the Baum-Welch algorithm [2]_. We use a
-    maximum-likelihood Markov state model to initialize the HMM estimation as
-    described in [3]_.
-
-    .. [1] L. R. Rabiner: A Tutorial on Hidden Markov Models and Selected
-        Applications in Speech Recognition. Proc. IEEE 77, 257-286 (1989)
-
-    .. [2] L. Baum, T. Petrie, G. Soules and N. Weiss N: A maximization
-        technique occurring in the statistical analysis of probabilistic
-        functions of Markov chains. Ann. Math. Statist. 41, 164-171 (1970)
-
-    .. [3] F. Noe, H. Wu, J.-H. Prinz and N. Plattner: Projected and hidden
-        Markov models for calculating kinetics and  metastable states of
-        complex molecules. J. Chem. Phys. 139, 184114 (2013)
-
-
-    """
-    # initialize HMSM estimator
-    hmsm_estimator = _ML_HMSM(lag=lag, nstates=nstates, reversible=reversible, msm_init='largest-strong',
-                              connectivity=connectivity, separate=separate,
-                              dt_traj=dt_traj, accuracy=accuracy, maxit=maxit)
-    # run estimation
-    return hmsm_estimator.estimate(dtrajs)
-
-
 def bayesian_markov_model(dtrajs, lag, reversible=True, statdist=None,
                           sparse=False, connectivity='largest',
-                          count_mode ='effective',
+                          count_mode='effective',
                           nsamples=100, conf=0.95, dt_traj='1 step',
                           show_progress=True):
     r""" Bayesian Markov model estimate using Gibbs sampling of the posterior
@@ -1005,8 +700,340 @@ def bayesian_markov_model(dtrajs, lag, reversible=True, statdist=None,
     return bmsm_estimator.estimate(dtrajs)
 
 
+# =============================================================================
+# HIDDEN MARKOV MODELS on discrete observation space
+# =============================================================================
+
+
+def timescales_hmsm(dtrajs, nstates, lags=None, nits=None, reversible=True, stationary=False,
+                    connectivity=None, mincount_connectivity='1/n', separate=None, errors=None, nsamples=100,
+                    n_jobs=1, show_progress=True):
+    r""" Calculate implied timescales from Hidden Markov state models estimated at a series of lag times.
+
+    Warning: this can be slow!
+
+    Parameters
+    ----------
+    dtrajs : array-like or list of array-likes
+        discrete trajectories
+    nstates : int
+        number of hidden states
+    lags : array-like of integers (optional)
+        integer lag times at which the implied timescales will be calculated
+    nits : int (optional)
+        number of implied timescales to be computed. Will compute less if the
+        number of states are smaller. None means the number of timescales will
+        be determined automatically.
+    connectivity : str, optional, default = None
+        Defines if the resulting HMM will be defined on all hidden states or on
+        a connected subset. Connectivity is defined by counting only
+        transitions with at least mincount_connectivity counts.
+        If a subset of states is used, all estimated quantities (transition
+        matrix, stationary distribution, etc) are only defined on this subset
+        and are correspondingly smaller than nstates.
+        Following modes are available:
+        * None or 'all' : The active set is the full set of states.
+          Estimation is done on all weakly connected subsets separately. The
+          resulting transition matrix may be disconnected.
+        * 'largest' : The active set is the largest reversibly connected set.
+        * 'populous' : The active set is the reversibly connected set with
+           most counts.
+    mincount_connectivity : float or '1/n'
+        minimum number of counts to consider a connection between two states.
+        Counts lower than that will count zero in the connectivity check and
+        may thus separate the resulting transition matrix. The default
+        evaluates to 1/nstates.
+    separate : None or iterable of int
+        Force the given set of observed states to stay in a separate hidden state.
+        The remaining nstates-1 states will be assigned by a metastable decomposition.
+    reversible : boolean (optional)
+        Estimate transition matrix reversibly (True) or nonreversibly (False)
+    stationary : bool, optional, default=False
+        If True, the initial distribution of hidden states is self-consistently
+        computed as the stationary distribution of the transition matrix. If False,
+        it will be estimated from the starting states. Only set this to true if
+        you're sure that the observation trajectories are initiated from a global
+        equilibrium distribution.
+    errors : None | 'bayes'
+        Specifies whether to compute statistical uncertainties (by default not),
+        an which algorithm to use if yes. The only option is currently 'bayes'.
+        This algorithm is much faster than MSM-based error calculation because
+        the involved matrices are much smaller.
+    nsamples : int
+        Number of approximately independent HMSM samples generated for each lag
+        time for uncertainty quantification. Only used if errors is not None.
+    n_jobs = 1 : int
+        how many subprocesses to start to estimate the models for each lag time.
+    show_progress : bool, default=True
+        Show progressbars for calculation?
+
+    Returns
+    -------
+    itsobj : :class:`ImpliedTimescales <pyemma.msm.ImpliedTimescales>` object
+
+    See also
+    --------
+    ImpliedTimescales
+        The object returned by this function.
+    pyemma.plots.plot_implied_timescales
+        Plotting function for the :class:`ImpliedTimescales <pyemma.msm.ImpliedTimescales>` object
+
+    Example
+    -------
+    >>> from pyemma import msm
+    >>> import numpy as np
+    >>> np.set_printoptions(precision=3)
+    >>> dtraj = [0,1,1,0,0,0,1,1,0,0,0,1,2,2,2,2,2,2,2,2,2,1,1,0,0,0,1,1,0,1,0]   # mini-trajectory
+    >>> ts = msm.timescales_hmsm(dtraj, 2, [1,2,3,4])
+    >>> print(ts.timescales) # doctest: +ELLIPSIS
+    [[ 5.786]
+     [ 5.143]
+     [ 4.44 ]
+     [ 3.677]]
+
+    .. autoclass:: pyemma.msm.estimators.implied_timescales.ImpliedTimescales
+        :members:
+        :undoc-members:
+
+        .. rubric:: Methods
+
+        .. autoautosummary:: pyemma.msm.estimators.implied_timescales.ImpliedTimescales
+           :methods:
+
+        .. rubric:: Attributes
+
+        .. autoautosummary:: pyemma.msm.estimators.implied_timescales.ImpliedTimescales
+            :attributes:
+
+    References
+    ----------
+    Implied timescales as a lagtime-selection and MSM-validation approach were
+    suggested in [1]_. Hidden Markov state model estimation is done here as
+    described in [2]_. For uncertainty quantification we employ the Bayesian
+    sampling algorithm described in [3]_.
+
+    .. [1] Swope, W. C. and J. W. Pitera and F. Suits: Describing protein
+        folding kinetics by molecular dynamics simulations:  1. Theory.
+        J. Phys. Chem. B 108: 6571-6581 (2004)
+
+    .. [2] F. Noe, H. Wu, J.-H. Prinz and N. Plattner: Projected and hidden
+        Markov models for calculating kinetics and metastable states of
+        complex molecules. J. Chem. Phys. 139, 184114 (2013)
+
+    .. [3] J. D. Chodera et al:
+        Bayesian hidden Markov model analysis of single-molecule force
+        spectroscopy: Characterizing kinetics under measurement uncertainty
+        arXiv:1108.1430 (2011)
+
+    """
+    # format data
+    dtrajs = _types.ensure_dtraj_list(dtrajs)
+
+    # MLE or error estimation?
+    if errors is None:
+        estimator = _ML_HMSM(nstates=nstates, reversible=reversible, stationary=stationary, connectivity=connectivity,
+                             mincount_connectivity=mincount_connectivity, separate=separate)
+    elif errors == 'bayes':
+        estimator = _Bayes_HMSM(nstates=nstates, reversible=reversible, stationary=stationary,
+                                connectivity=connectivity, mincount_connectivity=mincount_connectivity,
+                                separate=separate, show_progress=show_progress, nsamples=nsamples)
+    else:
+        raise NotImplementedError('Error estimation method'+str(errors)+'currently not implemented')
+
+    # go
+    itsobj = _ImpliedTimescales(estimator, lags=lags, nits=nits, n_jobs=n_jobs,
+                                show_progress=show_progress)
+    itsobj.estimate(dtrajs)
+    return itsobj
+
+
+def estimate_hidden_markov_model(dtrajs, nstates, lag, reversible=True, stationary=False,
+                                 connectivity=None, mincount_connectivity='1/n', separate=None, observe_nonempty=True,
+                                 dt_traj='1 step', accuracy=1e-3, maxit=1000):
+    r""" Estimates a Hidden Markov state model from discrete trajectories
+
+    Returns a :class:`MaximumLikelihoodHMSM` that contains a transition
+    matrix between a few (hidden) metastable states. Each metastable state has
+    a probability distribution of visiting the discrete 'microstates' contained
+    in the input trajectories. The resulting object is a hidden Markov model
+    that allows to compute a large number of quantities.
+
+    Parameters
+    ----------
+    dtrajs : list containing ndarrays(dtype=int) or ndarray(n, dtype=int)
+        discrete trajectories, stored as integer ndarrays (arbitrary size)
+        or a single ndarray for only one trajectory.
+    lag : int
+        lagtime for the MSM estimation in multiples of trajectory steps
+    nstates : int
+        the number of metastable states in the resulting HMM
+    reversible : bool, optional, default = True
+        If true compute reversible MSM, else non-reversible MSM
+    stationary : bool, optional, default=False
+        If True, the initial distribution of hidden states is self-consistently
+        computed as the stationary distribution of the transition matrix. If False,
+        it will be estimated from the starting states. Only set this to true if
+        you're sure that the observation trajectories are initiated from a global
+        equilibrium distribution.
+    connectivity : str, optional, default = None
+        Defines if the resulting HMM will be defined on all hidden states or on
+        a connected subset. Connectivity is defined by counting only
+        transitions with at least mincount_connectivity counts.
+        If a subset of states is used, all estimated quantities (transition
+        matrix, stationary distribution, etc) are only defined on this subset
+        and are correspondingly smaller than nstates.
+        Following modes are available:
+        * None or 'all' : The active set is the full set of states.
+          Estimation is done on all weakly connected subsets separately. The
+          resulting transition matrix may be disconnected.
+        * 'largest' : The active set is the largest reversibly connected set.
+        * 'populous' : The active set is the reversibly connected set with
+           most counts.
+    mincount_connectivity : float or '1/n'
+        minimum number of counts to consider a connection between two states.
+        Counts lower than that will count zero in the connectivity check and
+        may thus separate the resulting transition matrix. The default
+        evaluates to 1/nstates.
+    separate : None or iterable of int
+        Force the given set of observed states to stay in a separate hidden state.
+        The remaining nstates-1 states will be assigned by a metastable decomposition.
+    observe_nonempty : bool
+        If True, will restricted the observed states to the states that have
+        at least one observation in the lagged input trajectories.
+    dt_traj : str, optional, default='1 step'
+        Description of the physical time corresponding to the trajectory time
+        step. May be used by analysis algorithms such as plotting tools to
+        pretty-print the axes. By default '1 step', i.e. there is no physical
+        time unit. Specify by a number, whitespace and unit. Permitted units
+        are (* is an arbitrary string):
+
+        |  'fs',  'femtosecond*'
+        |  'ps',  'picosecond*'
+        |  'ns',  'nanosecond*'
+        |  'us',  'microsecond*'
+        |  'ms',  'millisecond*'
+        |  's',   'second*'
+    accuracy : float
+        convergence threshold for EM iteration. When two the likelihood does
+        not increase by more than accuracy, the iteration is stopped
+        successfully.
+    maxit : int
+        stopping criterion for EM iteration. When so many iterations are
+        performed without reaching the requested accuracy, the iteration is
+        stopped without convergence (a warning is given)
+
+    Returns
+    -------
+    hmsm : :class:`MaximumLikelihoodHMSM <pyemma.msm.MaximumLikelihoodHMSM>`
+        Estimator object containing the HMSM and estimation information.
+
+    Example
+    -------
+    >>> from pyemma import msm
+    >>> import numpy as np
+    >>> np.set_printoptions(precision=3)
+    >>> dtrajs = [[0,1,2,2,2,2,1,2,2,2,1,0,0,0,0,0,0,0], [0,0,0,0,1,1,2,2,2,2,2,2,2,1,0,0]]  # two trajectories
+    >>> mm = msm.estimate_hidden_markov_model(dtrajs, 2, 2)
+
+    We have estimated a 2x2 hidden transition matrix between the metastable
+    states:
+
+    >>> print(mm.transition_matrix)
+    [[ 0.684  0.316]
+     [ 0.242  0.758]]
+
+    With the equilibrium distribution:
+
+    >>> print(mm.stationary_distribution) # doctest: +ELLIPSIS
+    [ 0.43...  0.56...]
+
+    The observed states are the three discrete clusters that we have in our
+    discrete trajectory:
+
+    >>> print(mm.observable_set)
+    [0 1 2]
+
+    The metastable distributions (mm.metastable_distributions), or equivalently
+    the observation probabilities are the probability to be in a given cluster
+    ('microstate') if we are in one of the hidden metastable states.
+    So it's a 2 x 3 matrix:
+
+    >>> print(mm.observation_probabilities) # doctest: +SKIP
+    [[ 0.9620883   0.0379117   0.        ]
+     [ 0.          0.28014352  0.71985648]]
+
+    The first metastable state ist mostly in cluster 0, and a little bit in the
+    transition state cluster 1. The second metastable state is less well
+    defined, but mostly in cluster 2 and less prominently in the transition
+    state cluster 1.
+
+    We can print the lifetimes of the metastable states:
+
+    >>> print(mm.lifetimes) # doctest: +ELLIPSIS
+    [ 5...  7...]
+
+    And the timescale of the hidden transition matrix - now we only have one
+    relaxation timescale:
+
+    >>> print(mm.timescales())  # doctest: +ELLIPSIS
+    [ 2.4...]
+
+    The mean first passage times can also be computed between metastable states:
+
+    >>> print(mm.mfpt(0, 1))  # doctest: +ELLIPSIS
+    6.3...
+
+    See also
+    --------
+    EstimatedHMSM : A discrete HMM object that has been estimated from data
+
+
+    .. autoclass:: pyemma.msm.estimators.maximum_likelihood_hmsm.MaximumLikelihoodHMSM
+        :members:
+        :undoc-members:
+
+        .. rubric:: Methods
+
+        .. autoautosummary:: pyemma.msm.estimators.maximum_likelihood_hmsm.MaximumLikelihoodHMSM
+           :methods:
+
+        .. rubric:: Attributes
+
+        .. autoautosummary:: pyemma.msm.estimators.maximum_likelihood_hmsm.MaximumLikelihoodHMSM
+            :attributes:
+
+
+    References
+    ----------
+    [1]_ is an excellent review of estimation algorithms for discrete Hidden
+    Markov Models. This function estimates a discrete HMM on the discrete
+    input states using the Baum-Welch algorithm [2]_. We use a
+    maximum-likelihood Markov state model to initialize the HMM estimation as
+    described in [3]_.
+
+    .. [1] L. R. Rabiner: A Tutorial on Hidden Markov Models and Selected
+        Applications in Speech Recognition. Proc. IEEE 77, 257-286 (1989)
+
+    .. [2] L. Baum, T. Petrie, G. Soules and N. Weiss N: A maximization
+        technique occurring in the statistical analysis of probabilistic
+        functions of Markov chains. Ann. Math. Statist. 41, 164-171 (1970)
+
+    .. [3] F. Noe, H. Wu, J.-H. Prinz and N. Plattner: Projected and hidden
+        Markov models for calculating kinetics and  metastable states of
+        complex molecules. J. Chem. Phys. 139, 184114 (2013)
+
+
+    """
+    # initialize HMSM estimator
+    hmsm_estimator = _ML_HMSM(lag=lag, nstates=nstates, reversible=reversible, msm_init='largest-strong',
+                              connectivity=connectivity, mincount_connectivity=mincount_connectivity, separate=separate,
+                              observe_nonempty=observe_nonempty, dt_traj=dt_traj, accuracy=accuracy, maxit=maxit)
+    # run estimation
+    return hmsm_estimator.estimate(dtrajs)
+
+
 def bayesian_hidden_markov_model(dtrajs, nstates, lag, nsamples=100, reversible=True, stationary=False,
-                                 connectivity=None, separate=None,
+                                 connectivity=None, mincount_connectivity='1/n', separate=None, observe_nonempty=True,
                                  conf=0.95, dt_traj='1 step', store_hidden=False, show_progress=True):
     r""" Bayesian Hidden Markov model estimate using Gibbs sampling of the posterior
 
@@ -1045,9 +1072,17 @@ def bayesian_hidden_markov_model(dtrajs, nstates, lag, nsamples=100, reversible=
         * 'largest' : The active set is the largest reversibly connected set.
         * 'populous' : The active set is the reversibly connected set with
            most counts.
+    mincount_connectivity : float or '1/n'
+        minimum number of counts to consider a connection between two states.
+        Counts lower than that will count zero in the connectivity check and
+        may thus separate the resulting transition matrix. The default
+        evaluates to 1/nstates.
     separate : None or iterable of int
         Force the given set of observed states to stay in a separate hidden state.
         The remaining nstates-1 states will be assigned by a metastable decomposition.
+    observe_nonempty : bool
+        If True, will restricted the observed states to the states that have
+        at least one observation in the lagged input trajectories.
     nsamples : int, optional, default=100
         number of transition matrix samples to compute and store
     conf : float, optional, default=0.95
@@ -1142,7 +1177,8 @@ def bayesian_hidden_markov_model(dtrajs, nstates, lag, nsamples=100, reversible=
 
     """
     bhmsm_estimator = _Bayes_HMSM(lag=lag, nstates=nstates, nsamples=nsamples, reversible=reversible,
-                                  connectivity=connectivity, separate=separate,
+                                  connectivity=connectivity, mincount_connectivity=mincount_connectivity,
+                                  separate=separate, observe_nonempty=observe_nonempty,
                                   dt_traj=dt_traj, conf=conf, store_hidden=store_hidden, show_progress=show_progress)
     return bhmsm_estimator.estimate(dtrajs)
 

--- a/pyemma/msm/estimators/__init__.py
+++ b/pyemma/msm/estimators/__init__.py
@@ -24,7 +24,4 @@ from .bayesian_msm import BayesianMSM
 from .maximum_likelihood_hmsm import MaximumLikelihoodHMSM
 from .bayesian_hmsm import BayesianHMSM
 from .implied_timescales import ImpliedTimescales
-from .lagged_model_validators import ChapmanKolmogorovValidator, EigenvalueDecayValidator#
-
-from .estimated_msm import EstimatedMSM
-from .estimated_hmsm import EstimatedHMSM
+from .lagged_model_validators import ChapmanKolmogorovValidator, EigenvalueDecayValidator

--- a/pyemma/msm/estimators/_dtraj_stats.py
+++ b/pyemma/msm/estimators/_dtraj_stats.py
@@ -106,11 +106,15 @@ class DiscreteTrajectoryStats(object):
             self._C_sub[i] = submatrix(self._C, self._connected_sets[i])
 
         # largest connected set
-        lcs = self._connected_sets[0]
+        self._lcs = self._connected_sets[0]
+
+        # if lcs has no counts, make lcs empty
+        if submatrix(self._C, self._lcs).sum() == 0:
+            self._lcs = np.array([], dtype=int)
 
         # mapping from full to lcs
         self._full2lcs = -1 * np.ones((self._nstates), dtype=int)
-        self._full2lcs[lcs] = np.array(list(range(len(lcs))), dtype=int)
+        self._full2lcs[self._lcs] = np.array(list(range(len(self._lcs))), dtype=int)
 
         # remember that this function was called
         self._counted_at_lag = True
@@ -135,6 +139,8 @@ class DiscreteTrajectoryStats(object):
         A : int or int array
             set of states
         """
+        if np.size(A) == 0:
+            return True  # empty set is always contained
         assert np.max(A) < self._nstates, 'Chosen set contains states that are not included in the data.'
 
     @property
@@ -254,7 +260,7 @@ class DiscreteTrajectoryStats(object):
 
         """
         self._assert_counted_at_lag()
-        return self._connected_sets[0]
+        return self._lcs
 
     @property
     def visited_set(self):

--- a/pyemma/msm/estimators/bayesian_hmsm.py
+++ b/pyemma/msm/estimators/bayesian_hmsm.py
@@ -203,20 +203,6 @@ class BayesianHMSM(_MaximumLikelihoodHMSM, _SampledHMSM, ProgressReporter):
         from bhmm import discrete_hmm, bayesian_hmm
         hmm_mle = discrete_hmm(init_hmsm.stationary_distribution, init_hmsm.transition_matrix, pobs)
 
-        # # define prior
-        # if self.prior == 'sparse':
-        #     self.prior_count_matrix = _np.zeros((self.nstates, self.nstates), dtype=_np.float64)
-        # elif self.prior == 'uniform':
-        #     self.prior_count_matrix = _np.ones((self.nstates, self.nstates), dtype=_np.float64)
-        # elif self.prior == 'mixed':
-        #     # C0 = _np.dot(_np.diag(init_hmsm.stationary_distribution), init_hmsm.transition_matrix)
-        #     P0 = init_hmsm.transition_matrix
-        #     P0_offdiag = P0 - _np.diag(_np.diag(P0))
-        #     scaling_factor = 1.0 / _np.sum(P0_offdiag, axis=1)
-        #     self.prior_count_matrix = P0 * scaling_factor[:, None]
-        # else:
-        #     raise ValueError('Unknown prior mode: '+self.prior)
-        #
         sampled_hmm = bayesian_hmm(init_hmsm.discrete_trajectories_lagged, hmm_mle, nsample=self.nsamples,
                                    reversible=self.reversible, stationary=self.stationary,
                                    p0_prior=self.p0_prior, transition_matrix_prior=self.transition_matrix_prior,

--- a/pyemma/msm/estimators/estimated_msm.py
+++ b/pyemma/msm/estimators/estimated_msm.py
@@ -498,8 +498,7 @@ class EstimatedMSM(MSM):
         # run estimate
         from pyemma.msm.estimators.maximum_likelihood_hmsm import MaximumLikelihoodHMSM
         estimator = MaximumLikelihoodHMSM(lag=self.lagtime, nstates=nstates, msm_init=self,
-                                          reversible=self.is_reversible, connectivity=self.connectivity,
-                                          observe_active=True, dt_traj=self.dt_traj)
+                                          reversible=self.is_reversible, observe_active=True, dt_traj=self.dt_traj)
         estimator.estimate(self.discrete_trajectories_full)
         return estimator.model
 

--- a/pyemma/msm/estimators/estimated_msm.py
+++ b/pyemma/msm/estimators/estimated_msm.py
@@ -327,11 +327,14 @@ class EstimatedMSM(MSM):
         # compute stationary distribution, expanded to full set
         statdist_full = np.zeros([self._nstates_full])
         statdist_full[self.active_set] = self.stationary_distribution
+        # histogram observed states
+        import msmtools.dtraj as msmtraj
+        hist = 1.0 * msmtraj.count_states(self.discrete_trajectories_full)
         # simply read off stationary distribution and accumulate total weight
         W = []
         wtot = 0.0
         for dtraj in self.discrete_trajectories_full:
-            w = statdist_full[dtraj]
+            w = statdist_full[dtraj] / hist[dtraj]
             W.append(w)
             wtot += np.sum(W)
         # normalize

--- a/pyemma/msm/estimators/implied_timescales.py
+++ b/pyemma/msm/estimators/implied_timescales.py
@@ -143,7 +143,7 @@ class ImpliedTimescales(Estimator, ProgressReporter):
             self.estimator.show_progress = False
 
         # run estimation on all lag times
-        self._models, self._estimators = estimate_param_scan(self.estimator, data, param_sets, failfast=True,
+        self._models, self._estimators = estimate_param_scan(self.estimator, data, param_sets, failfast=False,
                                                              return_estimators=True, n_jobs=self.n_jobs,
                                                              progress_reporter=self)
 

--- a/pyemma/msm/estimators/implied_timescales.py
+++ b/pyemma/msm/estimators/implied_timescales.py
@@ -143,7 +143,7 @@ class ImpliedTimescales(Estimator, ProgressReporter):
             self.estimator.show_progress = False
 
         # run estimation on all lag times
-        self._models, self._estimators = estimate_param_scan(self.estimator, data, param_sets, failfast=False,
+        self._models, self._estimators = estimate_param_scan(self.estimator, data, param_sets, failfast=True,
                                                              return_estimators=True, n_jobs=self.n_jobs,
                                                              progress_reporter=self)
 
@@ -191,13 +191,14 @@ class ImpliedTimescales(Estimator, ProgressReporter):
             # samples
             timescales_samples = [m.sample_f('timescales') for m in self._models]
             nsamples = np.shape(timescales_samples[0])[0]
-            self._its_samples = np.zeros((nsamples, len(self._lags), self.nits))
+            self._its_samples = np.empty((nsamples, len(self._lags), self.nits))
+            self._its_samples[:] = np.NAN  # initialize with NaN in order to point out timescales that were not computed
 
             for i, ts in enumerate(timescales_samples):
                 if ts is not None:
                     ts = np.vstack(ts)
                     ts = ts[:, :self.nits]
-                    self._its_samples[:, i, :ts.shape[1]] = ts  # copy into array. Leave 0 if there is no timescales
+                    self._its_samples[:, i, :ts.shape[1]] = ts  # copy into array. Leave NaN if there is no timescales
 
             if np.any(np.isnan(self._its_samples)):
                 computed_all = False

--- a/pyemma/msm/estimators/lagged_model_validators.py
+++ b/pyemma/msm/estimators/lagged_model_validators.py
@@ -131,10 +131,8 @@ class LaggedModelValidator(Estimator, ProgressReporter):
             progress_reporter = None
 
         estimated_models, estimators = \
-            estimate_param_scan(self.test_estimator, data, pargrid,
-                                return_estimators=True,
-                                progress_reporter=progress_reporter,
-                                n_jobs=self.n_jobs)
+            estimate_param_scan(self.test_estimator, data, pargrid, return_estimators=True, failfast=False,
+                                progress_reporter=progress_reporter, n_jobs=self.n_jobs)
         if include0:
             estimated_models = [None] + estimated_models
             estimators = [None] + estimators

--- a/pyemma/msm/estimators/maximum_likelihood_hmsm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_hmsm.py
@@ -42,7 +42,7 @@ from pyemma.util.units import TimeUnit
 class MaximumLikelihoodHMSM(_Estimator, _EstimatedHMSM):
     r"""Maximum likelihood estimator for a Hidden MSM given a MSM"""
 
-    def __init__(self, nstates=2, lag=1, stride=1, msm_init=None, reversible=True, stationary=False,
+    def __init__(self, nstates=2, lag=1, stride=1, msm_init='largest-strong', reversible=True, stationary=False,
                  connectivity=None, mincount_connectivity='1/n', observe_active=False,
                  separate=None, dt_traj='1 step', accuracy=1e-3, maxit=1000):
         r"""Maximum likelihood estimator for a Hidden MSM given a MSM
@@ -64,8 +64,12 @@ class MaximumLikelihoodHMSM(_Estimator, _EstimatedHMSM):
             stride in order to have statistically uncorrelated trajectories.
             Setting stride = 'effective' uses the largest neglected timescale as
             an estimate for the correlation time and sets the stride accordingly
-        msm_init : :class:`MSM <pyemma.msm.estimators.msm_estimated.MSM>`
-            MSM object to initialize the estimation
+        msm_init : str or :class:`MSM <pyemma.msm.estimators.msm_estimated.MSM>`
+            MSM object to initialize the estimation, or one of following keywords:
+            * 'largest-strong' | None (default) : Estimate a MSM and use its largest
+              strongly connected set to generate an initial HMM
+            * 'all' : Estimate MSM(s) on the full state space to initialize the
+              HMM. This estimate maybe weakly connected or disconnected.
         reversible : bool, optional, default = True
             If true compute reversible MSM, else non-reversible MSM
         stationary : bool, optional, default=False
@@ -167,7 +171,7 @@ class MaximumLikelihoodHMSM(_Estimator, _EstimatedHMSM):
                                 + 'trajectory. HMM might be inaccurate.')
 
         # if no initial MSM is given, estimate it now
-        if self.msm_init is None:
+        if self.msm_init is None or self.msm_init=='largest-strong':
             # estimate with sparse=False, because we need to do PCCA which is currently not implemented for sparse
             # estimate with connectivity='largest', because otherwise we might have a lot of singlet states
             msm_estimator = _MSMEstimator(lag=self.lag, reversible=self.reversible, sparse=False,
@@ -213,11 +217,9 @@ class MaximumLikelihoodHMSM(_Estimator, _EstimatedHMSM):
         # TODO: observable set is also not used, it is just saved.
         nstates_obs_full = msm_init.nstates_full
         if self.observe_active:
-            nstates_obs = msm_init.nstates
             observable_set = msm_init.active_set
             dtrajs_obs = msm_init.discrete_trajectories_active
         else:
-            nstates_obs = msm_init.nstates_full
             observable_set = np.arange(nstates_obs_full)
             dtrajs_obs = msm_init.discrete_trajectories_full
 

--- a/pyemma/msm/estimators/maximum_likelihood_hmsm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_hmsm.py
@@ -200,6 +200,7 @@ class MaximumLikelihoodHMSM(_Estimator, _HMSM):
 
         # INIT HMM
         from bhmm import init_discrete_hmm
+        from pyemma.msm.estimators import MaximumLikelihoodMSM
         if self.msm_init=='largest-strong':
             hmm_init = init_discrete_hmm(dtrajs_lagged_strided, self.nstates, lag=1,
                                          reversible=self.reversible, stationary=True, regularize=True,
@@ -208,7 +209,7 @@ class MaximumLikelihoodHMSM(_Estimator, _HMSM):
             hmm_init = init_discrete_hmm(dtrajs_lagged_strided, self.nstates, lag=1,
                                          reversible=self.reversible, stationary=True, regularize=True,
                                          method='spectral', separate=self.separate)
-        elif issubclass(self.msm_init.__class__, MaximumLikelihoodHMSM):  # initial MSM given.
+        elif issubclass(self.msm_init.__class__, MaximumLikelihoodMSM):  # initial MSM given.
             from bhmm.init.discrete import init_discrete_hmm_spectral
             p0, P0, pobs0 = init_discrete_hmm_spectral(self.msm_init.count_matrix_full, self.nstates,
                                                        reversible=self.reversible, stationary=True,

--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -18,20 +18,20 @@
 
 from __future__ import absolute_import
 from six.moves import range
-__author__ = 'noe'
 
 import numpy as _np
 from msmtools import estimation as msmest
 
+from pyemma.util.annotators import alias, aliased
 from pyemma.util.types import ensure_dtraj_list
 from pyemma._base.estimator import Estimator as _Estimator
 from pyemma.msm.estimators._dtraj_stats import DiscreteTrajectoryStats as _DiscreteTrajectoryStats
-from pyemma.msm.estimators.estimated_msm import EstimatedMSM as _EstimatedMSM
+from pyemma.msm.models.msm import MSM as _MSM
 from pyemma.util.units import TimeUnit as _TimeUnit
 from pyemma.util import types as _types
 
-
-class MaximumLikelihoodMSM(_Estimator, _EstimatedMSM):
+@aliased
+class MaximumLikelihoodMSM(_Estimator, _MSM):
     r"""Maximum likelihood estimator for MSMs given discrete trajectory statistics"""
 
     def __init__(self, lag=1, reversible=True, statdist_constraint=None,
@@ -192,17 +192,17 @@ class MaximumLikelihoodMSM(_Estimator, _EstimatedMSM):
 
     def _estimate(self, dtrajs):
         """
-            Parameters
-            ----------
-            dtrajs : list containing ndarrays(dtype=int) or ndarray(n, dtype=int) or :class:`pyemma.msm.util.dtraj_states.DiscreteTrajectoryStats`
-                discrete trajectories, stored as integer ndarrays (arbitrary size)
-                or a single ndarray for only one trajectory.
-            **params :
-                Other keyword parameters if different from the settings when this estimator was constructed
+        Parameters
+        ----------
+        dtrajs : list containing ndarrays(dtype=int) or ndarray(n, dtype=int) or :class:`pyemma.msm.util.dtraj_states.DiscreteTrajectoryStats`
+            discrete trajectories, stored as integer ndarrays (arbitrary size)
+            or a single ndarray for only one trajectory.
+        **params :
+            Other keyword parameters if different from the settings when this estimator was constructed
 
-            Returns
-            -------
-            MSM : :class:`pyemma.msm.EstimatedMSM` or :class:`pyemma.msm.MSM`
+        Returns
+        -------
+        MSM : :class:`pyemma.msm.EstimatedMSM` or :class:`pyemma.msm.MSM`
 
         """
         # ensure right format
@@ -299,6 +299,454 @@ class MaximumLikelihoodMSM(_Estimator, _EstimatedMSM):
                               dt_model=self.timestep_traj.get_scaled(self.lag))
 
         return self
+
+    def _check_is_estimated(self):
+        assert self._is_estimated, 'You tried to access model parameters before estimating it - run estimate first!'
+
+    ################################################################################
+    # Basic attributes
+    ################################################################################
+
+    @property
+    def lagtime(self):
+        """
+        The lag time at which the Markov model was estimated
+
+        """
+        return self.lag
+
+    @property
+    def nstates_full(self):
+        r""" Number of states in discrete trajectories """
+        self._check_is_estimated()
+        return self._nstates_full
+
+    @property
+    def active_set(self):
+        """
+        The active set of states on which all computations and estimations will be done
+
+        """
+        self._check_is_estimated()
+        return self._active_set
+
+    @active_set.setter
+    def active_set(self, value):
+        self._active_set = value
+
+    @property
+    def connectivity(self):
+        """Returns the connectivity mode of the MSM """
+        return self._connectivity
+
+    @connectivity.setter
+    def connectivity(self, value):
+        self._connectivity = value
+
+    @property
+    def largest_connected_set(self):
+        """
+        The largest reversible connected set of states
+
+        """
+        self._check_is_estimated()
+        return self._connected_sets[0]
+
+    @property
+    def connected_sets(self):
+        """
+        The reversible connected sets of states, sorted by size (descending)
+
+        """
+        self._check_is_estimated()
+        return self._connected_sets
+
+    @property
+    @alias('dtrajs_full')
+    def discrete_trajectories_full(self):
+        """
+        A list of integer arrays with the original (unmapped) discrete trajectories:
+
+        """
+        self._check_is_estimated()
+        return self._dtrajs_full
+
+    @property
+    @alias('dtrajs_active')
+    def discrete_trajectories_active(self):
+        """
+        A list of integer arrays with the discrete trajectories mapped to the connectivity mode used.
+        For example, for connectivity='largest', the indexes will be given within the connected set.
+        Frames that are not in the connected set will be -1.
+
+        """
+        self._check_is_estimated()
+        # compute connected dtrajs
+        self._dtrajs_active = []
+        for dtraj in self._dtrajs_full:
+            self._dtrajs_active.append(self._full2active[dtraj])
+
+        return self._dtrajs_active
+
+    @property
+    def count_matrix_active(self):
+        """The count matrix on the active set given the connectivity mode used.
+
+        For example, for connectivity='largest', the count matrix is given only on the largest reversibly connected set.
+        Attention: This count matrix has been obtained by sliding a window of length tau across the data. It contains
+        a factor of tau more counts than are statistically uncorrelated. It's fine to use this matrix for maximum
+        likelihood estimated, but it will give far too small errors if you use it for uncertainty calculations. In order
+        to do uncertainty calculations, use the effective count matrix, see:
+        :attr:`effective_count_matrix`
+
+        See Also
+        --------
+        effective_count_matrix
+            For a count matrix with effective (statistically uncorrelated) counts.
+
+        """
+        self._check_is_estimated()
+        return self._C_active
+
+    # TODO: change to statistically effective count matrix!
+    @property
+    def effective_count_matrix(self):
+        """Statistically uncorrelated transition counts within the active set of states
+
+        You can use this count matrix for Bayesian estimation or error perturbation.
+
+        References
+        ----------
+        [1] Noe, F. (2015) Statistical inefficiency of Markov model count matrices
+            http://publications.mi.fu-berlin.de/1699/1/autocorrelation_counts.pdf
+
+        """
+        self._check_is_estimated()
+        import msmtools.estimation as msmest
+        Ceff_full = msmest.effective_count_matrix(self._dtrajs_full, self.lag)
+        from pyemma.util.linalg import submatrix
+        Ceff = submatrix(Ceff_full, self.active_set)
+        return Ceff
+        # return self._C_active / float(self.lag)
+
+    @property
+    def count_matrix_full(self):
+        """
+        The count matrix on full set of discrete states, irrespective as to whether they are connected or not.
+        Attention: This count matrix has been obtained by sliding a window of length tau across the data. It contains
+        a factor of tau more counts than are statistically uncorrelated. It's fine to use this matrix for maximum
+        likelihood estimated, but it will give far too small errors if you use it for uncertainty calculations. In order
+        to do uncertainty calculations, use the effective count matrix, see: :attr:`effective_count_matrix`
+        (only implemented on the active set), or divide this count matrix by tau.
+
+        See Also
+        --------
+        effective_count_matrix
+            For a active-set count matrix with effective (statistically uncorrelated) counts.
+
+        """
+        self._check_is_estimated()
+        return self._C_full
+
+    @property
+    def active_state_fraction(self):
+        """The fraction of states in the largest connected set.
+
+        """
+        self._check_is_estimated()
+        return float(self._nstates) / float(self._nstates_full)
+
+    @property
+    def active_count_fraction(self):
+        """The fraction of counts in the largest connected set.
+
+        """
+        self._check_is_estimated()
+        from pyemma.util.discrete_trajectories import count_states
+
+        hist = count_states(self._dtrajs_full)
+        hist_active = hist[self.active_set]
+        return float(_np.sum(hist_active)) / float(_np.sum(hist))
+
+    ################################################################################
+    # For general statistics
+    ################################################################################
+
+    def trajectory_weights(self):
+        r"""Uses the MSM to assign a probability weight to each trajectory frame.
+
+        This is a powerful function for the calculation of arbitrary observables in the trajectories one has
+        started the analysis with. The stationary probability of the MSM will be used to reweigh all states.
+        Returns a list of weight arrays, one for each trajectory, and with a number of elements equal to
+        trajectory frames. Given :math:`N` trajectories of lengths :math:`T_1` to :math:`T_N`, this function
+        returns corresponding weights:
+
+        .. math::
+
+            (w_{1,1}, ..., w_{1,T_1}), (w_{N,1}, ..., w_{N,T_N})
+
+        that are normalized to one:
+
+        .. math::
+
+            \sum_{i=1}^N \sum_{t=1}^{T_i} w_{i,t} = 1
+
+        Suppose you are interested in computing the expectation value of a function :math:`a(x)`, where :math:`x`
+        are your input configurations. Use this function to compute the weights of all input configurations and
+        obtain the estimated expectation by:
+
+        .. math::
+
+            \langle a \rangle = \sum_{i=1}^N \sum_{t=1}^{T_i} w_{i,t} a(x_{i,t})
+
+        Or if you are interested in computing the time-lagged correlation between functions :math:`a(x)` and
+        :math:`b(x)` you could do:
+
+        .. math::
+
+            \langle a(t) b(t+\tau) \rangle_t = \sum_{i=1}^N \sum_{t=1}^{T_i} w_{i,t} a(x_{i,t}) a(x_{i,t+\tau})
+
+
+        Returns
+        -------
+        weights : list of ndarray
+            The normalized trajectory weights. Given :math:`N` trajectories of lengths :math:`T_1` to :math:`T_N`,
+            returns the corresponding weights:
+
+            .. math::
+
+                (w_{1,1}, ..., w_{1,T_1}), (w_{N,1}, ..., w_{N,T_N})
+
+        """
+        self._check_is_estimated()
+        # compute stationary distribution, expanded to full set
+        statdist_full = _np.zeros([self._nstates_full])
+        statdist_full[self.active_set] = self.stationary_distribution
+        # histogram observed states
+        import msmtools.dtraj as msmtraj
+        hist = 1.0 * msmtraj.count_states(self.discrete_trajectories_full)
+        # simply read off stationary distribution and accumulate total weight
+        W = []
+        wtot = 0.0
+        for dtraj in self.discrete_trajectories_full:
+            w = statdist_full[dtraj] / hist[dtraj]
+            W.append(w)
+            wtot += _np.sum(W)
+        # normalize
+        for w in W:
+            w /= wtot
+        # done
+        return W
+
+    ################################################################################
+    # Generation of trajectories and samples
+    ################################################################################
+
+    @property
+    def active_state_indexes(self):
+        """
+        Ensures that the connected states are indexed and returns the indices
+        """
+        self._check_is_estimated()
+        try:  # if we have this attribute, return it
+            return self._active_state_indexes
+        except:  # didn't exist? then create it.
+            import pyemma.util.discrete_trajectories as dt
+
+            self._active_state_indexes = dt.index_states(self.discrete_trajectories_full, subset=self.active_set)
+            return self._active_state_indexes
+
+    def generate_traj(self, N, start=None, stop=None, stride=1):
+        """Generates a synthetic discrete trajectory of length N and simulation time stride * lag time * N
+
+        This information can be used
+        in order to generate a synthetic molecular dynamics trajectory - see
+        :func:`pyemma.coordinates.save_traj`
+
+        Note that the time different between two samples is the Markov model lag time tau. When comparing
+        quantities computing from this synthetic trajectory and from the input trajectories, the time points of this
+        trajectory must be scaled by the lag time in order to have them on the same time scale.
+
+        Parameters
+        ----------
+        N : int
+            Number of time steps in the output trajectory. The total simulation time is stride * lag time * N
+        start : int, optional, default = None
+            starting state. If not given, will sample from the stationary distribution of P
+        stop : int or int-array-like, optional, default = None
+            stopping set. If given, the trajectory will be stopped before N steps
+            once a state of the stop set is reached
+        stride : int, optional, default = 1
+            Multiple of lag time used as a time step. By default, the time step is equal to the lag time
+
+        Returns
+        -------
+        indexes : ndarray( (N, 2) )
+            trajectory and time indexes of the simulated trajectory. Each row consist of a tuple (i, t), where i is
+            the index of the trajectory and t is the time index within the trajectory.
+            Note that the time different between two samples is the Markov model lag time tau
+
+        See also
+        --------
+        pyemma.coordinates.save_traj
+            in order to save this synthetic trajectory as a trajectory file with molecular structures
+
+        """
+        # TODO: this is the only function left which does something time-related in a multiple of tau rather than dt.
+        # TODO: we could generate dt-strided trajectories by sampling tau times from the current state, but that would
+        # TODO: probably lead to a weird-looking trajectory. Maybe we could use a HMM to generate intermediate 'hidden'
+        # TODO: frames. Anyway, this is a nontrivial issue.
+        self._check_is_estimated()
+        # generate synthetic states
+        from msmtools.generation import generate_traj as _generate_traj
+
+        syntraj = _generate_traj(self.transition_matrix, N, start=start, stop=stop, dt=stride)
+        # result
+        from pyemma.util.discrete_trajectories import sample_indexes_by_sequence
+
+        return sample_indexes_by_sequence(self.active_state_indexes, syntraj)
+
+    def sample_by_state(self, nsample, subset=None, replace=True):
+        """Generates samples of the connected states.
+
+        For each state in the active set of states, generates nsample samples with trajectory/time indexes.
+        This information can be used in order to generate a trajectory of length nsample * nconnected using
+        :func:`pyemma.coordinates.save_traj` or nconnected trajectories of length nsample each using
+        :func:`pyemma.coordinates.save_traj`
+
+        Parameters
+        ----------
+        N : int
+            Number of time steps in the output trajectory. The total simulation time is stride * lag time * N
+        nsample : int
+            Number of samples per state. If replace = False, the number of returned samples per state could be smaller
+            if less than nsample indexes are available for a state.
+        subset : ndarray((n)), optional, default = None
+            array of states to be indexed. By default all states in the connected set will be used
+        replace : boolean, optional
+            Whether the sample is with or without replacement
+        start : int, optional, default = None
+            starting state. If not given, will sample from the stationary distribution of P
+
+        Returns
+        -------
+        indexes : list of ndarray( (N, 2) )
+            list of trajectory/time index arrays with an array for each state.
+            Within each index array, each row consist of a tuple (i, t), where i is
+            the index of the trajectory and t is the time index within the trajectory.
+
+        See also
+        --------
+        pyemma.coordinates.save_traj
+            in order to save the sampled frames sequentially in a trajectory file with molecular structures
+        pyemma.coordinates.save_trajs
+            in order to save the sampled frames in nconnected trajectory files with molecular structures
+
+        """
+        self._check_is_estimated()
+        # generate connected state indexes
+        import pyemma.util.discrete_trajectories as dt
+
+        return dt.sample_indexes_by_state(self.active_state_indexes, nsample, subset=subset, replace=replace)
+
+    # TODO: add sample_metastable() for sampling from metastable (pcca or hmm) states.
+    def sample_by_distributions(self, distributions, nsample):
+        """Generates samples according to given probability distributions
+
+        Parameters
+        ----------
+        distributions : list or array of ndarray ( (n) )
+            m distributions over states. Each distribution must be of length n and must sum up to 1.0
+        nsample : int
+            Number of samples per distribution. If replace = False, the number of returned samples per state could be
+            smaller if less than nsample indexes are available for a state.
+
+        Returns
+        -------
+        indexes : length m list of ndarray( (nsample, 2) )
+            List of the sampled indices by distribution.
+            Each element is an index array with a number of rows equal to nsample, with rows consisting of a
+            tuple (i, t), where i is the index of the trajectory and t is the time index within the trajectory.
+
+        """
+        self._check_is_estimated()
+        # generate connected state indexes
+        import pyemma.util.discrete_trajectories as dt
+
+        return dt.sample_indexes_by_distribution(self.active_state_indexes, distributions, nsample)
+
+    ################################################################################
+    # HMM-based coarse graining
+    ################################################################################
+
+    def hmm(self, nhidden):
+        """Estimates a hidden Markov state model as described in [1]_
+
+        Parameters
+        ----------
+        nhidden : int
+            number of hidden (metastable) states
+
+        Returns
+        -------
+        hmsm : :class:`MaximumLikelihoodHMSM`
+
+        References
+        ----------
+        .. [1] F. Noe, H. Wu, J.-H. Prinz and N. Plattner:
+            Projected and hidden Markov models for calculating kinetics and metastable states of complex molecules
+            J. Chem. Phys. 139, 184114 (2013)
+
+        """
+        self._check_is_estimated()
+        # check if the time-scale separation is OK
+        # if hmm.nstates = msm.nstates there is no problem. Otherwise, check spectral gap
+        if self.nstates > nhidden:
+            timescale_ratios = self.timescales()[:-1] / self.timescales()[1:]
+            if timescale_ratios[self.nstates-2] < 1.5:
+                self.logger.warning('Requested coarse-grained model with ' + str(nhidden) + ' metastable states at ' +
+                                 'lag=' + str(self.lag) + '.' + 'The ratio of relaxation timescales between ' +
+                                 str(nhidden) + ' and ' + str(nhidden+1) + ' states is only ' +
+                                 str(timescale_ratios[nhidden-2]) + ' while we recommend at least 1.5. ' +
+                                 ' It is possible that the resulting HMM is inaccurate. Handle with caution.')
+        # run HMM estimate
+        from pyemma.msm.estimators.maximum_likelihood_hmsm import MaximumLikelihoodHMSM
+        estimator = MaximumLikelihoodHMSM(lag=self.lagtime, nstates=nhidden, msm_init=self,
+                                          reversible=self.is_reversible, dt_traj=self.dt_traj)
+        estimator.estimate(self.discrete_trajectories_full)
+        return estimator.model
+
+    def coarse_grain(self, ncoarse, method='hmm'):
+        r"""Returns a coarse-grained Markov model.
+
+        Currently only the HMM method described in [1]_ is available for coarse-graining MSMs.
+
+        Parameters
+        ----------
+        ncoarse : int
+            number of coarse states
+
+        Returns
+        -------
+        hmsm : :class:`MaximumLikelihoodHMSM`
+
+        References
+        ----------
+        .. [1] F. Noe, H. Wu, J.-H. Prinz and N. Plattner:
+            Projected and hidden Markov models for calculating kinetics and metastable states of complex molecules
+            J. Chem. Phys. 139, 184114 (2013)
+
+        """
+        self._check_is_estimated()
+        # check input
+        assert _types.is_int(self.nstates) and ncoarse > 1 and ncoarse <= self.nstates, \
+            'nstates must be an int in [2,msmobj.nstates]'
+
+        return self.hmm(ncoarse)
+
+    ################################################################################
+    # MODEL VALIDATION
+    ################################################################################
 
     def cktest(self, nsets, memberships=None, mlags=10, conf=0.95, err_est=False,
                show_progress=True):

--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -703,7 +703,7 @@ class MaximumLikelihoodMSM(_Estimator, _MSM):
         # if hmm.nstates = msm.nstates there is no problem. Otherwise, check spectral gap
         if self.nstates > nhidden:
             timescale_ratios = self.timescales()[:-1] / self.timescales()[1:]
-            if timescale_ratios[self.nstates-2] < 1.5:
+            if timescale_ratios[nhidden-2] < 1.5:
                 self.logger.warning('Requested coarse-grained model with ' + str(nhidden) + ' metastable states at ' +
                                  'lag=' + str(self.lag) + '.' + 'The ratio of relaxation timescales between ' +
                                  str(nhidden) + ' and ' + str(nhidden+1) + ' states is only ' +

--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -243,6 +243,10 @@ class MaximumLikelihoodMSM(_Estimator, _EstimatedMSM):
         # is estimated
         self._is_estimated = True
 
+        # if active set is empty, we can't do anything.
+        if _np.size(self.active_set) == 0:
+            raise RuntimeError('Active set is empty. Cannot estimate MSM.')
+
         # active count matrix and number of states
         self._C_active = dtrajstats.count_matrix(subset=self.active_set)
         self._nstates = self._C_active.shape[0]

--- a/pyemma/msm/models/hmsm.py
+++ b/pyemma/msm/models/hmsm.py
@@ -225,6 +225,42 @@ class HMSM(_MSM):
         # normalize to 1.0 and return
         return pk / pk.sum()
 
+    def submodel(self, states=None, obs=None):
+        """Returns a HMM with restricted state space
+
+        Parameters
+        ----------
+        states : None or int-array
+            Hidden states to restrict the model to (if not None).
+        obs : None, str or int-array
+            Observed states to restrict the model to (if not None).
+
+        Returns
+        -------
+        hmm : HMM
+            The restricted HMM.
+
+        """
+        if states is None and obs is None:
+            return self  # do nothing
+        if states is None:
+            states = _np.arange(self.nstates)
+        if obs is None:
+            obs = _np.arange(self.nstates_obs)
+
+        # transition matrix
+        P = self.transition_matrix[_np.ix_(states, states)].copy()
+        P /= P.sum(axis=1)[:, None]
+
+        # observation matrix
+        B = self.observation_probabilities[_np.ix_(states, obs)].copy()
+        B /= B.sum(axis=1)[:, None]
+
+        sub_hmsm = HMSM(P, B)
+        sub_hmsm.update_model_params(reversible=self.reversible)
+        return sub_hmsm
+
+
     # ================================================================================================================
     # Experimental properties: Here we allow to use either coarse-grained or microstate observables
     # ================================================================================================================
@@ -331,10 +367,12 @@ class HMSM(_MSM):
             complex molecules. J. Chem. Phys. 139, 184114 (2013)
 
         """
-        A = _np.dot(_np.diag(self.stationary_distribution), self.observation_probabilities)
-        M = _np.dot(A, _np.diag(1.0/self.stationary_distribution_obs)).T
+        nonzero = _np.nonzero(self.stationary_distribution_obs)[0]
+        M = _np.zeros((self.nstates_obs, self.nstates))
+        M[nonzero, :] = _np.transpose(_np.diag(self.stationary_distribution).dot(
+            self.observation_probabilities[:, nonzero]) / self.stationary_distribution_obs[nonzero])
         # renormalize
-        M /= M.sum(axis=1)[:, None]
+        M[nonzero, :] /= M.sum(axis=1)[nonzero, None]
         return M
 
     @property

--- a/pyemma/msm/models/hmsm.py
+++ b/pyemma/msm/models/hmsm.py
@@ -256,7 +256,7 @@ class HMSM(_MSM):
         B = self.observation_probabilities[_np.ix_(states, obs)].copy()
         B /= B.sum(axis=1)[:, None]
 
-        sub_hmsm = HMSM(P, B)
+        sub_hmsm = HMSM(P, B, dt_model=self.dt_model)
         sub_hmsm.update_model_params(reversible=self.reversible)
         return sub_hmsm
 

--- a/pyemma/msm/models/hmsm_sampled.py
+++ b/pyemma/msm/models/hmsm_sampled.py
@@ -65,7 +65,7 @@ class SampledHMSM(_HMSM, _SampledModel):
             pobsref = self.sample_mean('pobs')
             _HMSM.__init__(self, Pref, pobsref, dt_model=samples[0].dt_model)
         else:
-            _HMSM.__init__(self, ref.Pref, ref.pobs, dt_model=ref.dt_model)
+            _HMSM.__init__(self, ref.transition_matrix, ref.observation_probabilities, dt_model=ref.dt_model)
 
 
     # TODO: maybe rename to parametrize in order to avoid confusion with set_params that has a different behavior?
@@ -86,210 +86,25 @@ class SampledHMSM(_HMSM, _SampledModel):
         _HMSM.set_model_params(self, P=P, pobs=pobs, pi=pi, reversible=reversible, dt_model=dt_model, neig=neig)
 
 
-    # def _do_sample_eigendecomposition(self):
-    #     """Conducts the eigenvalue decompositions for all sampled matrices.
-    #
-    #     Stores all eigenvalues, left and right eigenvectors for all sampled matrices
-    #
-    #     """
-    #     from msmtools.analysis import rdl_decomposition
-    #     from pyemma.util import linalg
-    #
-    #     # left eigenvectors
-    #     self._sample_Ls = _np.empty((self._nsamples, self._nstates, self._nstates), dtype=float)
-    #     # eigenvalues
-    #     self._sample_eigenvalues = _np.empty((self._nsamples, self._nstates), dtype=float)
-    #     # right eigenvectors
-    #     self._sample_Rs = _np.empty((self._nsamples, self._nstates, self._nstates), dtype=float)
-    #
-    #     for i in range(self._nsamples):
-    #         if self._reversible:
-    #             R, D, L = rdl_decomposition(self._sample_Ps[i], norm='reversible')
-    #             # everything must be real-valued
-    #             R = R.real
-    #             D = D.real
-    #             L = L.real
-    #         else:
-    #             R, D, L = rdl_decomposition(self._sample_Ps[i], norm='standard')
-    #         # assign ordered
-    #         I = linalg.match_eigenvectors(self.eigenvectors_right, R,
-    #                                       w_ref=self.stationary_distribution, w=self._sample_mus[i])
-    #         self._sample_Ls[i, :, :] = L[I, :]
-    #         self._sample_eigenvalues[i, :] = _np.diag(D)[I]
-    #         self._sample_Rs[i, :, :] = R[:, I]
-    #
-    # def set_confidence(self, conf):
-    #     self._confidence = conf
-    #
-    # @property
-    # def nsamples(self):
-    #     r""" Number of samples """
-    #     return self._nsamples
-    #
-    # @property
-    # def confidence_interval(self):
-    #     r""" Confidence interval used """
-    #     return self._confidence
-    #
-    # @property
-    # def stationary_distribution_samples(self):
-    #     r""" Samples of the initial distribution """
-    #     return self._sample_mus
-    #
-    # @property
-    # def stationary_distribution_mean(self):
-    #     r""" The mean of the initial distribution of the hidden states """
-    #     return _np.mean(self.stationary_distribution_samples, axis=0)
-    #
-    # @property
-    # def stationary_distribution_std(self):
-    #     r""" The standard deviation of the initial distribution of the hidden states """
-    #     return _np.std(self.stationary_distribution_samples, axis=0)
-    #
-    # @property
-    # def stationary_distribution_conf(self):
-    #     r""" The confidence interval of the initial distribution of the hidden states """
-    #     return confidence_interval(self.stationary_distribution_samples, alpha=self._confidence)
-    #
-    # @property
-    # def transition_matrix_samples(self):
-    #     r""" Samples of the transition matrix """
-    #     return self._sample_Ps
-    #
-    # @property
-    # def transition_matrix_mean(self):
-    #     r""" The mean of the transition_matrix of the hidden states """
-    #     return _np.mean(self.transition_matrix_samples, axis=0)
-    #
-    # @property
-    # def transition_matrix_std(self):
-    #     r""" The standard deviation of the transition_matrix of the hidden states """
-    #     return _np.std(self.transition_matrix_samples, axis=0)
-    #
-    # @property
-    # def transition_matrix_conf(self):
-    #     r""" The confidence interval of the transition_matrix of the hidden states """
-    #     return confidence_interval(self.transition_matrix_samples, alpha=self._confidence)
-    #
-    # @property
-    # def output_probabilities_samples(self):
-    #     r""" Samples of the output probability matrix """
-    #     return self._sample_pobs
-    #
-    # @property
-    # def output_probabilities_mean(self):
-    #     r""" The mean of the output probability matrix """
-    #     return _np.mean(self.output_probabilities_samples, axis=0)
-    #
-    # @property
-    # def output_probabilities_std(self):
-    #     r""" The standard deviation of the output probability matrix """
-    #     return _np.std(self.output_probabilities_samples, axis=0)
-    #
-    # @property
-    # def output_probabilities_conf(self):
-    #     r""" The standard deviation of the output probability matrix """
-    #     return confidence_interval(self.output_probabilities_samples, alpha=self._confidence)
-    #
-    # @property
-    # def eigenvalues_samples(self):
-    #     r""" Samples of the eigenvalues """
-    #     return self._sample_eigenvalues
-    #
-    # @property
-    # def eigenvalues_mean(self):
-    #     r""" The mean of the eigenvalues of the hidden states """
-    #     return _np.mean(self.eigenvalues_samples, axis=0)
-    #
-    # @property
-    # def eigenvalues_std(self):
-    #     r""" The standard deviation of the eigenvalues of the hidden states """
-    #     return _np.std(self.eigenvalues_samples, axis=0)
-    #
-    # @property
-    # def eigenvalues_conf(self):
-    #     r""" The confidence interval of the eigenvalues of the hidden states """
-    #     return confidence_interval(self.eigenvalues_samples, alpha=self._confidence)
-    #
-    # @property
-    # def eigenvectors_left_samples(self):
-    #     r""" Samples of the left eigenvectors of the hidden transition matrix """
-    #     return self._sample_Ls
-    #
-    # @property
-    # def eigenvectors_left_mean(self):
-    #     r""" The mean of the left eigenvectors of the hidden transition matrix """
-    #     return _np.mean(self.eigenvectors_left_samples, axis=0)
-    #
-    # @property
-    # def eigenvectors_left_std(self):
-    #     r""" The standard deviation of the left eigenvectors of the hidden transition matrix """
-    #     return _np.std(self.eigenvectors_left_samples, axis=0)
-    #
-    # @property
-    # def eigenvectors_left_conf(self):
-    #     r""" The confidence interval of the left eigenvectors of the hidden transition matrix """
-    #     return confidence_interval(self.eigenvectors_left_samples, alpha=self._confidence)
-    #
-    # @property
-    # def eigenvectors_right_samples(self):
-    #     r""" Samples of the right eigenvectors of the hidden transition matrix """
-    #     return self._sample_Rs
-    #
-    # @property
-    # def eigenvectors_right_mean(self):
-    #     r""" The mean of the right eigenvectors of the hidden transition matrix """
-    #     return _np.mean(self.eigenvectors_right_samples, axis=0)
-    #
-    # @property
-    # def eigenvectors_right_std(self):
-    #     r""" The standard deviation of the right eigenvectors of the hidden transition matrix """
-    #     return _np.std(self.eigenvectors_right_samples, axis=0)
-    #
-    # @property
-    # def eigenvectors_right_conf(self):
-    #     r""" The confidence interval of the right eigenvectors of the hidden transition matrix """
-    #     return confidence_interval(self.eigenvectors_right_samples, alpha=self._confidence)
-    #
-    # @property
-    # def timescales_samples(self):
-    #     r""" Samples of the timescales """
-    #     return -self.lagtime / _np.log(_np.abs(self._sample_eigenvalues[:,1:]))
-    #
-    # @property
-    # def timescales_mean(self):
-    #     r""" The mean of the timescales of the hidden states """
-    #     return _np.mean(self.timescales_samples, axis=0)
-    #
-    # @property
-    # def timescales_std(self):
-    #     r""" The standard deviation of the timescales of the hidden states """
-    #     return _np.std(self.timescales_samples, axis=0)
-    #
-    # @property
-    # def timescales_conf(self):
-    #     r""" The confidence interval of the timescales of the hidden states """
-    #     return confidence_interval(self.timescales_samples, alpha=self._confidence)
-    #
-    # @property
-    # def lifetimes_samples(self):
-    #     r""" Samples of the lifetimes """
-    #     res = _np.empty((self.nsamples, self.nstates), dtype=float)
-    #     for i in range(self.nsamples):
-    #         res[i,:] = -self._lag / _np.log(_np.diag(self._sample_Ps[i]))
-    #     return res
-    #
-    # @property
-    # def lifetimes_mean(self):
-    #     r""" The mean of the lifetimes of the hidden states """
-    #     return _np.mean(self.lifetimes_samples, axis=0)
-    #
-    # @property
-    # def lifetimes_std(self):
-    #     r""" The standard deviation of the lifetimes of the hidden states """
-    #     return _np.std(self.lifetimes_samples, axis=0)
-    #
-    # @property
-    # def lifetimes_conf(self):
-    #     r""" The confidence interval of the lifetimes of the hidden states """
-    #     return confidence_interval(self.lifetimes_samples, alpha=self._confidence)
+    def submodel(self, states=None, obs=None):
+        """Returns a HMM with restricted state space
+
+        Parameters
+        ----------
+        states : None or int-array
+            Hidden states to restrict the model to (if not None).
+        obs : None, str or int-array
+            Observed states to restrict the model to (if not None).
+
+        Returns
+        -------
+        hmm : HMM
+            The restricted HMM.
+
+        """
+        # get the reference HMM submodel
+        ref = super(SampledHMSM, self).submodel(states=states, obs=obs)
+        # get the sample submodels
+        samples_sub = [sample.submodel(states=states, obs=obs) for sample in self.samples]
+        # new model
+        return SampledHMSM(samples_sub, ref=ref, conf=self.conf)

--- a/pyemma/msm/models/msm.py
+++ b/pyemma/msm/models/msm.py
@@ -140,15 +140,8 @@ class MSM(_Model):
         import msmtools.analysis as msmana
         # check input
         if P is not None:
-            import msmtools.estimation as msmest
             if not msmana.is_transition_matrix(P, tol=1e-8):
                 raise ValueError('T is not a transition matrix.')
-            # check connectivity
-            # TODO: abusing C-connectivity test for T. Either provide separate T-connectivity test or move to a central
-            # TODO: location because it's the same code.
-            if not msmest.is_connected(P):
-                raise NotImplementedError('Transition matrix T is disconnected. ' +
-                                          'This is currently not supported in the MSM object.')
 
         # update all parameters
         self.update_model_params(P=P, pi=pi, reversible=reversible, dt_model=dt_model, neig=neig)

--- a/pyemma/msm/tests/test_bayesian_hmsm.py
+++ b/pyemma/msm/tests/test_bayesian_hmsm.py
@@ -40,8 +40,7 @@ class TestBHMM(unittest.TestCase):
         cls.nsamples = 100
 
         cls.lag = 10
-        cls.bhmm = bayesian_hidden_markov_model([obs], cls.nstates, cls.lag, reversible=True,
-                                                             nsamples=cls.nsamples)
+        cls.bhmm = bayesian_hidden_markov_model([obs], cls.nstates, cls.lag, reversible=True, nsamples=cls.nsamples)
         
     def test_reversible(self):
         self._reversible(self.bhmm)
@@ -306,6 +305,20 @@ class TestBHMM(unittest.TestCase):
 
     # TODO: these tests can be made compact because they are almost the same. can define general functions for testing
     # TODO: samples and stats, only need to implement consistency check individually.
+
+class TestBHMMSpecialCases(unittest.TestCase):
+
+    def test_separate_states(self):
+        dtrajs = [np.array([0, 1, 1, 1, 1, 1, 0, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1]),
+                  np.array([2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 2]),]
+        hmm_bayes = bayesian_hidden_markov_model(dtrajs, 3, lag=1, separate=[0], nsamples=100)
+        # we expect zeros in all samples at the following indexes:
+        pobs_zeros = [[0, 1, 2, 2, 2], [0, 0, 1, 2, 3]]
+        for s in hmm_bayes.samples:
+            assert np.allclose(s.observation_probabilities[pobs_zeros], 0)
+        for strajs in hmm_bayes.sampled_trajs:
+            assert strajs[0][0] == 2
+            assert strajs[0][6] == 2
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/msm/tests/test_hmsm.py
+++ b/pyemma/msm/tests/test_hmsm.py
@@ -37,6 +37,7 @@ class TestMLHMM(unittest.TestCase):
         # load observations
         import pyemma.datasets
         obs = pyemma.datasets.load_2well_discrete().dtraj_T100K_dt10
+        obs -= np.min(obs)  # remove empty states
 
         # hidden states
         nstates = 2
@@ -44,8 +45,10 @@ class TestMLHMM(unittest.TestCase):
         # run with lag 1 and 10
         cls.msm_lag1 = msm.estimate_markov_model([obs], 1, reversible=True, connectivity='largest')
         cls.hmsm_lag1 = msm.estimate_hidden_markov_model([obs], nstates, 1, reversible=True, connectivity='largest')
+        cls.hmsm_lag1 = cls.hmsm_lag1.submodel(obs='nonempty')
         cls.msm_lag10 = msm.estimate_markov_model([obs], 10, reversible=True, connectivity='largest')
         cls.hmsm_lag10 = msm.estimate_hidden_markov_model([obs], nstates, 10, reversible=True, connectivity='largest')
+        cls.hmsm_lag10 = cls.hmsm_lag10.submodel(obs='nonempty')
 
     # =============================================================================
     # Test basic HMM properties

--- a/pyemma/msm/tests/test_hmsm.py
+++ b/pyemma/msm/tests/test_hmsm.py
@@ -44,20 +44,18 @@ class TestMLHMM(unittest.TestCase):
 
         # run with lag 1 and 10
         cls.msm_lag1 = msm.estimate_markov_model([obs], 1, reversible=True, connectivity='largest')
-        cls.hmsm_lag1 = msm.estimate_hidden_markov_model([obs], nstates, 1, reversible=True, connectivity='largest')
-        cls.hmsm_lag1 = cls.hmsm_lag1.submodel(obs='nonempty')
+        cls.hmsm_lag1 = msm.estimate_hidden_markov_model([obs], nstates, 1, reversible=True, observe_nonempty=True)
         cls.msm_lag10 = msm.estimate_markov_model([obs], 10, reversible=True, connectivity='largest')
-        cls.hmsm_lag10 = msm.estimate_hidden_markov_model([obs], nstates, 10, reversible=True, connectivity='largest')
-        cls.hmsm_lag10 = cls.hmsm_lag10.submodel(obs='nonempty')
+        cls.hmsm_lag10 = msm.estimate_hidden_markov_model([obs], nstates, 10, reversible=True, observe_nonempty=True)
 
     # =============================================================================
     # Test basic HMM properties
     # =============================================================================
 
     def test_hmm_type(self):
-        from pyemma.msm.estimators.estimated_hmsm import EstimatedHMSM
-        assert isinstance(self.hmsm_lag1, EstimatedHMSM)
-        assert isinstance(self.hmsm_lag10, EstimatedHMSM)
+        from pyemma.msm.estimators.maximum_likelihood_hmsm import MaximumLikelihoodHMSM
+        assert isinstance(self.hmsm_lag1, MaximumLikelihoodHMSM)
+        assert isinstance(self.hmsm_lag10, MaximumLikelihoodHMSM)
 
     def test_reversible(self):
         assert self.hmsm_lag1.is_reversible

--- a/pyemma/msm/tests/test_hmsm.py
+++ b/pyemma/msm/tests/test_hmsm.py
@@ -415,5 +415,16 @@ class TestMLHMM(unittest.TestCase):
         k2 = 1.0 / t2
         assert np.abs(k2 - ksum) < 1e-4
 
+
+class TestHMMSpecialCases(unittest.TestCase):
+
+    def test_separate_states(self):
+        dtrajs = [np.array([0, 1, 1, 1, 1, 1, 0, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 1]),
+                  np.array([2, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 2]),]
+        hmm = msm.estimate_hidden_markov_model(dtrajs, 3, lag=1, separate=[0])
+        # we expect zeros in all samples at the following indexes:
+        pobs_zeros = [[0, 1, 2, 2, 2], [0, 0, 1, 2, 3]]
+        assert np.allclose(hmm.observation_probabilities[pobs_zeros], 0)
+
 if __name__=="__main__":
     unittest.main()

--- a/pyemma/msm/tests/test_its.py
+++ b/pyemma/msm/tests/test_its.py
@@ -194,17 +194,17 @@ class TestITS_AllEstimators(unittest.TestCase):
 
     def test_its_hmsm(self):
         estimator = msm.timescales_hmsm([self.double_well_data.dtraj_T100K_dt10_n6good], 2, lags = [1, 10, 100])
-        ref = np.array([[ 222.0641768 ],
-                        [ 336.530405  ],
-                        [ 369.57961198]])
+        ref = np.array([[ 222.0187561 ],
+                        [ 339.47351559],
+                        [ 382.39905462]])
 
         assert np.allclose(estimator.timescales, ref, rtol=0.1, atol=10.0)  # rough agreement
 
     def test_its_bhmm(self):
         estimator = msm.timescales_hmsm([self.double_well_data.dtraj_T100K_dt10_n6good], 2, lags = [1, 10],
                                         errors='bayes', nsamples=100)
-        ref = np.array([[ 222.02102829],
-                        [ 342.49101981]])
+        ref = np.array([[ 222.0187561 ],
+                        [ 342.49015547]])
         # rough agreement with MLE
         assert np.allclose(estimator.timescales, ref, rtol=0.1, atol=10.0)
         # within left / right intervals. This test should fail only 1 out of 1000 times.

--- a/pyemma/util/statistics.py
+++ b/pyemma/util/statistics.py
@@ -51,7 +51,8 @@ def _confidence_interval_1d(data, alpha):
     """
     if alpha < 0 or alpha > 1:
         raise ValueError('Not a meaningful confidence level: '+str(alpha))
-      # exception: if data are constant, return three times the constant and raise a warning
+    if np.any(np.isnan(data)):
+        return np.nan, np.nan, np.nan
     dmin = np.min(data)
     dmax = np.max(data)
     # if dmin == dmax:
@@ -65,7 +66,7 @@ def _confidence_interval_1d(data, alpha):
     sdata = np.sort(data)
     # index of the mean
     im = np.searchsorted(sdata, m)
-    if im == 0 or im == len(sdata):
+    if im == 0 or im == len(sdata) or (np.isinf(m-sdata[im-1]) and np.isinf(sdata[im]-sdata[im-1])):
         pm = im
     else:
         pm = (im-1) + (m-sdata[im-1])/(sdata[im]-sdata[im-1])
@@ -73,12 +74,18 @@ def _confidence_interval_1d(data, alpha):
     pl = pm - alpha*pm
     il1 = max(0, int(math.floor(pl)))
     il2 = min(len(sdata)-1, int(math.ceil(pl)))
-    l = sdata[il1] + (pl - il1)*(sdata[il2] - sdata[il1])
+    if sdata[il1] == sdata[il2]:  # catch infs
+        l = sdata[il1]
+    else:
+        l = sdata[il1] + (pl - il1)*(sdata[il2] - sdata[il1])
     # right interval boundary
     pr = pm + alpha*(len(data)-im)
     ir1 = max(0, int(math.floor(pr)))
     ir2 = min(len(sdata)-1, int(math.ceil(pr)))
-    r = sdata[ir1] + (pr - ir1)*(sdata[ir2] - sdata[ir1])
+    if sdata[ir1] == sdata[ir2]:  # catch infs
+        r = sdata[ir1]
+    else:
+        r = sdata[ir1] + (pr - ir1)*(sdata[ir2] - sdata[ir1])
 
     # return
     return m, l, r

--- a/setup.py
+++ b/setup.py
@@ -215,7 +215,7 @@ metadata = dict(
                       'matplotlib',
                       'msmtools',
                       'thermotools>=0.1.14',
-                      'bhmm<0.6',
+                      'bhmm<0.7',
                       'joblib==0.8.4',
                       'pyyaml',
                       'psutil>=3.1.1',

--- a/tools/conda-recipe/meta.yaml
+++ b/tools/conda-recipe/meta.yaml
@@ -13,7 +13,7 @@ requirements:
     - setuptools
     - cython >=0.20
 
-    - bhmm <0.6
+    - bhmm <0.7
     - joblib ==0.8.4
     - matplotlib
     - mdtraj >=1.5
@@ -31,7 +31,7 @@ requirements:
   run:
     - python
     - setuptools
-    - bhmm <0.6
+    - bhmm <0.7
     - joblib ==0.8.4
     - matplotlib
     - mdtraj >=1.5


### PR DESCRIPTION
Brings significantly improved Hidden Markov Model code. This is the PyEMMA interface for bhmm 0.6. Features:
- Maximum likelihood estimation can deal with disconnected hidden transition matrices. The desired connectivity is selected only at the end of the estimation (optionally), or a posteriori.
- Much more robust estimation of initial Hidden Markov model. 
- Added option stationary that controls whether input data is assumed to be sampled from the stationary distribution (and then the initial HMM distribution is taked as the stationary distribution of the hidden transition matrix), or not (then it's independently estimated using the EM standard approach). Default: stationary=False. This _changes the default behavior_ w.r.t. the previous version, but in a good way: Now the maximum-likelihood estimator always converges. Unfortunately that also means it is much slower compared to previous versions which stopped without proper convergence.
- Hidden connectivity: By default delivers a HMM with the full hidden transition matrix, that may be disconnected. This _changes the default behavior_ w.r.t. the previous version. Set connectivity='largest' or connectivity='populous' to focus the model on the largest or most populous connected set of hidden states
- Provides a way to measure connectivity in HMM transition matrices: A transition only counts as real if the hidden count matrix element is larger than mincount_connectivity (by default 1 over the number of hidden states). This seems to be a much more robust metric of real connectivity than MSM count matrix connectivity.
- Observable set: If HMMs are used for MSM coarse-graining, the MSM active set will become the observed set (as before). If a HMM is estimated directly, by default will focus on the nonempty set (states with nonzero counts in the lagged trajectories). Optionally can also use the full set labels - in this case no indexing or relabeling with respect to the original clustered data is needed.
- Hidden Markov Model provides estimator results (Viterbi hidden trajectories, convergence information, hidden count matrix). Fixes #528 
- BayesianHMSM object now accepts Dirichlet priors for transition matrix and initial distribution.
- Fixes #640 (general, not only for HMMs) by allowing estimates at individual lag times to fail in an ImpliedTimescales run (reported as Warnings).
- Fixes #636
