### PR TITLE
[trajectory_weights] sum over array is now sum over list

### DIFF
--- a/pyemma/msm/estimators/maximum_likelihood_hmsm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_hmsm.py
@@ -549,7 +549,7 @@ class MaximumLikelihoodHMSM(_Estimator, _HMSM):
         for dtraj in self.discrete_trajectories_obs:
             w = statdist[dtraj] / hist[dtraj]
             W.append(w)
-            wtot += _np.sum(W)
+            wtot += _np.sum([iW.sum() for iW in W])
         # normalize
         for w in W:
             w /= wtot

--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -531,7 +531,7 @@ class MaximumLikelihoodMSM(_Estimator, _MSM):
         for dtraj in self.discrete_trajectories_full:
             w = statdist_full[dtraj] / hist[dtraj]
             W.append(w)
-            wtot += _np.sum(W)
+            wtot += _np.sum([iW.sum() for iW in W])
         # normalize
         for w in W:
             w /= wtot


### PR DESCRIPTION
This cures #717 

The sum over the list instead of over the array does not have much influence on a set with 5000 trajs each with 1000 frames:

```
%timeit -n 1 -r 1 traj_w_copy_of_current_impl(MSM)
1 loop, best of 1: 57.7 s per loop

%timeit -n 1 -r 1 traj_w_new_impl(MSM)
1 loop, best of 1: 1min 1s per loop
```

I tried the "chain" solution proposed here, but was incredibly slow:
http://stackoverflow.com/questions/13334722/sum-for-list-of-lists#comment18195135_13334731
