### PR TITLE
Nicer config handling and wrapping

### DIFF
--- a/pyemma/__init__.py
+++ b/pyemma/__init__.py
@@ -33,3 +33,11 @@ from . import thermo
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions
+
+
+def setup_package():
+    # purpose is for nose testing only to silence progress bars etc.
+    import warnings
+    warnings.warn('You should never see this, only in unit testing!'
+                  ' This switches off progress bars')
+    config.show_progress_bars = False

--- a/pyemma/_base/progress/bar/gui.py
+++ b/pyemma/_base/progress/bar/gui.py
@@ -55,7 +55,6 @@ def __ipy_widget_version():
 def __attached_to_ipy_notebook():
     # first determine which IPython version we have (eg. ipywidgets or ipy3 deprecated,
     # then try to instanciate a widget to determine if we're interactive (raises, if not).
-    import sys
     if 'IPython' not in sys.modules:
         return
     ipy_widget_version = __ipy_widget_version()
@@ -74,7 +73,6 @@ def __attached_to_ipy_notebook():
         return False
     else:
         return True
-
 
 
 def __is_interactive():
@@ -129,8 +127,7 @@ def show_progressbar(bar, show_eta=True):
     show_eta : bool (optional)
 
     """
-    if not (str(config['show_progress_bars']) == 'True' and
-            is_interactive_session):
+    if not config.show_progress_bars:
         return
 
     # note: this check ensures we have IPython.display and so on.
@@ -150,7 +147,6 @@ def show_progressbar(bar, show_eta=True):
 
                 # make it visible once
                 display(box)
-                # box.visible=True
 
                 # update css for a more compact view
                 progress_widget._css = [

--- a/pyemma/_base/progress/reporter.py
+++ b/pyemma/_base/progress/reporter.py
@@ -94,8 +94,8 @@ class ProgressReporter(object):
             pg.description = ''
         else:
             pg = _ProgressBar(amount_of_work, description=description)
+
         self._prog_rep_progressbars[stage] = pg
-        assert stage in self._prog_rep_progressbars
 
 #     def _progress_set_description(self, stage, description):
 #         """ set description of an already existing progress """
@@ -158,12 +158,15 @@ class ProgressReporter(object):
 
         pg = self._prog_rep_progressbars[stage]
         pg.numerator += numerator_increment
-
+        # we are done
         if pg.numerator == pg.denominator:
-            _hide_progressbar(pg)
-
-        if pg.numerator > pg.denominator:
-            raise Exception("This should not happen")
+            self._progress_force_finish(stage)
+            return
+        elif pg.numerator > pg.denominator:
+            import warnings
+            warnings.warn("This should not happen. An caller pretended to have "
+                          "achieved more work than registered")
+            return
 
         _show_progressbar(pg)
         if hasattr(self, '_prog_rep_callbacks') and stage in self._prog_rep_callbacks:

--- a/pyemma/coordinates/tests/__init__.py
+++ b/pyemma/coordinates/tests/__init__.py
@@ -22,6 +22,6 @@ from __future__ import absolute_import
 
 def setup_package():
     # setup function for nose tests (for this package only)
-    from pyemma.util.config import conf_values
+    from pyemma.util import config
     # do not cache trajectory info in user directory (temp traj files)
-    conf_values['pyemma']['use_trajectory_lengths_cache'] = False
+    config.use_trajectory_lengths_cache = False

--- a/pyemma/util/annotators.py
+++ b/pyemma/util/annotators.py
@@ -36,7 +36,6 @@ Now, Bar.foo.__doc__ == Bar().foo.__doc__ == Foo.foo.__doc__ == "Frobber"
 from __future__ import absolute_import
 from functools import wraps
 import warnings
-from six import PY2
 from decorator import decorator, decorate
 from inspect import stack
 

--- a/pyemma/util/config.py
+++ b/pyemma/util/config.py
@@ -30,7 +30,8 @@ import pkg_resources
 
 
 # for IDE stupidity, just add a new cfg var here, if you add a property to Wrapper
-cfg_dir = default_config_file = logging_config = show_progress_bars = used_filenames = use_trajectory_lengths_cache = None
+cfg_dir = default_config_file = default_logging_config = logging_config = \
+    show_progress_bars = used_filenames = use_trajectory_lengths_cache = None
 
 __all__ = (
            'cfg_dir',
@@ -114,6 +115,13 @@ False
             warnings.warn("unable to read default configuration file. Logging and "
                           " progress bar handling could behave bad! Error: %s" % re)
 
+        from pyemma.util.log import setupLogging, LoggingConfigurationError
+        try:
+            setupLogging(self)
+        except LoggingConfigurationError as e:
+            warnings.warn("Error during logging configuration. Logging might not be functional!"
+                          "Error: %s" % e)
+
         # wrap this module
         self.wrapped = wrapped
         self.__wrapped__ = wrapped
@@ -134,6 +142,10 @@ False
     def default_config_file(self):
         """ default config file living in PyEMMA package """
         return pkg_resources.resource_filename('pyemma', Wrapper.DEFAULT_CONFIG_FILE_NAME)
+
+    @property
+    def default_logging_file(self):
+        return pkg_resources.resource_filename('pyemma', Wrapper.DEFAULT_LOGGING_FILE_NAME)
 
     @deprecated("do not use this!")
     def conf_values(self):

--- a/pyemma/util/config.py
+++ b/pyemma/util/config.py
@@ -36,6 +36,7 @@ cfg_dir = default_config_file = default_logging_config = logging_config = \
 __all__ = (
            'cfg_dir',
            'default_config_file',
+           'default_logging_file',
            'logging_config',
            'show_progress_bars',
            'used_filenames',
@@ -125,6 +126,9 @@ False
         # wrap this module
         self.wrapped = wrapped
         self.__wrapped__ = wrapped
+
+    def __call__(self, ):
+        return Wrapper(sys.modules[__name__])
 
     @property
     def cfg_dir(self):
@@ -225,7 +229,6 @@ False
         reads config files from various locations to build final config.
         """
         from six.moves import configparser
