### PR TITLE
[msm] use Ipython's ShimModule approach to warn upon access of a moved module.

### DIFF
--- a/pyemma/msm/__init__.py
+++ b/pyemma/msm/__init__.py
@@ -91,12 +91,12 @@ from __future__ import absolute_import as _
 # backward compatibility to PyEMMA 1.2.x
 # TODO: finally remove this stuff...
 import warnings as _warnings
-from pyemma.util._ext.shimmodule import ShimWarning as _ShimWarning
+from pyemma.util.exceptions import PyEMMA_DeprecationWarning as _dep_warning
 with _warnings.catch_warnings():
-    _warnings.filterwarnings('ignore', category=_ShimWarning)
+    _warnings.filterwarnings('ignore', category=_dep_warning)
     from . import analysis, estimation, generation, dtraj, flux
 io = dtraj
-del _warnings, _ShimWarning
+del _warnings, _dep_warning
 ######################################################
 from msmtools.analysis.dense.pcca import PCCA
 

--- a/pyemma/msm/__init__.py
+++ b/pyemma/msm/__init__.py
@@ -84,14 +84,21 @@ Low-level functions for estimation and analysis of transition matrices and io.
    msm.flux
 
 """
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import as _
 
 #####################################################
 # Low-level MSM functions (imported from msmtools)
 # backward compatibility to PyEMMA 1.2.x
-from msmtools import analysis, estimation, generation, dtraj, flux
-from msmtools.analysis.dense.pcca import PCCA
+# TODO: finally remove this stuff...
+import warnings as _warnings
+from pyemma.util._ext.shimmodule import ShimWarning as _ShimWarning
+with _warnings.catch_warnings():
+    _warnings.filterwarnings('ignore', category=_ShimWarning)
+    from . import analysis, estimation, generation, dtraj, flux
 io = dtraj
+del _warnings, _ShimWarning
+######################################################
+from msmtools.analysis.dense.pcca import PCCA
 
 #####################################################
 # Estimators and models

--- a/pyemma/msm/analysis/__init__.py
+++ b/pyemma/msm/analysis/__init__.py
@@ -1,0 +1,11 @@
+import sys
+import warnings
+
+from pyemma.util._ext.shimmodule import ShimModule, ShimWarning
+
+warnings.warn("The pyemma.msm.analysis module has been deprecated. "
+              "You should import msmtools.analysis now.", ShimWarning)
+
+sys.modules['pyemma.msm.analysis'] = ShimModule(src='pyemma.msm.analysis', mirror='msmtools.analysis')
+
+from msmtools.analysis import *

--- a/pyemma/msm/analysis/__init__.py
+++ b/pyemma/msm/analysis/__init__.py
@@ -1,10 +1,11 @@
 import sys
 import warnings
 
-from pyemma.util._ext.shimmodule import ShimModule, ShimWarning
+from pyemma.util._ext.shimmodule import ShimModule
+from pyemma.util.exceptions import PyEMMA_DeprecationWarning
 
 warnings.warn("The pyemma.msm.analysis module has been deprecated. "
-              "You should import msmtools.analysis now.", ShimWarning)
+              "You should import msmtools.analysis now.", PyEMMA_DeprecationWarning)
 
 sys.modules['pyemma.msm.analysis'] = ShimModule(src='pyemma.msm.analysis', mirror='msmtools.analysis')
 

--- a/pyemma/msm/dtraj/__init__.py
+++ b/pyemma/msm/dtraj/__init__.py
@@ -1,12 +1,12 @@
 import sys
 import warnings
 
-from pyemma.util._ext.shimmodule import ShimModule, ShimWarning
+from pyemma.util._ext.shimmodule import ShimModule
+from pyemma.util.exceptions import PyEMMA_DeprecationWarning
 
 warnings.warn("The pyemma.msm.dtraj module has been deprecated. "
-              "You should import msmtools.dtraj now.", ShimWarning)
+              "You should import msmtools.dtraj now.", PyEMMA_DeprecationWarning)
 
 sys.modules['pyemma.msm.dtraj'] = ShimModule(src='pyemma.msm.dtraj', mirror='msmtools.dtraj')
 #sys.modules['pyemma.msm.io'] = sys.modules['pyemma.msm.dtraj']
 
-from msmtools.dtraj import *

--- a/pyemma/msm/dtraj/__init__.py
+++ b/pyemma/msm/dtraj/__init__.py
@@ -7,6 +7,6 @@ warnings.warn("The pyemma.msm.dtraj module has been deprecated. "
               "You should import msmtools.dtraj now.", ShimWarning)
 
 sys.modules['pyemma.msm.dtraj'] = ShimModule(src='pyemma.msm.dtraj', mirror='msmtools.dtraj')
-sys.modules['pyemma.msm.io'] = sys.modules['pyemma.msm.dtraj']
+#sys.modules['pyemma.msm.io'] = sys.modules['pyemma.msm.dtraj']
 
 from msmtools.dtraj import *

--- a/pyemma/msm/dtraj/__init__.py
+++ b/pyemma/msm/dtraj/__init__.py
@@ -1,0 +1,12 @@
+import sys
+import warnings
+
+from pyemma.util._ext.shimmodule import ShimModule, ShimWarning
+
+warnings.warn("The pyemma.msm.dtraj module has been deprecated. "
+              "You should import msmtools.dtraj now.", ShimWarning)
+
+sys.modules['pyemma.msm.dtraj'] = ShimModule(src='pyemma.msm.dtraj', mirror='msmtools.dtraj')
+sys.modules['pyemma.msm.io'] = sys.modules['pyemma.msm.dtraj']
+
+from msmtools.dtraj import *

--- a/pyemma/msm/estimation/__init__.py
+++ b/pyemma/msm/estimation/__init__.py
@@ -1,11 +1,11 @@
 import sys
 import warnings
 
-from pyemma.util._ext.shimmodule import ShimModule, ShimWarning
+from pyemma.util._ext.shimmodule import ShimModule
+from pyemma.util.exceptions import PyEMMA_DeprecationWarning
 
 warnings.warn("The pyemma.msm.estimation module has been deprecated. "
-              "You should import msmtools.estimation now.", ShimWarning)
+              "You should import msmtools.estimation now.", PyEMMA_DeprecationWarning)
 
 sys.modules['pyemma.msm.estimation'] = ShimModule(src='pyemma.msm.estimation', mirror='msmtools.estimation')
 
-from msmtools.estimation import *

--- a/pyemma/msm/estimation/__init__.py
+++ b/pyemma/msm/estimation/__init__.py
@@ -1,0 +1,11 @@
+import sys
+import warnings
+
+from pyemma.util._ext.shimmodule import ShimModule, ShimWarning
+
+warnings.warn("The pyemma.msm.estimation module has been deprecated. "
+              "You should import msmtools.estimation now.", ShimWarning)
+
+sys.modules['pyemma.msm.estimation'] = ShimModule(src='pyemma.msm.estimation', mirror='msmtools.estimation')
+
+from msmtools.estimation import *

--- a/pyemma/msm/flux/__init__.py
+++ b/pyemma/msm/flux/__init__.py
@@ -1,11 +1,11 @@
 import sys
 import warnings
 
-from pyemma.util._ext.shimmodule import ShimModule, ShimWarning
+from pyemma.util._ext.shimmodule import ShimModule
+from pyemma.util.exceptions import PyEMMA_DeprecationWarning
 
 warnings.warn("The pyemma.msm.flux module has been deprecated. "
-              "You should import msmtools.flux now.", ShimWarning)
+              "You should import msmtools.flux now.", PyEMMA_DeprecationWarning)
 
 sys.modules['pyemma.msm.flux'] = ShimModule(src='pyemma.msm.flux', mirror='msmtools.flux')
 
-from msmtools.flux import *

--- a/pyemma/msm/flux/__init__.py
+++ b/pyemma/msm/flux/__init__.py
@@ -1,0 +1,11 @@
+import sys
+import warnings
+
+from pyemma.util._ext.shimmodule import ShimModule, ShimWarning
+
+warnings.warn("The pyemma.msm.flux module has been deprecated. "
+              "You should import msmtools.flux now.", ShimWarning)
+
+sys.modules['pyemma.msm.flux'] = ShimModule(src='pyemma.msm.flux', mirror='msmtools.flux')
+
+from msmtools.flux import *

--- a/pyemma/msm/generation/__init__.py
+++ b/pyemma/msm/generation/__init__.py
@@ -1,0 +1,11 @@
+import sys
+import warnings
+
+from pyemma.util._ext.shimmodule import ShimModule, ShimWarning
+
+warnings.warn("The pyemma.msm.generation module has been deprecated. "
+              "You should import msmtools.generation now.", ShimWarning)
+
+sys.modules['pyemma.msm.generation'] = ShimModule(src='pyemma.msm.generation', mirror='msmtools.generation')
+
+from msmtools.generation import *

--- a/pyemma/msm/generation/__init__.py
+++ b/pyemma/msm/generation/__init__.py
@@ -1,11 +1,11 @@
 import sys
 import warnings
 
-from pyemma.util._ext.shimmodule import ShimModule, ShimWarning
+from pyemma.util._ext.shimmodule import ShimModule
+from pyemma.util.exceptions import PyEMMA_DeprecationWarning
 
 warnings.warn("The pyemma.msm.generation module has been deprecated. "
-              "You should import msmtools.generation now.", ShimWarning)
+              "You should import msmtools.generation now.", PyEMMA_DeprecationWarning)
 
 sys.modules['pyemma.msm.generation'] = ShimModule(src='pyemma.msm.generation', mirror='msmtools.generation')
 
-from msmtools.generation import *

--- a/pyemma/msm/tests/test_msm_lowlevel_deprecation.py
+++ b/pyemma/msm/tests/test_msm_lowlevel_deprecation.py
@@ -12,6 +12,8 @@ class TestMSMSimple(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.old_filters = warnings.filters[:]
+        if sys.version_info.major == 2:
+            warnings.filters = []
 
     @classmethod
     def tearDownClass(cls):

--- a/pyemma/msm/tests/test_msm_lowlevel_deprecation.py
+++ b/pyemma/msm/tests/test_msm_lowlevel_deprecation.py
@@ -5,6 +5,7 @@ import mock
 import sys
 
 import pyemma
+from pyemma.util.exceptions import PyEMMA_DeprecationWarning
 
 
 class TestMSMSimple(unittest.TestCase):
@@ -26,12 +27,15 @@ class TestMSMSimple(unittest.TestCase):
             analysis.is_transition_matrix
 
         self.assertEqual(len(cm), 1)
+        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
         self.assertIn('analysis', cm[0].message.args[0])
 
         with warnings.catch_warnings(record=True) as cm:
             warnings.simplefilter("always")
             pyemma.msm.analysis.is_transition_matrix
         self.assertEqual(len(cm), 1)
+        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
+        self.assert
         self.assertIn('analysis', cm[0].message.args[0])
 
     def test_warn_was_called(self):
@@ -49,12 +53,14 @@ class TestMSMSimple(unittest.TestCase):
             estimation.count_matrix
 
         self.assertEqual(len(cm), 1)
+        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
         self.assertIn('estimation', cm[0].message.args[0])
 
         with warnings.catch_warnings(record=True) as cm:
             warnings.simplefilter("always")
             pyemma.msm.estimation.count_matrix
         self.assertEqual(len(cm), 1)
+        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
         self.assertIn('estimation', cm[0].message.args[0])
 
     def test_generation(self):
@@ -64,12 +70,14 @@ class TestMSMSimple(unittest.TestCase):
             generation.generate_traj
     
         self.assertEqual(len(cm), 1)
+        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
         self.assertIn('generation', cm[0].message.args[0])
     
         with warnings.catch_warnings(record=True) as cm:
             warnings.simplefilter("always")
             pyemma.msm.generation.generate_traj
         self.assertEqual(len(cm), 1)
+        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
         self.assertIn('generation', cm[0].message.args[0])
 
     def test_dtraj(self):
@@ -79,12 +87,14 @@ class TestMSMSimple(unittest.TestCase):
             dtraj.load_discrete_trajectory
     
         self.assertEqual(len(cm), 1)
+        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
         self.assertIn('dtraj', cm[0].message.args[0])
     
         with warnings.catch_warnings(record=True) as cm:
             warnings.simplefilter("always")
             pyemma.msm.dtraj.load_discrete_trajectory
         self.assertEqual(len(cm), 1)
+        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
         self.assertIn('dtraj', cm[0].message.args[0])
 
     def test_io(self):
@@ -94,12 +104,14 @@ class TestMSMSimple(unittest.TestCase):
             dtraj.load_discrete_trajectory
 
         self.assertEqual(len(cm), 1)
+        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
         self.assertIn('dtraj', cm[0].message.args[0])
 
         with warnings.catch_warnings(record=True) as cm:
             warnings.simplefilter("always")
             pyemma.msm.dtraj.load_discrete_trajectory
         self.assertEqual(len(cm), 1)
+        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
         self.assertIn('dtraj', cm[0].message.args[0])
 
     def test_flux(self):
@@ -109,10 +121,12 @@ class TestMSMSimple(unittest.TestCase):
             flux.total_flux
     
         self.assertEqual(len(cm), 1)
+        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
         self.assertIn('flux', cm[0].message.args[0])
     
         with warnings.catch_warnings(record=True) as cm:
             warnings.simplefilter("always")
             pyemma.msm.flux.total_flux
         self.assertEqual(len(cm), 1)
+        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
         self.assertIn('flux', cm[0].message.args[0])

--- a/pyemma/msm/tests/test_msm_lowlevel_deprecation.py
+++ b/pyemma/msm/tests/test_msm_lowlevel_deprecation.py
@@ -8,7 +8,7 @@ import pyemma
 from pyemma.util.exceptions import PyEMMA_DeprecationWarning
 
 
-
+@unittest.skipIf(sys.version_info.major == 2, "disabled on py2 for nosetest stupidness")
 class TestShowDeprecationWarningOnLowLevelAPIUsage(unittest.TestCase):
 
     @classmethod

--- a/pyemma/msm/tests/test_msm_lowlevel_deprecation.py
+++ b/pyemma/msm/tests/test_msm_lowlevel_deprecation.py
@@ -1,0 +1,96 @@
+import unittest
+import warnings
+import pyemma
+
+
+class TestMSMSimple(unittest.TestCase):
+
+    def test_analysis(self):
+        with warnings.catch_warnings(record=True) as cm:
+            warnings.simplefilter("always")
+            from pyemma.msm import analysis
+            analysis.is_transition_matrix
+
+        self.assertEqual(len(cm), 1)
+        self.assertIn('analysis', cm[0].message.args[0])
+
+        with warnings.catch_warnings(record=True) as cm:
+            warnings.simplefilter("always")
+            pyemma.msm.analysis.is_transition_matrix
+        self.assertEqual(len(cm), 1)
+        self.assertIn('analysis', cm[0].message.args[0])
+
+    def test_estimation(self):
+        with warnings.catch_warnings(record=True) as cm:
+            warnings.simplefilter("always")
+            from pyemma.msm import estimation
+            estimation.count_matrix
+
+        self.assertEqual(len(cm), 1)
+        self.assertIn('estimation', cm[0].message.args[0])
+
+        with warnings.catch_warnings(record=True) as cm:
+            warnings.simplefilter("always")
+            pyemma.msm.estimation.count_matrix
+        self.assertEqual(len(cm), 1)
+        self.assertIn('estimation', cm[0].message.args[0])
+
+    def test_generation(self):
+        with warnings.catch_warnings(record=True) as cm:
+            warnings.simplefilter("always")
+            from pyemma.msm import generation
+            generation.generate_traj
+    
+        self.assertEqual(len(cm), 1)
+        self.assertIn('generation', cm[0].message.args[0])
+    
+        with warnings.catch_warnings(record=True) as cm:
+            warnings.simplefilter("always")
+            pyemma.msm.generation.generate_traj
+        self.assertEqual(len(cm), 1)
+        self.assertIn('generation', cm[0].message.args[0])
+
+    def test_dtraj(self):
+        with warnings.catch_warnings(record=True) as cm:
+            warnings.simplefilter("always")
+            from pyemma.msm import dtraj
+            dtraj.load_discrete_trajectory
+    
+        self.assertEqual(len(cm), 1)
+        self.assertIn('dtraj', cm[0].message.args[0])
+    
+        with warnings.catch_warnings(record=True) as cm:
+            warnings.simplefilter("always")
+            pyemma.msm.dtraj.load_discrete_trajectory
+        self.assertEqual(len(cm), 1)
+        self.assertIn('dtraj', cm[0].message.args[0])
+
+    def test_io(self):
+        with warnings.catch_warnings(record=True) as cm:
+            warnings.simplefilter("always")
+            from pyemma.msm import io as dtraj
+            dtraj.load_discrete_trajectory
+
+        self.assertEqual(len(cm), 1)
+        self.assertIn('dtraj', cm[0].message.args[0])
+
+        with warnings.catch_warnings(record=True) as cm:
+            warnings.simplefilter("always")
+            pyemma.msm.dtraj.load_discrete_trajectory
+        self.assertEqual(len(cm), 1)
+        self.assertIn('dtraj', cm[0].message.args[0])
+
+    def test_flux(self):
+        with warnings.catch_warnings(record=True) as cm:
+            warnings.simplefilter("always")
+            from pyemma.msm import flux
+            flux.total_flux
+    
+        self.assertEqual(len(cm), 1)
+        self.assertIn('flux', cm[0].message.args[0])
+    
+        with warnings.catch_warnings(record=True) as cm:
+            warnings.simplefilter("always")
+            pyemma.msm.flux.total_flux
+        self.assertEqual(len(cm), 1)
+        self.assertIn('flux', cm[0].message.args[0])

--- a/pyemma/msm/tests/test_msm_lowlevel_deprecation.py
+++ b/pyemma/msm/tests/test_msm_lowlevel_deprecation.py
@@ -8,6 +8,9 @@ import pyemma
 
 
 class TestMSMSimple(unittest.TestCase):
+    def setUpClass(cls):
+        import logging
+        logging.getLogger('pyemma').info("warning filters: %s" % warnings.filters)
 
     def test_analysis(self):
         with warnings.catch_warnings(record=True) as cm:

--- a/pyemma/msm/tests/test_msm_lowlevel_deprecation.py
+++ b/pyemma/msm/tests/test_msm_lowlevel_deprecation.py
@@ -27,17 +27,16 @@ class TestMSMSimple(unittest.TestCase):
             analysis.is_transition_matrix
 
         self.assertEqual(len(cm), 1)
-        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
         self.assertIn('analysis', cm[0].message.args[0])
 
         with warnings.catch_warnings(record=True) as cm:
             warnings.simplefilter("always")
             pyemma.msm.analysis.is_transition_matrix
         self.assertEqual(len(cm), 1)
-        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
-        self.assert
+        self.assertIsInstance(cm[0].message, PyEMMA_DeprecationWarning)
         self.assertIn('analysis', cm[0].message.args[0])
 
+    @unittest.skipIf(sys.version_info.major == 2, "not on py2")
     def test_warn_was_called(self):
         shim_mod = sys.modules['pyemma.msm.analysis']
         with mock.patch.object(shim_mod, '_warn') as m:
@@ -53,14 +52,16 @@ class TestMSMSimple(unittest.TestCase):
             estimation.count_matrix
 
         self.assertEqual(len(cm), 1)
-        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
+        self.assertIsInstance(cm[0].message, PyEMMA_DeprecationWarning)
+
         self.assertIn('estimation', cm[0].message.args[0])
 
         with warnings.catch_warnings(record=True) as cm:
             warnings.simplefilter("always")
             pyemma.msm.estimation.count_matrix
         self.assertEqual(len(cm), 1)
-        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
+        self.assertIsInstance(cm[0].message, PyEMMA_DeprecationWarning)
+
         self.assertIn('estimation', cm[0].message.args[0])
 
     def test_generation(self):
@@ -70,14 +71,16 @@ class TestMSMSimple(unittest.TestCase):
             generation.generate_traj
     
         self.assertEqual(len(cm), 1)
-        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
+        self.assertIsInstance(cm[0].message, PyEMMA_DeprecationWarning)
+
         self.assertIn('generation', cm[0].message.args[0])
     
         with warnings.catch_warnings(record=True) as cm:
             warnings.simplefilter("always")
             pyemma.msm.generation.generate_traj
         self.assertEqual(len(cm), 1)
-        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
+        self.assertIsInstance(cm[0].message, PyEMMA_DeprecationWarning)
+
         self.assertIn('generation', cm[0].message.args[0])
 
     def test_dtraj(self):
@@ -87,14 +90,16 @@ class TestMSMSimple(unittest.TestCase):
             dtraj.load_discrete_trajectory
     
         self.assertEqual(len(cm), 1)
-        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
+        self.assertIsInstance(cm[0].message, PyEMMA_DeprecationWarning)
+
         self.assertIn('dtraj', cm[0].message.args[0])
     
         with warnings.catch_warnings(record=True) as cm:
             warnings.simplefilter("always")
             pyemma.msm.dtraj.load_discrete_trajectory
         self.assertEqual(len(cm), 1)
-        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
+        self.assertIsInstance(cm[0].message, PyEMMA_DeprecationWarning)
+
         self.assertIn('dtraj', cm[0].message.args[0])
 
     def test_io(self):
@@ -104,14 +109,16 @@ class TestMSMSimple(unittest.TestCase):
             dtraj.load_discrete_trajectory
 
         self.assertEqual(len(cm), 1)
-        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
+        self.assertIsInstance(cm[0].message, PyEMMA_DeprecationWarning)
+
         self.assertIn('dtraj', cm[0].message.args[0])
 
         with warnings.catch_warnings(record=True) as cm:
             warnings.simplefilter("always")
             pyemma.msm.dtraj.load_discrete_trajectory
         self.assertEqual(len(cm), 1)
-        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
+        self.assertIsInstance(cm[0].message, PyEMMA_DeprecationWarning)
+
         self.assertIn('dtraj', cm[0].message.args[0])
 
     def test_flux(self):
@@ -121,12 +128,14 @@ class TestMSMSimple(unittest.TestCase):
             flux.total_flux
     
         self.assertEqual(len(cm), 1)
-        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
+        self.assertIsInstance(cm[0].message, PyEMMA_DeprecationWarning)
+
         self.assertIn('flux', cm[0].message.args[0])
     
         with warnings.catch_warnings(record=True) as cm:
             warnings.simplefilter("always")
             pyemma.msm.flux.total_flux
         self.assertEqual(len(cm), 1)
-        self.assertTrue(isinstance(cm[0], PyEMMA_DeprecationWarning))
+        self.assertIsInstance(cm[0].message, PyEMMA_DeprecationWarning)
+
         self.assertIn('flux', cm[0].message.args[0])

--- a/pyemma/msm/tests/test_msm_lowlevel_deprecation.py
+++ b/pyemma/msm/tests/test_msm_lowlevel_deprecation.py
@@ -8,6 +8,8 @@ import pyemma
 
 
 class TestMSMSimple(unittest.TestCase):
+
+    @classmethod
     def setUpClass(cls):
         import logging
         logging.getLogger('pyemma').info("warning filters: %s" % warnings.filters)

--- a/pyemma/msm/tests/test_msm_lowlevel_deprecation.py
+++ b/pyemma/msm/tests/test_msm_lowlevel_deprecation.py
@@ -11,8 +11,11 @@ class TestMSMSimple(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        import logging
-        logging.getLogger('pyemma').info("warning filters: %s" % warnings.filters)
+        cls.old_filters = warnings.filters[:]
+
+    @classmethod
+    def tearDownClass(cls):
+        warnings.filters = cls.old_filters
 
     def test_analysis(self):
         with warnings.catch_warnings(record=True) as cm:

--- a/pyemma/msm/tests/test_msm_lowlevel_deprecation.py
+++ b/pyemma/msm/tests/test_msm_lowlevel_deprecation.py
@@ -1,5 +1,9 @@
 import unittest
 import warnings
+
+import mock
+import sys
+
 import pyemma
 
 
@@ -19,6 +23,14 @@ class TestMSMSimple(unittest.TestCase):
             pyemma.msm.analysis.is_transition_matrix
         self.assertEqual(len(cm), 1)
         self.assertIn('analysis', cm[0].message.args[0])
+
+    def test_warn_was_called(self):
+        shim_mod = sys.modules['pyemma.msm.analysis']
+        with mock.patch.object(shim_mod, '_warn') as m:
+            from pyemma.msm import analysis
+            analysis.is_transition_matrix
+
+        m.assert_called_once()
 
     def test_estimation(self):
         with warnings.catch_warnings(record=True) as cm:

--- a/pyemma/msm/tests/test_msm_lowlevel_deprecation.py
+++ b/pyemma/msm/tests/test_msm_lowlevel_deprecation.py
@@ -1,14 +1,15 @@
+import sys
 import unittest
 import warnings
 
 import mock
-import sys
 
 import pyemma
 from pyemma.util.exceptions import PyEMMA_DeprecationWarning
 
 
-class TestMSMSimple(unittest.TestCase):
+
+class TestShowDeprecationWarningOnLowLevelAPIUsage(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):

--- a/pyemma/util/_ext/shimmodule.py
+++ b/pyemma/util/_ext/shimmodule.py
@@ -102,6 +102,7 @@ class ShimModule(types.ModuleType):
     @property
     def __spec__(self):
         """Don't produce __spec__ until requested"""
