### PR TITLE
[travis] disable git submodules (we dont do anything with it right now).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: c 
+git:
+  submodules: false
 os:
  - linux
  - osx


### PR DESCRIPTION
At least on OSX it takes very long (5min) to clone the sub module. Since we do not use it at the moment - disable it.