-        from six import PY2
 
         # use these files to extend/overwrite the conf_values.
         # Last red file always overwrites existing values!
@@ -288,5 +291,4 @@ False
         self._conf_values['pyemma'][name] = value
 
 # assign an alias to the wrapped module under 'config._impl'
-sys.modules['pyemma.config._impl'] = Wrapper(sys.modules[__name__])
-sys.modules[__name__] = sys.modules['pyemma.config._impl']
+sys.modules[__name__] = Wrapper(sys.modules[__name__])

--- a/pyemma/util/log.py
+++ b/pyemma/util/log.py
@@ -40,7 +40,6 @@ def setupLogging(config):
     """ set up the logging system with the configured (in pyemma.cfg) logging config (logging.yml)
     @param config: instance of pyemma.config module (wrapper)
     """
-    #from pyemma.util import config
     import yaml
 
     args = config.logging_config
@@ -60,7 +59,7 @@ def setupLogging(config):
         # fall back to default
         if not default:
             try:
-                with open(config.default_logging_config) as f:
+                with open(config.default_logging_file) as f:
                     D = yaml.load(f)
                     warnings.warn('Your set logging configuration could not '
                                   'be used. Used default as fallback.')
@@ -87,7 +86,11 @@ def setupLogging(config):
     except ValueError as ve:
         # issue with file handler?
         if 'files' in str(ve) and 'rotating_files' in D['handlers']:
-                D['handlers']['rotating_files']['filename'] = os.path.join(config.cfg_dir, 'pyemma.log')
+            print("cfg dir", config.cfg_dir)
+            new_file = os.path.join(config.cfg_dir, 'pyemma.log')
+            warnings.warn("set logfile to %s, because there was"
+                          " an error writing to the desired one" % new_file)
+            D['handlers']['rotating_files']['filename'] = new_file
         else:
             raise
         dictConfig(D)

--- a/pyemma/util/log.py
+++ b/pyemma/util/log.py
@@ -1,4 +1,3 @@
-
 # This file is part of PyEMMA.
 #
 # Copyright (c) 2015, 2014 Computational Molecular Biology Group, Freie Universitaet Berlin (GER)
