### PR TITLE
[coor/tica] Check for too short trajs in partial fit mode.

### DIFF
--- a/pyemma/coordinates/data/_base/iterable.py
+++ b/pyemma/coordinates/data/_base/iterable.py
@@ -276,6 +276,9 @@ class LaggedIterator(object):
         n2 = self._it_lagged._n_chunks
         return min(n1, n2)
 
+    def __len__(self):
+        return min(self._it.trajectory_lengths(), self._it_lagged.trajectory_lengths())
+
     def __iter__(self):
         return self
 

--- a/pyemma/coordinates/tests/test_tica.py
+++ b/pyemma/coordinates/tests/test_tica.py
@@ -340,5 +340,20 @@ class TestTICAExtensive(unittest.TestCase):
         its = -self.tica_obj.lag/np.log(np.abs(self.tica_obj.eigenvalues))
         assert np.allclose(self.tica_obj.timescales, its)
 
+    def test_too_short_traj_partial_fit(self):
+        data = [np.empty((20, 3)), np.empty((10, 3))]
+        lag = 11
+        tica_obj = tica(lag=lag)
+        from pyemma.util.testing_tools import MockLoggingHandler
+        log_handler = MockLoggingHandler()
+        tica_obj.logger.addHandler(log_handler)
+        for x in data:
+            tica_obj.partial_fit(x)
+
+        self.assertEqual(tica_obj._used_data, 20 - lag)
+        self.assertEqual(len(log_handler.messages['warning']), 1)
+        self.assertIn("longer than lag time", log_handler.messages['warning'][0])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/transform/tica.py
+++ b/pyemma/coordinates/transform/tica.py
@@ -251,9 +251,15 @@ class TICA(StreamingTransformer):
             self._logger.debug("Running TICA with tau=%i; Estimating two covariance matrices"
                                " with dimension (%i, %i)" % (self._lag, indim, indim))
 
-        if not partial_fit and not any(iterable.trajectory_lengths(stride=self.stride, skip=self.lag) > 0):
-            raise ValueError("None single dataset [longest=%i] is longer than"
-                             " lag time [%i]." % (max(iterable.trajectory_lengths(self.stride)), self.lag))
+        if not any(iterable.trajectory_lengths(stride=self.stride, skip=self.lag) > 0):
+            if partial_fit:
+                self.logger.warn("Could not use data passed to partial_fit(), "
+                                 "because no single data set [longest=%i] is longer than lag time [%i]"
+                                 % (max(iterable.trajectory_lengths(self.stride)), self.lag))
+                return self
+            else:
+                raise ValueError("None single dataset [longest=%i] is longer than"
+                                 " lag time [%i]." % (max(iterable.trajectory_lengths(self.stride)), self.lag))
 
         it = iterable.iterator(lag=self.lag, return_trajindex=False)
         with it:
@@ -270,6 +276,10 @@ class TICA(StreamingTransformer):
 
         if not partial_fit:
             self._diagonalize()
+        else:
+            if not hasattr(self, "_used_data"):
+                self._used_data = 0
+            self._used_data += len(it)
 
         return self._model
 

--- a/pyemma/util/testing_tools.py
+++ b/pyemma/util/testing_tools.py
@@ -1,0 +1,20 @@
+import logging
+
+class MockLoggingHandler(logging.Handler):
+    """Mock logging handler to check for expected logs."""
+
+    def __init__(self, *args, **kwargs):
+        self.reset()
+        logging.Handler.__init__(self, *args, **kwargs)
+
+    def emit(self, record):
+        self.messages[record.levelname.lower()].append(record.getMessage())
+
+    def reset(self):
+        self.messages = {
+            'debug': [],
+            'info': [],
+            'warning': [],
+            'error': [],
+            'critical': [],
+        }


### PR DESCRIPTION
Also added a new field _used_data for partial fit mode to count the number
of frames used in calculation of cov.
- Added len method for LaggedIter
- Added a debug logging handler to record log messages.