+        self._warn()
         return __import__(self._mirror).__spec__
 
     def __dir__(self):
@@ -111,8 +112,8 @@ class ShimModule(types.ModuleType):
     @property
     def __all__(self):
         """Ensure __all__ is always defined"""
+        self._warn()
         mod = __import__(self._mirror)
-        #self._warn()
         try:
             return mod.__all__
         except AttributeError:
@@ -129,4 +130,5 @@ class ShimModule(types.ModuleType):
             raise AttributeError(key)
 
     def _warn(self):
-        warnings.warn(self.msg if self.msg else self.default_msg, ShimWarning)
+        from pyemma.util.exceptions import PyEMMA_DeprecationWarning
+        warnings.warn(self.msg if self.msg else self.default_msg, PyEMMA_DeprecationWarning)

--- a/pyemma/util/_ext/shimmodule.py
+++ b/pyemma/util/_ext/shimmodule.py
@@ -37,10 +37,6 @@ def import_item(name):
         return __import__(parts[0])
 
 
-class ShimWarning(Warning):
-    """A warning to show when a module has moved, and a shim is in its place."""
-
-
 class ShimImporter(object):
     """Import hook for a shim.
 
@@ -131,4 +127,5 @@ class ShimModule(types.ModuleType):
 
     def _warn(self):
         from pyemma.util.exceptions import PyEMMA_DeprecationWarning
-        warnings.warn(self.msg if self.msg else self.default_msg, PyEMMA_DeprecationWarning)
+        warnings.warn(self.msg if self.msg else self.default_msg,
+                      category=PyEMMA_DeprecationWarning)

--- a/pyemma/util/_ext/shimmodule.py
+++ b/pyemma/util/_ext/shimmodule.py
@@ -1,0 +1,132 @@
+"""A shim module for deprecated imports
+"""
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+
+import sys
+import types
+import warnings
+
+
+def import_item(name):
+    """Import and return ``bar`` given the string ``foo.bar``.
+    Calling ``bar = import_item("foo.bar")`` is the functional equivalent of
+    executing the code ``from foo import bar``.
+    Parameters
+    ----------
+    name : string
+      The fully qualified name of the module/package being imported.
+    Returns
+    -------
+    mod : module object
+       The module that was imported.
+    """
+
+    parts = name.rsplit('.', 1)
+    if len(parts) == 2:
+        # called with 'foo.bar....'
+        package, obj = parts
+        module = __import__(package, fromlist=[obj])
+        try:
+            pak = getattr(module, obj)
+        except AttributeError:
+            raise ImportError('No module named %s' % obj)
+        return pak
+    else:
+        # called with un-dotted string
+        return __import__(parts[0])
+
+
+class ShimWarning(Warning):
+    """A warning to show when a module has moved, and a shim is in its place."""
+
+
+class ShimImporter(object):
+    """Import hook for a shim.
+
+    This ensures that submodule imports return the real target module,
+    not a clone that will confuse `is` and `isinstance` checks.
+    """
+
+    def __init__(self, src, mirror):
+        self.src = src
+        self.mirror = mirror
+
+    def _mirror_name(self, fullname):
+        """get the name of the mirrored module"""
+
+        return self.mirror + fullname[len(self.src):]
+
+    def find_module(self, fullname, path=None):
+        """Return self if we should be used to import the module."""
+        if fullname.startswith(self.src + '.'):
+            mirror_name = self._mirror_name(fullname)
+            try:
+                mod = import_item(mirror_name)
+            except ImportError:
+                return
+            else:
+                if not isinstance(mod, types.ModuleType):
+                    # not a module
+                    return None
+                return self
+
+    def load_module(self, fullname):
+        """Import the mirrored module, and insert it into sys.modules"""
+        mirror_name = self._mirror_name(fullname)
+        mod = import_item(mirror_name)
+        sys.modules[fullname] = mod
+        return mod
+
+
+class ShimModule(types.ModuleType):
+    def __init__(self, *args, **kwargs):
+        self._mirror = kwargs.pop("mirror")
+        src = kwargs.pop("src", None)
+        if src:
+            kwargs['name'] = src.rsplit('.', 1)[-1]
+        super(ShimModule, self).__init__(*args, **kwargs)
+        # add import hook for descendent modules
+        if src:
+            sys.meta_path.append(
+                ShimImporter(src=src, mirror=self._mirror)
+            )
+        self.msg = kwargs.pop("msg", None)
+        self.default_msg = "Access to a moved module '%s' detected!" \
+                           " Please use '%s' in the future." % (src, self._mirror)
+
+    @property
+    def __path__(self):
+        return []
+
+    @property
+    def __spec__(self):
+        """Don't produce __spec__ until requested"""
+        return __import__(self._mirror).__spec__
+
+    def __dir__(self):
+        self._warn()
+        return dir(__import__(self._mirror))
+
+    @property
+    def __all__(self):
+        """Ensure __all__ is always defined"""
+        mod = __import__(self._mirror)
+        #self._warn()
+        try:
+            return mod.__all__
+        except AttributeError:
+            return [name for name in dir(mod) if not name.startswith('_')]
+
+    def __getattr__(self, key):
+        # Use the equivalent of import_item(name), see below
+        name = "%s.%s" % (self._mirror, key)
+        try:
+            item = import_item(name)
+            self._warn()
+            return item
+        except ImportError:
+            raise AttributeError(key)
+
+    def _warn(self):
+        warnings.warn(self.msg if self.msg else self.default_msg, ShimWarning)