@@ -15,8 +14,6 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-
 '''
 Created on 15.10.2013
 
@@ -25,10 +22,13 @@ Created on 15.10.2013
 
 from __future__ import absolute_import, print_function
 
-import pkg_resources
 import logging
-import warnings
+from logging.config import dictConfig
 import os.path
+import warnings
+
+import pkg_resources
+
 
 __all__ = ['getLogger',
            ]
@@ -36,27 +36,22 @@ __all__ = ['getLogger',
 def_conf_file = pkg_resources.resource_filename('pyemma', 'logging.yml')
 del pkg_resources
 
+class LoggingConfigurationError(RuntimeError):
+    pass
 
 def setupLogging():
     """
     parses pyemma configuration file and creates a logger conf_values from that
     """
-    from logging.config import dictConfig
     from pyemma.util import config
     import yaml
-
-    # copy default cfg to users dir
-    cfg_dir = config.create_cfg_dir(def_conf_file)
-
-    class LoggingConfigurationError(RuntimeError):
-        pass
 
     args = config.logging_config
     default = False
 
     if args.upper() == 'DEFAULT':
         default = True
-        src = os.path.join(cfg_dir, 'logging.yml')
+        src = os.path.join(config.cfg_dir, 'logging.yml')
     else:
         src = args
 
@@ -117,7 +112,3 @@ def getLogger(name=None):
         name = t[0][0]
 
     return logging.getLogger(name)
-
-
-# init logging
-setupLogging()

--- a/pyemma/util/tests/test_log.py
+++ b/pyemma/util/tests/test_log.py
@@ -1,0 +1,68 @@
+# This file is part of PyEMMA.
+#
+# Copyright (c) 2015, 2014 Computational Molecular Biology Group, Freie Universitaet Berlin (GER)
+#
+# PyEMMA is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+'''
+Created on 09.03.2016
+
+@author: marscher
+'''
+from tempfile import NamedTemporaryFile
+import sys
+import unittest
+import logging
+
+
+from pyemma.util import log
+from pyemma.util import config
+import mock
+
+
+class TestNonWriteableLogFile(unittest.TestCase):
+
+    def tearDown(self):
+        # reset logging
+        log.setupLogging(config)
+
+    @unittest.skipIf('win32' in sys.platform, "disabled on win")
+    def test(self):
+        conf = """
+# do not disable other loggers by default.
+disable_existing_loggers: False
+
+# please do not change version, it is an internal variable used by Python.
+version: 1
+
+handlers:
+    rotating_files:
+        class: logging.handlers.RotatingFileHandler
+        filename: /pyemma.log
+
+loggers:
+    pyemma:
+        level: INFO
+        handlers: [rotating_files]
+        """
+        with NamedTemporaryFile(delete=False) as f:
+            f.write(conf)
+            f.close()
+            with mock.patch('pyemma.util.log.open', create=True) as mock_open:
+                mock_open.return_value = open(f.name)
+
+                log.setupLogging(config)
+                assert logging.getLogger('pyemma').handlers[0].baseFilename.startswith(config.cfg_dir)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyemma/util/tests/test_log.py
+++ b/pyemma/util/tests/test_log.py
@@ -27,7 +27,11 @@ import logging
 
 from pyemma.util import log
 from pyemma.util import config
-import mock
+import six
+if six.PY2:
+    import mock
+else:
+    from unittest import mock
 
 
 class TestNonWriteableLogFile(unittest.TestCase):
@@ -38,7 +42,7 @@ class TestNonWriteableLogFile(unittest.TestCase):
 
     @unittest.skipIf('win32' in sys.platform, "disabled on win")
     def test(self):
-        conf = """
+        conf = b"""
 # do not disable other loggers by default.
 disable_existing_loggers: False
 


### PR DESCRIPTION
- introduced proper types for config vars
- progressbar handling during tests does not depend on execution order any more
- logging is initialized in the config wrapper
- Fix issue with non-writeable logfiles (fall-back to $HOME/.pyemma/pyemma.log) #725 
