### PR TITLE
Plot its new optargs nits ans process

### DIFF
--- a/pyemma/plots/tests/test_its.py
+++ b/pyemma/plots/tests/test_its.py
@@ -1,0 +1,61 @@
+
+# This file is part of PyEMMA.
+#
+# Copyright (c) 2015, 2014 Computational Molecular Biology Group, Freie Universitaet Berlin (GER)
+#
+# PyEMMA is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+'''
+Created on 10.03.2016
+
+@author: gph82
+'''
+
+from __future__ import absolute_import
+import unittest
+import numpy as np
+
+from pyemma.msm import its
+from pyemma.plots import plot_implied_timescales
+from msmtools.generation import generate_traj
+
+class TestItsPlot(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        P = np.array([[0.5, .25, .25, 0.],
+                      [0., .25, .5, .25],
+                      [.25, .25, .5, 0],
+                      [.25, .25, .25, .25],
+                      ])
+        # bogus its object
+        lags = [1,2,3,5,10]
+        cls.its = its(generate_traj(P, 100), lags=lags, errors='bayes'
+                      )
+        cls.refs = cls.its.timescales[-1]
+        return cls
+
+    def test_plot(self):
+        plot_implied_timescales(self.its,
+                                refs=self.refs)
+    def test_nits(self):
+        plot_implied_timescales(self.its,
+                                refs=self.refs, nits=2)
+    def test_process(self):
+        plot_implied_timescales(self.its,
+                                refs=self.refs, process=[1,2])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyemma/plots/timescales.py
+++ b/pyemma/plots/timescales.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import
 
 from six.moves import range
 import numpy as _np
-from pyemma.util.types import  is_iterable_of_int as _is_iterable_of_int
+from pyemma.util.types import  is_iterable_of_int as _is_iterable_of_int, is_int as _is_int
 
 __author__ = 'noe'
 
@@ -97,7 +97,9 @@ def plot_implied_timescales(ITS, ax=None, outfile=None, show_mle=True, show_mean
         # Now that it's for sure that nits==-1, process is iter_of_ints, and the requested processes exist in its object:
         its_idx = process
     else:
-        its_idx = range(ITS.number_of_timescales)[:nits]
+        if not _is_int(nits):
+            raise TypeError('nits is not an integer, ',nits)
+        its_idx = _np.arange(ITS.number_of_timescales)[:nits]
 
     # Check units and dt for user error.
     if isinstance(units,list) and len(units)!=2:

--- a/pyemma/plots/timescales.py
+++ b/pyemma/plots/timescales.py
@@ -58,7 +58,7 @@ def plot_implied_timescales(ITS, ax=None, outfile=None, show_mle=True, show_mean
     process : iterable of integers, default is None
         list or ndarray((m), dtype=int) containing a list of the processes to be shown. The default behaviour is
         to show all timescales available.
-        :py:obj:`process` != -1 and :py:obj:`nits` != None are mutually exclusive
+        :py:obj:`process` != None and :py:obj:`nits` != -1 are mutually exclusive
     units: str or list (len=2) of strings, optional, default = 'steps'
         Affects the labeling of the axes. Used with :py:obj:`dt`, allows for changing the physical units of the axes.
         Accepts simple LaTeX math strings, eg. '$\mu$s'
@@ -98,7 +98,6 @@ def plot_implied_timescales(ITS, ax=None, outfile=None, show_mle=True, show_mean
         its_idx = process
     else:
         its_idx = range(ITS.number_of_timescales)[:nits]
-        pass
 
     # Check units and dt for user error.
     if isinstance(units,list) and len(units)!=2:

--- a/pyemma/plots/timescales.py
+++ b/pyemma/plots/timescales.py
@@ -53,10 +53,11 @@ def plot_implied_timescales(ITS, ax=None, outfile=None, show_mle=True, show_mean
         Reference (exact solution or other reference) timescales if known. The number of timescales must match those
         in the ITS object
     nits: integer, default = -1
-        Number of implied timescales to be shown. The default behaviour (-1) is to show all available.
+        Number of implied timescales to be shown. The default behaviour (-1) is to show all timescales available.
         :py:obj:`nits` != -1 and :py:obj:`process` != None are mutually exclusive
     process : iterable of integers, default is None
-        list or ndarray((m), dtype=int) containing a list of the processes to be shown.
+        list or ndarray((m), dtype=int) containing a list of the processes to be shown. The default behaviour is
+        to show all timescales available.
         :py:obj:`process` != -1 and :py:obj:`nits` != None are mutually exclusive
     units: str or list (len=2) of strings, optional, default = 'steps'
         Affects the labeling of the axes. Used with :py:obj:`dt`, allows for changing the physical units of the axes.
@@ -127,8 +128,8 @@ def plot_implied_timescales(ITS, ax=None, outfile=None, show_mle=True, show_mean
             ax.fill_between(lags*dt[0], lconf*dt[1], rconf*dt[1], alpha=0.2, color=colors[i % len(colors)])
         # reference available?
         if (refs is not None):
-            tref = refs[i]
-            ax.plot([0,min(tref,xmax)]*dt[0], [tref,tref]*dt[1], color='black', linewidth=1)
+            tref = refs[i]*dt[1]
+            ax.plot([0,min(tref,xmax)*dt[0]], [tref,tref], color='black', linewidth=1)
     # cutoff
     ax.plot(lags*dt[0], lags*dt[1], linewidth=2, color='black')
     ax.set_xlim([1*dt[0], xmax*dt[0]])


### PR DESCRIPTION
More flexibility when plotting its objects without having to alter the its object itself: 
- Keyword nits  will stop plotting after the nits-th timescale, and avoid cluttering the lower part graph if one estimated many its that are not necessarily needed in the plot
- Keyword process allows for direct selection of the wanted processes, like "show just its nr. 2"  or nrs. [0, 2, 4]. 
- Both keywords are mutually exclusive and work well the other options like showing the refs, the errorbars, and the dt units.

The name of the keywords are chosen to be the same as in its.get_timescale(process=None) and pyemma.msm.its(dtrajs, lag, nits=5). 

I have also added a minimal test, since the code starts to be a bit more complex now. So far, it only tests that things work together without breaking, but is intended to be more comprehensive with time

What do you guys think?
