### PR TITLE
fit transform for list of ndarrays

### DIFF
--- a/pyemma/_base/estimator.py
+++ b/pyemma/_base/estimator.py
@@ -127,9 +127,8 @@ def _estimate_param_scan_worker(estimator, params, X, evaluate, evaluate_args,
 
     """
     # run estimation
-    model = None
     try:  # catch any exception
-        model = estimator.estimate(X, **params)
+        estimator.estimate(X, **params)
     except:
         e = sys.exc_info()[0]
         if failfast:
@@ -142,7 +141,7 @@ def _estimate_param_scan_worker(estimator, params, X, evaluate, evaluate_args,
 
     # deal with result
     if evaluate is None:  # we want full models
-        res.append(model)
+        res.append(estimator.model)
     # we want to evaluate function(s) of the model
     elif _types.is_iterable(evaluate):
         values = []  # the function values the model
@@ -155,7 +154,7 @@ def _estimate_param_scan_worker(estimator, params, X, evaluate, evaluate_args,
             # evaluate
             try:
                 # try calling method/property/attribute
-                value = _call_member(model, name, args=args)
+                value = _call_member(estimator.model, name, args=args)
             # couldn't find method/property/attribute
             except AttributeError as e:
                 if failfast:
@@ -334,8 +333,8 @@ class Estimator(_BaseEstimator, Loggable):
 
         Returns
         -------
-        model : object
-            The estimated model.
+        estimator : object
+            The estimated estimator with the model being available.
 
         """
         # set params
@@ -343,7 +342,7 @@ class Estimator(_BaseEstimator, Loggable):
             self.set_params(**params)
         self._model = self._estimate(X)
         self._estimated = True
-        return self._model
+        return self
 
     def _estimate(self, X):
         raise NotImplementedError(
@@ -359,11 +358,12 @@ class Estimator(_BaseEstimator, Loggable):
 
         Returns
         -------
-        model : object
-            The estimated model.
+        estimator : object
+            The estimator (self) with estimated model.
 
         """
-        return self.estimate(X)
+        self.estimate(X)
+        return self
 
     @property
     def model(self):

--- a/pyemma/_ext/sklearn/base.py
+++ b/pyemma/_ext/sklearn/base.py
@@ -432,10 +432,12 @@ class TransformerMixin(object):
         # method is possible for a given clustering algorithm
         if y is None:
             # fit method of arity 1 (unsupervised transformation)
-            return self.fit(X, **fit_params).transform(X)
+            self.fit(X, **fit_params)
+            return self.transform(X)
         else:
             # fit method of arity 2 (supervised transformation)
-            return self.fit(X, y, **fit_params).transform(X)
+            self.fit(X, y, **fit_params)
+            return self.transform(X)
 
 
 ###############################################################################

--- a/pyemma/_ext/sklearn/base.py
+++ b/pyemma/_ext/sklearn/base.py
@@ -432,12 +432,10 @@ class TransformerMixin(object):
         # method is possible for a given clustering algorithm
         if y is None:
             # fit method of arity 1 (unsupervised transformation)
-            self.fit(X, **fit_params)
-            return self.transform(X)
+            return self.fit(X, **fit_params).transform(X)
         else:
             # fit method of arity 2 (supervised transformation)
-            self.fit(X, y, **fit_params)
-            return self.transform(X)
+            return self.fit(X, y, **fit_params).transform(X)
 
 
 ###############################################################################

--- a/pyemma/coordinates/tests/test_tica.py
+++ b/pyemma/coordinates/tests/test_tica.py
@@ -92,6 +92,15 @@ class TestTICA_Basic(unittest.TestCase):
         assert tica_obj.eigenvectors.dtype == np.float64
         assert tica_obj.eigenvalues.dtype == np.float64
 
+    def test_duplicated_data_in_fit_transform(self):
+        X = np.random.randn(100, 2)
+        d = DataInMemory([X, X])
+        tica = api.tica(data=d, lag=1, dim=1)
+        out1 = tica.get_output()
+        out2 = tica.fit_transform([X, X])
+        np.testing.assert_array_almost_equal(out1, out2)
+
+
     def test_singular_zeros(self):
         # make some data that has one column of all zeros
         X = np.random.randn(100, 2)

--- a/pyemma/coordinates/transform/transformer.py
+++ b/pyemma/coordinates/transform/transformer.py
@@ -178,11 +178,12 @@ class StreamingTransformer(Transformer, DataSource, NotifyOnChangesMixIn):
     def estimate(self, X, **kwargs):
         # TODO: X is either Iterable of an array
         if not isinstance(X, Iterable):
-            if isinstance(X, np.ndarray):
+            if isinstance(X, np.ndarray) or \
+                    (isinstance(X, (list, tuple)) and len(X) > 0 and all([isinstance(x, np.ndarray) for x in X])):
                 X = DataInMemory(X, self.chunksize)
                 self.data_producer = X
             else:
-                raise ValueError("no array given")
+                raise ValueError("no np.ndarray or non-empty list of np.ndarrays given")
 
         model = None
         # run estimation

--- a/pyemma/coordinates/transform/transformer.py
+++ b/pyemma/coordinates/transform/transformer.py
@@ -38,7 +38,7 @@ __all__ = ['Transformer', 'StreamingTransformer']
 __author__ = 'noe, marscher'
 
 
-class Transformer(six.with_metaclass(ABCMeta, Estimator, TransformerMixin)):
+class Transformer(six.with_metaclass(ABCMeta, TransformerMixin)):
     """ A transformer takes data and transforms it """
 
     @abstractmethod
@@ -106,7 +106,7 @@ class Transformer(six.with_metaclass(ABCMeta, Estimator, TransformerMixin)):
         pass
 
 
-class StreamingTransformer(Transformer, DataSource, NotifyOnChangesMixIn):
+class StreamingTransformer(Transformer, Estimator, DataSource, NotifyOnChangesMixIn):
 
     r""" Basis class for pipelined Transformers
 
@@ -176,7 +176,6 @@ class StreamingTransformer(Transformer, DataSource, NotifyOnChangesMixIn):
                                             return_trajindex=return_trajindex, cols=cols)
 
     def estimate(self, X, **kwargs):
-        # TODO: X is either Iterable of an array
         if not isinstance(X, Iterable):
             if isinstance(X, np.ndarray) or \
                     (isinstance(X, (list, tuple)) and len(X) > 0 and all([isinstance(x, np.ndarray) for x in X])):
@@ -185,10 +184,9 @@ class StreamingTransformer(Transformer, DataSource, NotifyOnChangesMixIn):
             else:
                 raise ValueError("no np.ndarray or non-empty list of np.ndarrays given")
 
-        model = None
         # run estimation
         try:
-            model = super(StreamingTransformer, self).estimate(X, **kwargs)
+            super(StreamingTransformer, self).estimate(X, **kwargs)
         except NotConvergedWarning as ncw:
             self._logger.info(
                 "Presumely finished estimation. Message: %s" % ncw)
@@ -199,7 +197,7 @@ class StreamingTransformer(Transformer, DataSource, NotifyOnChangesMixIn):
 
         self._estimated = True
 
-        return model
+        return self
 
     def get_output(self, dimensions=slice(0, None), stride=1, skip=0, chunk=0):
         if not self._estimated:


### PR DESCRIPTION
Changed the transformer to allow a list of ndarrays upon estimate call and added a test for that.

Also, changed the sklearn/base fit_transform implementation, such that transform gets called on self, rather on what estimate returns, as the returned value might be a model (that does not have a transform method). Or am I mixing something up here and the model should indeed have a transform method?

This should deal with issue #752.