--- a/pyemma/util/annotators.py
+++ b/pyemma/util/annotators.py
@@ -39,6 +39,8 @@ import warnings
 from decorator import decorator, decorate
 from inspect import stack
 
+from pyemma.util.exceptions import PyEMMA_DeprecationWarning
+
 __all__ = ['alias',
            'aliased',
            'deprecated',
@@ -213,7 +215,7 @@ def deprecated(*optional_message):
 
         warnings.warn_explicit(
             user_msg,
-            category=DeprecationWarning,
+            category=PyEMMA_DeprecationWarning,
             filename=filename,
             lineno=lineno
         )

--- a/pyemma/util/exceptions.py
+++ b/pyemma/util/exceptions.py
@@ -65,3 +65,8 @@ class ParserWarning(UserWarning):
 class ConfigDirectoryException(Exception):
     """ Some operation with PyEMMAs configuration directory went wrong. """
     pass
+
+
+class PyEMMA_DeprecationWarning(UserWarning):
+    """You are using a feature, which will be removed in a future release. You have been warned!"""
+    pass


### PR DESCRIPTION
This adresses #550. Remove those packages again in version 2.3

The user will get a "ShimWarning", when he/she tries to access an attribute from a moved module.
All msmtools sub-packages like analysis and estimation are now ShimModules, which redirects the functionality to the actual implementation, but print a warning upon doing so.

This way we can safely remove pyemma.msm.msmtools stuff in the next minor version. 
