### PR TITLE
[coor.PCA|TICA] implemented partial_fit. Fixes #682

### DIFF
--- a/pyemma/_base/logging.py
+++ b/pyemma/_base/logging.py
@@ -22,8 +22,7 @@ Created on 30.08.2015
 @author: marscher
 '''
 from __future__ import absolute_import
-
-from logging import getLogger
+import logging
 import weakref
 from itertools import count
 
@@ -35,6 +34,12 @@ class Loggable(object):
     __ids = count(0)
     # holds weak references to instances of this, to clean up logger instances.
     __refs = {}
+
+    _loglevel_DEBUG = logging.DEBUG
+    _loglevel_INFO = logging.INFO
+    _loglevel_WARN = logging.WARN
+    _loglevel_ERROR = logging.ERROR
+    _loglevel_CRITICAL = logging.CRITICAL
 
     @property
     def name(self):
@@ -60,18 +65,14 @@ class Loggable(object):
     def _logger(self):
         return self.logger
 
-    @property
-    def _logger_has_instance(self):
-        return hasattr(self, 'logger_instance')
-
     def _logger_is_active(self, level):
         """ @param level: int log level (debug=10, info=20, warn=30, error=40, critical=50)"""
-        return self._logger_has_instance and self.logger.level >= level
+        return hasattr(self, '_logger_instance') and self.logger.level >= level
 
     def __create_logger(self):
         _weak_logger_refs = Loggable.__refs
         # creates a logger based on the the attribe "name" of self
-        self._logger_instance = getLogger(self.name)
+        self._logger_instance = logging.getLogger(self.name)
 
         # store a weakref to this instance to clean the logger instance.
         logger_id = id(self._logger_instance)
@@ -84,7 +85,7 @@ class Loggable(object):
         # removes logger from root manager
 
         def remove_logger(weak):
-            d = getLogger().manager.loggerDict
+            d = logging.getLogger().manager.loggerDict
             del d[logger_name]
             del Loggable.__refs[logger_id]
         return remove_logger

--- a/pyemma/coordinates/data/_base/datasource.py
+++ b/pyemma/coordinates/data/_base/datasource.py
@@ -238,6 +238,7 @@ class IteratorState(object):
         self.return_trajindex = return_trajindex
         self.itraj = 0
         self.current_itraj = 0
+        self.ntraj = ntraj
         self.t = 0
         self.pos = 0
         self.pos_adv = 0

--- a/pyemma/coordinates/data/_base/iterable.py
+++ b/pyemma/coordinates/data/_base/iterable.py
@@ -73,7 +73,7 @@ class Iterable(six.with_metaclass(ABCMeta, ProgressReporter, Loggable)):
             self._in_memory = op_in_mem
 
     def _clear_in_memory(self):
-        if self._logger_is_active(10):
+        if self._logger_is_active(self._loglevel_DEBUG):
             self._logger.debug("clear memory")
         assert self.in_memory, "tried to delete in memory results which are not set"
         self._Y = None
@@ -81,7 +81,7 @@ class Iterable(six.with_metaclass(ABCMeta, ProgressReporter, Loggable)):
 
     def _map_to_memory(self, stride=1):
         r"""Maps results to memory. Will be stored in attribute :attr:`_Y`."""
-        if self._logger_is_active(10):
+        if self._logger_is_active(self._loglevel_DEBUG):
             self._logger.debug("mapping to mem")
         assert self._in_memory
         self._mapping_to_mem_active = True
@@ -139,7 +139,7 @@ class Iterable(six.with_metaclass(ABCMeta, ProgressReporter, Loggable)):
                                        " Consider using a larger stride.")
                 return
 
-            if self._logger_is_active(10):
+            if self._logger_is_active(self._loglevel_DEBUG):
                 self._logger.debug("get_output(): dimensions=%s" % str(dimensions))
                 self._logger.debug("get_output(): created output trajs with shapes: %s"
                                    % [x.shape for x in trajs])

--- a/pyemma/coordinates/estimators/covar/covar_c/_covartools.c
+++ b/pyemma/coordinates/estimators/covar/covar_c/_covartools.c
@@ -83,17 +83,6 @@ void _subtract_row_float_copy(float* X0, float* X, float* row, int M, int N)
 }
 
 
-int* _bool_to_list(int* b, int N, int nnz)
-{
-        int i;
-        int k=0;
-        int* list = (int*)malloc(nnz*sizeof(int));
-        for (i=0; i<N; i++)
-                if (b[i] == 1)
-                        list[k++] = i;
-        return (list);
-}
-
 /** Checks each column whether it is constant in the rows or not
 
 @param cols : (N) result array that will be filled with 0 (column constant) or 1 (column variable)

--- a/pyemma/coordinates/estimators/covar/covar_c/_covartools.h
+++ b/pyemma/coordinates/estimators/covar/covar_c/_covartools.h
@@ -20,7 +20,6 @@
 void _subtract_row_double(double* X, double* row, int M, int N);
 void _subtract_row_float(double* X, double* row, int M, int N);
 void _subtract_row_double_copy(double* X0, double* X, double* row, int M, int N);
-int* _bool_to_list(int* b, int N, int nnz);
 void _variable_cols_char(int* cols, char* X, int M, int N, int min_constant);
 void _variable_cols_int(int* cols, int* X, int M, int N, int min_constant);
 void _variable_cols_long(int* cols, long* X, int M, int N, int min_constant);

--- a/pyemma/coordinates/tests/test_featurereader_and_tica.py
+++ b/pyemma/coordinates/tests/test_featurereader_and_tica.py
@@ -109,7 +109,7 @@ class TestFeatureReaderAndTICA(unittest.TestCase):
             partial.partial_fit(traj)
 
         np.testing.assert_allclose(partial.eigenvalues, ref.eigenvalues)
-        np.testing.assert_allclose(np.abs(partial.eigenvectors), np.abs(ref.eigenvectors), atol=1e-12)
+        np.testing.assert_allclose(np.abs(partial.eigenvectors), np.abs(ref.eigenvectors), atol=1e-8)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/tests/test_featurereader_and_tica.py
+++ b/pyemma/coordinates/tests/test_featurereader_and_tica.py
@@ -83,7 +83,6 @@ class TestFeatureReaderAndTICA(unittest.TestCase):
 
     def test_covariances_and_eigenvalues(self):
         reader = FeatureReader(self.trajnames, self.temppdb, chunksize=10000)
-        #TICA(tau=1, output_dimension=self.dim)
         for lag in [1, 11, 101, 1001, 2001]:  # avoid cos(w*tau)==0
             trans = api.tica(data=reader, dim=self.dim, lag=lag)
             log.info('number of trajectories reported by tica %d' % trans.number_of_trajectories())
@@ -98,6 +97,18 @@ class TestFeatureReaderAndTICA(unittest.TestCase):
             self.assertTrue(np.allclose(ana_cov_tau, trans.cov_tau, atol=1.E-3))
             log.info('max. eigenvalue: %f' % np.max(trans.eigenvalues))
             self.assertTrue(np.all(trans.eigenvalues <= 1.0))
+
+    def test_partial_fit(self):
+        reader = FeatureReader(self.trajnames, self.temppdb, chunksize=10000)
+        output = reader.get_output()
+        params = {'dim': self.dim, 'lag': 1001, }
+        ref = api.tica(reader, **params)
+        partial = api.tica(**params)
+
+        for traj in output:
+            partial.partial_fit(traj)
+        np.testing.assert_allclose(partial.eigenvalues, ref.eigenvalues)
+        np.testing.assert_allclose(np.abs(partial.eigenvectors), np.abs(ref.eigenvectors))
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/tests/test_featurereader_and_tica.py
+++ b/pyemma/coordinates/tests/test_featurereader_and_tica.py
@@ -101,14 +101,15 @@ class TestFeatureReaderAndTICA(unittest.TestCase):
     def test_partial_fit(self):
         reader = FeatureReader(self.trajnames, self.temppdb, chunksize=10000)
         output = reader.get_output()
-        params = {'dim': self.dim, 'lag': 1001, }
+        params = {'dim': self.dim, 'lag': 1001}
         ref = api.tica(reader, **params)
         partial = api.tica(**params)
 
         for traj in output:
             partial.partial_fit(traj)
+
         np.testing.assert_allclose(partial.eigenvalues, ref.eigenvalues)
-        np.testing.assert_allclose(np.abs(partial.eigenvectors), np.abs(ref.eigenvectors))
+        np.testing.assert_allclose(np.abs(partial.eigenvectors), np.abs(ref.eigenvectors), atol=1e-12)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/tests/test_featurereader_and_tica_projection.py
+++ b/pyemma/coordinates/tests/test_featurereader_and_tica_projection.py
@@ -33,7 +33,7 @@ import unittest
 from nose.plugins.attrib import attr
 import mdtraj
 
-from pyemma.coordinates.api import tica#, _TICA as TICA
+from pyemma.coordinates.api import tica
 from pyemma.coordinates.data.feature_reader import FeatureReader
 from pyemma.util.contexts import numpy_random_seed
 from pyemma.util.log import getLogger
@@ -112,7 +112,7 @@ class TestFeatureReaderAndTICAProjection(unittest.TestCase):
             log.info('max. eigenvalue: %f' % np.max(trans.eigenvalues))
             self.assertTrue(np.all(trans.eigenvalues <= 1.0))
             # check ICs
-            check = tica(data=data, lag=tau, dim=self.dim, force_eigenvalues_le_one=True)
+            check = tica(data=data, lag=tau, dim=self.dim)
             check.parametrize()
 
             np.testing.assert_allclose(np.eye(self.dim), check.cov, atol=1e-8)

--- a/pyemma/coordinates/tests/test_pca.py
+++ b/pyemma/coordinates/tests/test_pca.py
@@ -173,5 +173,17 @@ class TestPCAExtensive(unittest.TestCase):
 
         np.testing.assert_allclose(pca_spec_mean.cov, pca_calc_mean.cov)
 
+    def test_partial_fit(self):
+        data = [np.random.random((100, 3)), np.random.random((100, 3))]
+        pca_part = pca()
+        pca_part.partial_fit(data[0])
+        pca_part.partial_fit(data[1])
+
+        ref = pca(data)
+        np.testing.assert_allclose(pca_part.mean, ref.mean)
+
+        np.testing.assert_allclose(pca_part.eigenvalues, ref.eigenvalues)
+        np.testing.assert_allclose(pca_part.eigenvectors, ref.eigenvectors)
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/tests/test_tica.py
+++ b/pyemma/coordinates/tests/test_tica.py
@@ -340,40 +340,5 @@ class TestTICAExtensive(unittest.TestCase):
         its = -self.tica_obj.lag/np.log(np.abs(self.tica_obj.eigenvalues))
         assert np.allclose(self.tica_obj.timescales, its)
 
-    def test_partial_fit(self):
-        d = 2
-        arrays = [np.arange(300).reshape(-1, d),
-                  np.arange(300, 600).reshape(-1, d)]
-
-        means = [np.mean(x, axis=0) for x in arrays]
-
-        tica_obj = tica(lag=1)
-        tica_obj.partial_fit(arrays[0])
-        assert not tica_obj._estimated
-        np.testing.assert_almost_equal(tica_obj.mean, means[0], decimal=2)
-        # acccess eigenvectors to force diagonalization
-        tica_obj.eigenvectors
-        assert tica_obj._estimated
-
-        tica_obj.partial_fit(arrays[1])
-        assert not tica_obj._estimated
-        np.testing.assert_almost_equal(tica_obj.mean, (means[0] + means[1]) / 2, decimal=2)
-
-        tica_obj.eigenvalues
-        assert tica_obj._estimated
-
-    def test_partial_fit_sequences(self):
-        # update tica with a bunch of trajs
-        arrays = [np.random.random((100, 3)), np.random.random((300, 3)),
-                  np.random.random((400, 3)), np.random.random((9,3))]
-        lag = 20
-        tica_part = tica(lag=lag)
-        tica_part.partial_fit(arrays)
-
-        tica_one_batch = tica(arrays, lag=lag)
-        np.testing.assert_equal(tica_part.mean, tica_one_batch.mean)
-        np.testing.assert_equal(tica_part.eigenvalues, tica_one_batch.eigenvalues)
-        np.testing.assert_equal(tica_part.eigenvectors, tica_one_batch.eigenvectors)
-
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/tests/test_tica.py
+++ b/pyemma/coordinates/tests/test_tica.py
@@ -326,18 +326,6 @@ class TestTICAExtensive(unittest.TestCase):
         np.testing.assert_allclose(test_corr, true_corr, atol=1.E-8)
         #assert np.isclose(test_corr, true_corr).all()
 
-    def test_skipped_trajs(self):
-
-        feature_trajs = [np.arange(10),
-                         np.arange(11),
-                         np.arange(12),
-                         np.arange(13)]
-
-        tica_obj = tica(data=feature_trajs, lag=11)
-        # we skip the trajs right away in the iterator
-        assert (len(tica_obj._skipped_trajs) == 0)
-        # assert np.allclose(tica_obj._skipped_trajs, [0,1])
-
     def test_provided_means(self):
         data = np.random.random((300, 3))
         mean = data.mean(axis=0)
@@ -351,6 +339,41 @@ class TestTICAExtensive(unittest.TestCase):
     def test_timescales(self):
         its = -self.tica_obj.lag/np.log(np.abs(self.tica_obj.eigenvalues))
         assert np.allclose(self.tica_obj.timescales, its)
+
+    def test_partial_fit(self):
+        d = 2
+        arrays = [np.arange(300).reshape(-1, d),
+                  np.arange(300, 600).reshape(-1, d)]
+
+        means = [np.mean(x, axis=0) for x in arrays]
+
+        tica_obj = tica(lag=1)
+        tica_obj.partial_fit(arrays[0])
+        assert not tica_obj._estimated
+        np.testing.assert_almost_equal(tica_obj.mean, means[0], decimal=2)
+        # acccess eigenvectors to force diagonalization
+        tica_obj.eigenvectors
+        assert tica_obj._estimated
+
+        tica_obj.partial_fit(arrays[1])
+        assert not tica_obj._estimated
+        np.testing.assert_almost_equal(tica_obj.mean, (means[0] + means[1]) / 2, decimal=2)
+
+        tica_obj.eigenvalues
+        assert tica_obj._estimated
+
+    def test_partial_fit_sequences(self):
+        # update tica with a bunch of trajs
+        arrays = [np.random.random((100, 3)), np.random.random((300, 3)),
+                  np.random.random((400, 3)), np.random.random((9,3))]
+        lag = 20
+        tica_part = tica(lag=lag)
+        tica_part.partial_fit(arrays)
+
+        tica_one_batch = tica(arrays, lag=lag)
+        np.testing.assert_equal(tica_part.mean, tica_one_batch.mean)
+        np.testing.assert_equal(tica_part.eigenvalues, tica_one_batch.eigenvalues)
+        np.testing.assert_equal(tica_part.eigenvectors, tica_one_batch.eigenvectors)
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/transform/pca.py
+++ b/pyemma/coordinates/transform/pca.py
@@ -29,10 +29,21 @@ from pyemma.util.reflection import get_default_args
 
 from pyemma.coordinates.estimators.covar.running_moments import running_covar
 import numpy as np
+from decorator import decorator
 
 
 __all__ = ['PCA']
 __author__ = 'noe'
+
+
+@decorator
+def _lazy_estimation(func, *args, **kw):
+    assert isinstance(args[0], PCA)
+    tica_obj = args[0]
+    if not tica_obj._estimated:
+        tica_obj._diagonalize()
+    return func(*args, **kw)
+
 
 class PCAModel(Model):
     # todo: do we really want this?
@@ -87,7 +98,7 @@ class PCA(StreamingTransformer, ProgressReporter):
 
         self._model = PCAModel()
         self.set_params(dim=dim, var_cutoff=var_cutoff, mean=mean)
-
+        self._model = PCAModel()
 
     @doc_inherit
     def describe(self):
@@ -110,6 +121,7 @@ class PCA(StreamingTransformer, ProgressReporter):
         return d
 
     @property
+    @_lazy_estimation
     def cumvar(self):
         return self._model.cumvar
 
@@ -118,6 +130,7 @@ class PCA(StreamingTransformer, ProgressReporter):
         self._model.cumvar = value
 
     @property
+    @_lazy_estimation
     def eigenvalues(self):
         return self._model.eigenvalues
 
@@ -126,12 +139,13 @@ class PCA(StreamingTransformer, ProgressReporter):
         self._model.eigenvalues = value
 
     @property
+    @_lazy_estimation
     def eigenvectors(self):
         return self._model.eigenvectors
 
     @eigenvectors.setter
     def eigenvectors(self, value):
-        pass
+        self._model.eigenvectors = value
 
     @property
     def mean(self):
@@ -141,23 +155,16 @@ class PCA(StreamingTransformer, ProgressReporter):
     def mean(self, value):
         self._model.mean = value
 
-    def _estimate(self, iterable, **kwargs):
-        with iterable.iterator(return_trajindex=False) as it:
-            n_chunks = it._n_chunks
-            self._progress_register(n_chunks, "calc mean and covar", 0)
-            nsave = max(math.log(math.ceil(n_chunks), 2), 2)
-            self._logger.debug("using %s moments for %i chunks" % (nsave, n_chunks))
-            self._covar = running_covar(xx=True, xy=False, yy=False,
-                                        remove_mean=True, symmetrize=False,
-                                        nsave=nsave)
+    def partial_fit(self, X):
+        from pyemma.coordinates import source
+        iterable = source(X)
 
-            for chunk in it:
-                self._covar.add(chunk)
-                self._progress_update(1, 0)
+        self._estimate(iterable, partial=True)
+        self._estimated = False
 
-        self.cov = self._covar.cov_XX()
-        self.mu = self._covar.mean_X()
+        return self
 
+    def _diagonalize(self):
         (v, R) = np.linalg.eigh(self.cov)
         # sort
         I = np.argsort(v)[::-1]
@@ -168,13 +175,35 @@ class PCA(StreamingTransformer, ProgressReporter):
         cumvar = np.cumsum(eigenvalues)
         cumvar /= cumvar[-1]
 
-        model = PCAModel()
-        model.update_model_params(cumvar=cumvar, eigenvalues=eigenvalues,
-                                  eigenvectors=eigenvectors,
-                                  mean=self._covar.mean_X())
-        self._model = model
+        self._model.update_model_params(eigenvalues=eigenvalues,
+                                        eigenvectors=eigenvectors,
+                                        cumvar=cumvar)
 
-        return model
+    def _estimate(self, iterable, **kw):
+        partial_fit = 'partial' in kw
+
+        with iterable.iterator(return_trajindex=False) as it:
+            n_chunks = it._n_chunks
+            self._progress_register(n_chunks, "calc mean and covar", 0)
+            if not hasattr(self, '_covar'):
+                nsave = max(math.log(math.ceil(n_chunks), 2), 2)
+                self._logger.debug("using %s moments for %i chunks" % (nsave, n_chunks))
+                self._covar = running_covar(xx=True, xy=False, yy=False,
+                                            remove_mean=True, symmetrize=False,
+                                            nsave=nsave)
+
+            for chunk in it:
+                self._covar.add(chunk)
+                self._progress_update(1, 0)
+
+        self.cov = self._covar.cov_XX()
+        self.mu = self._covar.mean_X()
+
+        self._model.update_model_params(mean=self._covar.mean_X())
+        if not partial_fit:
+            self._diagonalize()
+
+        return self._model
 
     def _transform_array(self, X):
         r"""

--- a/pyemma/coordinates/transform/pca.py
+++ b/pyemma/coordinates/transform/pca.py
@@ -184,7 +184,7 @@ class PCA(StreamingTransformer, ProgressReporter):
 
         with iterable.iterator(return_trajindex=False) as it:
             n_chunks = it._n_chunks
-            self._progress_register(n_chunks, "calc mean and covar", 0)
+            self._progress_register(n_chunks, "calc mean+cov", 0)
             if not hasattr(self, '_covar'):
                 nsave = max(math.log(math.ceil(n_chunks), 2), 2)
                 self._logger.debug("using %s moments for %i chunks" % (nsave, n_chunks))

--- a/pyemma/coordinates/transform/tica.py
+++ b/pyemma/coordinates/transform/tica.py
@@ -22,23 +22,34 @@ Created on 19.01.2015
 
 from __future__ import absolute_import
 
+from decorator import decorator
 from math import ceil, log
 
 from pyemma._base.model import Model
+from pyemma.coordinates.estimators.covar.running_moments import running_covar
 from pyemma.util.annotators import doc_inherit, deprecated
 from pyemma.util.linalg import eig_corr
 from pyemma.util.reflection import get_default_args
 
 import numpy as np
-from pyemma.coordinates.estimators.covar.running_moments import running_covar
 
 from .transformer import StreamingTransformer
+
 
 __all__ = ['TICA']
 
 
 class TICAModel(Model):
     pass
+
+
+@decorator
+def _lazy_estimation(func, *args, **kw):
+    assert isinstance(args[0], TICA)
+    tica_obj = args[0]
+    if not tica_obj._estimated:
+        tica_obj._diagonalize()
+    return func(*args, **kw)
 
 
 class TICA(StreamingTransformer):
@@ -198,6 +209,36 @@ class TICA(StreamingTransformer):
     def cov(self, value):
         self._model.cov = value
 
+    def partial_fit(self, X):
+        from pyemma.coordinates import source
+        iterable = source(X)
+
+        self._estimate(iterable, partial=True)
+        self._estimated = False
+
+        return self
+
+    def _diagonalize(self):
+        if len(self._skipped_trajs) >= 1:
+            self._logger.warning("Had to skip %u trajectories for being too short (len<lag). "
+                                 "Their indices are in tica_obj._skipped_trajs."
+                                 % len(self._skipped_trajs))
+
+        # diagonalize with low rank approximation
+        self._logger.debug("diagonalize Cov and Cov_tau.")
+        eigenvalues, eigenvectors = eig_corr(self.cov, self.cov_tau, self.epsilon)
+        self._logger.debug("finished diagonalisation.")
+
+        # compute cumulative variance
+        cumvar = np.cumsum(eigenvalues ** 2)
+        cumvar /= cumvar[-1]
+
+        self._model.update_model_params(cumvar=cumvar,
+                                        eigenvalues=eigenvalues,
+                                        eigenvectors=eigenvectors)
+
+        self._estimated = True
+
     def _estimate(self, iterable, **kw):
         r"""
         Chunk-based parameterization of TICA. Iterates over all data and estimates
@@ -205,6 +246,7 @@ class TICA(StreamingTransformer):
         generalized eigenvalue problem is solved to determine
         the independent components.
         """
+        partial_fit = 'partial' in kw
         indim = iterable.dimension()
         assert indim > 0, "zero dimension from data source!"
         assert self.dim <= indim, ("requested more output dimensions (%i) than dimension"
@@ -212,52 +254,36 @@ class TICA(StreamingTransformer):
 
         self._logger.debug("Running TICA with tau=%i; Estimating two covariance matrices"
                            " with dimension (%i, %i)" % (self._lag, indim, indim))
-        if not any(iterable.trajectory_lengths(self.stride) > self.lag):
+
+        if not partial_fit and not any(iterable.trajectory_lengths(self.stride) > self.lag):
             raise ValueError("None single dataset [longest=%i] is longer than"
                              " lag time [%i]." % (max(iterable.trajectory_lengths(self.stride)), self.lag))
 
-        self._skipped_trajs = np.fromiter((i for i in range(self._ntraj) if
-                                           iterable.trajectory_length(i) < self.lag),
-                                          dtype=int)
         it = iterable.iterator(lag=self.lag, return_trajindex=False)
         with it:
-            # register progress
+            # register progresss
             n_chunks = it._n_chunks
             self._progress_register(n_chunks, "calculate mean+cov", 0)
             nsave = int(max(log(ceil(n_chunks), 2), 2))
-            self._logger.debug("using %s moments for %i chunks" % (nsave, n_chunks))
-            covar = running_covar(xx=True, xy=True, yy=False,
-                                  remove_mean=self.remove_mean,
-                                  symmetrize=True, nsave=nsave)
+            self._logger.debug(
+                "using %s moments for %i chunks" % (nsave, n_chunks))
+            if not hasattr(self, '_covar'):
+                self._covar = running_covar(xx=True, xy=True, yy=False,
+                                            remove_mean=self.remove_mean,
+                                            symmetrize=True, nsave=nsave)
 
             for X, Y in it:
-                covar.add(X, Y)
+                self._covar.add(X, Y)
                 # counting chunks and log of eta
                 self._progress_update(1, stage=0)
 
-        cov, cov_tau = covar.cov_XX(), covar.cov_XY()
+        self._model.update_model_params(mean=self._covar.mean_X(),
+                                        cov=self._covar.cov_XX(),
+                                        cov_tau=self._covar.cov_XY())
 
-        # diagonalize with low rank approximation
-        self._logger.debug("diagonalize Cov and Cov_tau.")
-        eigenvalues, eigenvectors = \
-            eig_corr(cov, cov_tau, self.epsilon)
-        self._logger.debug("finished diagonalisation.")
+        if not partial_fit:
+            self._diagonalize()
 
-        # compute cumulative variance
-        cumvar = np.cumsum(eigenvalues ** 2)
-        cumvar /= cumvar[-1]
-
-        if len(self._skipped_trajs) >= 1:
-            self._logger.warning("Had to skip %u trajectories for being too short (len<lag). "
-                                 "Their indices are in tica_obj._skipped_trajs."
-                                 % len(self._skipped_trajs))
-
-        self._model.update_model_params(mean=covar.mean_X(),
-                                        cov=cov,
-                                        cov_tau=cov_tau,
-                                        cumvar=cumvar,
-                                        eigenvalues=eigenvalues,
-                                        eigenvectors=eigenvectors)
         return self._model
 
     def _transform_array(self, X):
@@ -322,12 +348,10 @@ class TICA(StreamingTransformer):
             input coordinates were available. However, less eigenvalues will be returned if the TICA matrices
             were not full rank or :py:obj:`var_cutoff` was parsed
         """
-        if self._estimated:
-            return -self.lag / np.log(np.abs(self.eigenvalues))
-        else:
-            self._logger.info("TICA not yet parametrized")
+        return -self.lag / np.log(np.abs(self.eigenvalues))
 
     @property
+    @_lazy_estimation
     def eigenvalues(self):
         r"""Eigenvalues of the TICA problem (usually denoted :math:`\lambda`
 
@@ -338,6 +362,7 @@ class TICA(StreamingTransformer):
         return self._model.eigenvalues
 
     @property
+    @_lazy_estimation
     def eigenvectors(self):
         r"""Eigenvectors of the TICA problem, columnwise
 
@@ -348,6 +373,7 @@ class TICA(StreamingTransformer):
         return self._model.eigenvectors
 
     @property
+    @_lazy_estimation
     def cumvar(self):
         r"""Cumulative sum of the the TICA eigenvalues
 


### PR DESCRIPTION
There is one thing I'm currently not sure about. For both PCA and TICA there is a running_covar instance created with n_save estimated from the first data set/array being added. If later on a much larger array is added, we could in principle "need" or want more storages being used, right? 

Should we add a setter for the size of underlying storages?
