### PR TITLE
Fix use of dummy progressbar

### DIFF
--- a/pyemma/_base/progress/bar/gui.py
+++ b/pyemma/_base/progress/bar/gui.py
@@ -26,6 +26,7 @@ import sys
 import warnings
 
 from pyemma import config
+from pyemma._base.progress.bar import ProgressBar
 
 
 __all__ = ('is_interactive_session', 'show_progressbar')
@@ -130,7 +131,7 @@ def show_progressbar(bar, show_eta=True):
         return
 
     # note: this check ensures we have IPython.display and so on.
-    if ipython_notebook_session:
+    if ipython_notebook_session and isinstance(bar, ProgressBar):
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', DeprecationWarning)
             # create IPython widgets on first call

--- a/pyemma/_base/progress/reporter.py
+++ b/pyemma/_base/progress/reporter.py
@@ -70,6 +70,7 @@ class ProgressReporter(object):
                 pass
             pg = dummy()
             pg.__str__ = lambda: description
+            pg.description = ''
             pg.numerator = 0
             pg.denominator = 1
         else:


### PR DESCRIPTION
#695 was due to using a dummy progress bar. I added a simple instance check, that the ipython widget is only run if the progress bar is realy a ProgressBar instance. That should fix this bug.
