### PR TITLE
[coordinates/util] change_notification fix to lazy instantiate list

### DIFF
--- a/pyemma/coordinates/tests/test_pipeline.py
+++ b/pyemma/coordinates/tests/test_pipeline.py
@@ -34,6 +34,7 @@ import tempfile
 from six.moves import range
 import pkg_resources
 from pyemma.util.files import TemporaryDirectory
+import pyemma.coordinates as coor
 
 class TestPipeline(unittest.TestCase):
     @classmethod
@@ -78,6 +79,17 @@ class TestPipeline(unittest.TestCase):
         self.assertFalse(p._is_estimated(), "If run=false, the pipeline should not be parametrized.")
         p.parametrize()
         self.assertTrue(p._is_estimated(), "If parametrized was called, the pipeline should be parametrized.")
+
+    def test_notify_changes_mixin(self):
+        X_t = np.random.random((30,30))
+        source = coor.source(np.array(X_t))
+
+        t1 = coor.tica(source)
+        from pyemma.coordinates.transform import TICA
+        t2 = TICA(lag=10)
+        assert len(t1._stream_children) == 0
+        t2.data_producer = t1
+        assert t1._stream_children[0] == t2
 
     def test_np_reader_in_pipeline(self):
         with TemporaryDirectory() as td:

--- a/pyemma/coordinates/util/change_notification.py
+++ b/pyemma/coordinates/util/change_notification.py
@@ -38,8 +38,12 @@ def inform_children_upon_change(f):
 
 class NotifyOnChangesMixIn(object):
     #### interface to handle events
-    def __init__(self):
-        self._stream_children = []
+
+    @property
+    def _stream_children(self):
+        if not hasattr(self, "_stream_children_list"):
+            self._stream_children_list = []
+        return self._stream_children_list
 
     def _stream_register_child(self, data_producer):
         """ should be called upon setting of data_producer """


### PR DESCRIPTION
This PR fixes an issue that occurred when you tried to build up a coordinates pipeline as follows:

``` python
import numpy as np
import pyemma.coordinates as coor
X_t = np.random.random((30,30))
source = coor.source(np.array(X_t))
tica = coor.tica(source, dim=2, lag=1)
cl = coor.cluster_kmeans(tica, k=100, stride=10, max_iter=30)
```

It would raise a 'no attribute' exception because the constructor of the NotifyOnChangesMixIn would not be called (due to multiple inheritance).
