### PR TITLE
Bugfix in covariance computation.

### DIFF
--- a/pyemma/coordinates/estimators/covar/moments.py
+++ b/pyemma/coordinates/estimators/covar/moments.py
@@ -95,8 +95,6 @@ import math, sys, numbers
 import numpy as np
 from .covar_c import covartools
 
-__author__ = 'noe'
-
 
 def _is_zero(x):
     """ Returns True if x is numerically 0 or an array with 0's. """
@@ -187,8 +185,8 @@ def _sparsify_pair(X, Y, remove_mean=False, modify_data=False, symmetrize=False,
     Y0, mask_Y, yconst = _sparsify(Y, sparse_mode=sparse_mode, sparse_tol=sparse_tol)
     # if we have nonzero constant columns and the number of samples is too small, do not treat as
     # sparse, because then the const-specialized dot product function doesn't pay off.
-    is_const = not (_is_zero(xconst) and _is_zero(yconst))
-    if is_const and (symmetrize or not remove_mean) and 10*T < N:
+    # is_var = mask_X is None or mask_Y is None
+    if mask_X is None or mask_Y is None:  # removed clauses: (is_var or 10*T < N):  # (symmetrize or not remove_mean)
         return X, None, None, Y, None, None
     else:
         return X0, mask_X, xconst, Y0, mask_Y, yconst
@@ -428,12 +426,6 @@ def _M2_const(Xvar, mask_X, xvarsum, xconst, Yvar, mask_Y, yvarsum, yconst):
         Unnormalized covariance matrix.
 
     """
-    # check input
-    if mask_X is None:
-        mask_X = np.ones(Xvar.shape[1], dtype=np.bool)
-    elif mask_Y is None:
-        mask_Y = np.ones(Yvar.shape[1], dtype=np.bool)
-
     C = np.zeros((len(mask_X), len(mask_Y)))
     # Block 11
     C[np.ix_(mask_X, mask_Y)] = np.dot(Xvar.T, Yvar)

--- a/pyemma/coordinates/estimators/covar/running_moments.py
+++ b/pyemma/coordinates/estimators/covar/running_moments.py
@@ -172,6 +172,15 @@ class RunningCovar(object):
     symmetrize : bool
         Use symmetric estimates with sum defined by sum_t x_t + y_t and
         second moment matrices defined by X'X + Y'Y and Y'X + X'Y.
+    modify_data : bool
+        If remove_mean=True, the mean will be removed in the input data,
+        without creating an independent copy. This option is faster but should
+        only be selected if the input data is not used elsewhere.
+    sparse_mode : str
+        one of:
+            * 'dense' : always use dense mode
+            * 'sparse' : always use sparse mode if possible
+            * 'auto' : automatic
     nsave : int
         Depth of Moment storage. Moments computed from each chunk will be
         combined with Moments of similar statistical weight using the pairwise
@@ -185,8 +194,7 @@ class RunningCovar(object):
 
     # to get the Y mean, but this is currently not stored.
     def __init__(self, compute_XX=True, compute_XY=False, compute_YY=False,
-                 remove_mean=False, symmetrize=False,
-                 nsave=5):
+                 remove_mean=False, symmetrize=False, sparse_mode='auto', modify_data=False, nsave=5):
         # check input
         if not compute_XX and not compute_XY:
             raise ValueError('One of compute_XX or compute_XY must be True.')
@@ -207,6 +215,9 @@ class RunningCovar(object):
         # symmetry
         self.remove_mean = remove_mean
         self.symmetrize = symmetrize
+        # flags
+        self.sparse_mode = sparse_mode
+        self.modify_data = modify_data
 
     def add(self, X, Y=None):
         # check input
@@ -215,18 +226,21 @@ class RunningCovar(object):
             assert Y.shape[0] == T, 'X and Y must have equal length'
         # estimate and add to storage
         if self.compute_XX and not self.compute_XY:
-            w, s_X, C_XX = moments_XX(X, remove_mean=self.remove_mean)
+            w, s_X, C_XX = moments_XX(X, remove_mean=self.remove_mean,
+                                      sparse_mode=self.sparse_mode, modify_data=self.modify_data)
             self.storage_XX.store(Moments(w, s_X, s_X, C_XX))
         elif self.compute_XX and self.compute_XY:
             assert Y is not None
-            w, s_X, s_Y, C_XX, C_XY = moments_XXXY(X, Y, remove_mean=self.remove_mean, symmetrize=self.symmetrize)
+            w, s_X, s_Y, C_XX, C_XY = moments_XXXY(X, Y, remove_mean=self.remove_mean, symmetrize=self.symmetrize,
+                                                   sparse_mode=self.sparse_mode, modify_data=self.modify_data)
             # make copy in order to get independently mergeable moments
             self.storage_XX.store(Moments(w, s_X, s_X, C_XX))
             self.storage_XY.store(Moments(w, s_X, s_Y, C_XY))
         else:  # compute block
             assert Y is not None
             assert not self.symmetrize
-            w, s, C = moments_block(X, Y, remove_mean=self.remove_mean)
+            w, s, C = moments_block(X, Y, remove_mean=self.remove_mean,
+                                    sparse_mode=self.sparse_mode, modify_data=self.modify_data)
             # make copy in order to get independently mergeable moments
             self.storage_XX.store(Moments(w, s[0], s[0], C[0, 0]))
             self.storage_XY.store(Moments(w, s[0], s[1], C[0, 1]))
@@ -292,7 +306,8 @@ class RunningCovar(object):
         return self.storage_YY.moments.covar
 
 
-def running_covar(xx=True, xy=False, yy=False, remove_mean=False, symmetrize=False, nsave=5):
+def running_covar(xx=True, xy=False, yy=False, remove_mean=False, symmetrize=False,
+                  sparse_mode='auto', modify_data=False, nsave=5):
     """ Returns a running covariance estimator
 
     Returns an estimator object that can be fed chunks of X and Y data, and
@@ -312,6 +327,15 @@ def running_covar(xx=True, xy=False, yy=False, remove_mean=False, symmetrize=Fal
     symmetrize : bool
         Use symmetric estimates with sum defined by sum_t x_t + y_t and
         second moment matrices defined by X'X + Y'Y and Y'X + X'Y.
+    modify_data : bool
+        If remove_mean=True, the mean will be removed in the input data,
+        without creating an independent copy. This option is faster but should
+        only be selected if the input data is not used elsewhere.
+    sparse_mode : str
+        one of:
+            * 'dense' : always use dense mode
+            * 'sparse' : always use sparse mode if possible
+            * 'auto' : automatic
     nsave : int
         Depth of Moment storage. Moments computed from each chunk will be
         combined with Moments of similar statistical weight using the pairwise
@@ -322,5 +346,5 @@ def running_covar(xx=True, xy=False, yy=False, remove_mean=False, symmetrize=Fal
     .. [1] http://i.stanford.edu/pub/cstr/reports/cs/tr/79/773/CS-TR-79-773.pdf
 
     """
-    return RunningCovar(compute_XX=xx, compute_XY=xy, compute_YY=yy,
-                        remove_mean=remove_mean, symmetrize=symmetrize, nsave=nsave)
+    return RunningCovar(compute_XX=xx, compute_XY=xy, compute_YY=yy, remove_mean=remove_mean,
+                        symmetrize=symmetrize, sparse_mode=sparse_mode, modify_data=modify_data, nsave=nsave)

--- a/pyemma/util/log.py
+++ b/pyemma/util/log.py
@@ -106,9 +106,10 @@ def setupLogging(config):
         # gracefully shutdown logging system
         logging.shutdown()
         for f in log_files:
-            if f is not None and os.path.exists(f) and os.stat(f).st_size == 0:
+            if f is not None and os.path.exists(f):
                 try:
-                    os.remove(f)
+                    if os.stat(f).st_size == 0:
+                        os.remove(f)
                 except OSError as o:
                     print("during removal of empty logfiles there was a problem: ", o)
 


### PR DESCRIPTION
- [coordinates.estimators.covar]: bugfix in covar of data with mixed sparsity
- logfile fix that avoids a test suite error on _some_ MacOS (this was not a problem on Travis)
