### PR TITLE
[msm.estimators]: fixed trajectory weights (MSM/HMM)

### DIFF
--- a/pyemma/msm/estimators/maximum_likelihood_hmsm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_hmsm.py
@@ -549,7 +549,7 @@ class MaximumLikelihoodHMSM(_Estimator, _HMSM):
         for dtraj in self.discrete_trajectories_obs:
             w = statdist[dtraj] / hist[dtraj]
             W.append(w)
-            wtot += _np.sum(W)
+            wtot += _np.sum(w)
         # normalize
         for w in W:
             w /= wtot

--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -531,7 +531,7 @@ class MaximumLikelihoodMSM(_Estimator, _MSM):
         for dtraj in self.discrete_trajectories_full:
             w = statdist_full[dtraj] / hist[dtraj]
             W.append(w)
-            wtot += _np.sum(W)
+            wtot += _np.sum(w)
         # normalize
         for w in W:
             w /= wtot


### PR DESCRIPTION
Fixes #717 

@marscher : this failure occurs on my system. Please check:

```
======================================================================
ERROR: test_corrupted_db (pyemma.coordinates.tests.test_traj_info_cache.TestTrajectoryInfoCache)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/noe/data/software_projects/pyemma/pyemma/coordinates/tests/test_traj_info_cache.py", line 209, in test_corrupted_db
    db = TrajectoryInfoCache(name)
  File "/Users/noe/data/software_projects/pyemma/pyemma/coordinates/data/util/traj_info_cache.py", line 156, in __init__
    self._database.sync()
AttributeError: sync
```
