### PR TITLE
Move msmtools.flux.ReactiveFlux to pyemma.msm.models

### DIFF
--- a/pyemma/msm/__init__.py
+++ b/pyemma/msm/__init__.py
@@ -90,7 +90,6 @@ from __future__ import absolute_import, print_function
 # Low-level MSM functions (imported from msmtools)
 # backward compatibility to PyEMMA 1.2.x
 from msmtools import analysis, estimation, generation, dtraj, flux
-from msmtools.flux import ReactiveFlux
 from msmtools.analysis.dense.pcca import PCCA
 io = dtraj
 
@@ -101,7 +100,7 @@ from .estimators import MaximumLikelihoodHMSM, BayesianHMSM
 from .estimators import ImpliedTimescales
 from .estimators import ChapmanKolmogorovValidator
 
-from .models import MSM, HMSM, SampledMSM, SampledHMSM
+from .models import MSM, HMSM, SampledMSM, SampledHMSM, ReactiveFlux
 
 # high-level api
 from .api import *

--- a/pyemma/msm/api.py
+++ b/pyemma/msm/api.py
@@ -27,7 +27,6 @@ from .estimators import BayesianHMSM as _Bayes_HMSM
 from .estimators import MaximumLikelihoodMSM as _ML_MSM
 from .estimators import ImpliedTimescales as _ImpliedTimescales
 
-from msmtools.flux import tpt as tpt_factory
 from .models import MSM
 from pyemma.util.annotators import shortcut
 from pyemma.util import types as _types
@@ -1199,9 +1198,7 @@ def bayesian_hidden_markov_model(dtrajs, nstates, lag, nsamples=100, reversible=
                                   dt_traj=dt_traj, conf=conf, store_hidden=store_hidden, show_progress=show_progress)
     return bhmsm_estimator.estimate(dtrajs)
 
-# TODO: need code examples
-#     Examples
-#     --------
+
 def tpt(msmobj, A, B):
     r""" A->B reactive flux from transition path theory (TPT)
 
@@ -1221,29 +1218,29 @@ def tpt(msmobj, A, B):
 
     Returns
     -------
-    tptobj : :class:`ReactiveFlux <msmtools.flux.ReactiveFlux>` object
+    tptobj : :class:`ReactiveFlux <pyemma.msm.reactive_flux.ReactiveFlux>` object
         An object containing the reactive A->B flux network
         and several additional quantities, such as the stationary probability,
         committors and set definitions.
 
     See also
     --------
-    :class:`ReactiveFlux <msmtools.flux.ReactiveFlux>`
-        Reactive Flux object
+    :class:`ReactiveFlux <pyemma.msm.reactive_flux.ReactiveFlux>`
+        Reactive Flux model
 
 
-    .. autoclass:: msmtools.flux.reactive_flux.ReactiveFlux
+    .. autoclass:: pyemma.msm.reactive_flux.ReactiveFlux
         :members:
         :undoc-members:
 
         .. rubric:: Methods
 
-        .. autoautosummary:: msmtools.flux.reactive_flux.ReactiveFlux
+        .. autoautosummary:: pyemma.msm.reactive_flux.ReactiveFlux
            :methods:
 
         .. rubric:: Attributes
 
-        .. autoautosummary:: msmtools.flux.reactive_flux.ReactiveFlux
+        .. autoautosummary:: pyemma.msm.reactive_flux.ReactiveFlux
             :attributes:
 
     References
@@ -1268,10 +1265,88 @@ def tpt(msmobj, A, B):
         from Short Off-Equilibrium Simulations.
         Proc. Natl. Acad. Sci. USA, 106, 19011-19016 (2009)
 
+
+    Computes the A->B reactive flux using transition path theory (TPT)
+
+    Parameters
+    ----------
+    T : (M, M) ndarray or scipy.sparse matrix
+        Transition matrix (default) or Rate matrix (if rate_matrix=True)
+    A : array_like
+        List of integer state labels for set A
+    B : array_like
+        List of integer state labels for set B
+    mu : (M,) ndarray (optional)
+        Stationary vector
+    qminus : (M,) ndarray (optional)
+        Backward committor for A->B reaction
+    qplus : (M,) ndarray (optional)
+        Forward committor for A-> B reaction
+    rate_matrix = False : boolean
+        By default (False), T is a transition matrix.
+        If set to True, T is a rate matrix.
+
+    Returns
+    -------
+    tpt: msmtools.flux.ReactiveFlux object
+        A python object containing the reactive A->B flux network
+        and several additional quantities, such as stationary probability,
+        committors and set definitions.
+
+    Notes
+    -----
+    The central object used in transition path theory is
+    the forward and backward comittor function.
+
+    TPT (originally introduced in [1]) for continous systems has a
+    discrete version outlined in [2]. Here, we use the transition
+    matrix formulation described in [3].
+
+    See also
+    --------
+    msmtools.analysis.committor, ReactiveFlux
+
+    References
+    ----------
+    .. [1] W. E and E. Vanden-Eijnden.
+        Towards a theory of transition paths.
+        J. Stat. Phys. 123: 503-523 (2006)
+    .. [2] P. Metzner, C. Schuette and E. Vanden-Eijnden.
+        Transition Path Theory for Markov Jump Processes.
+        Multiscale Model Simul 7: 1192-1219 (2009)
+    .. [3] F. Noe, Ch. Schuette, E. Vanden-Eijnden, L. Reich and T. Weikl:
+        Constructing the Full Ensemble of Folding Pathways from Short Off-Equilibrium Simulations.
+        Proc. Natl. Acad. Sci. USA, 106, 19011-19016 (2009)
+
     """
+    from msmtools.flux import flux_matrix, to_netflux
+    import msmtools.analysis as msmana
+
     T = msmobj.transition_matrix
     mu = msmobj.stationary_distribution
     A = _types.ensure_ndarray(A, kind='i')
     B = _types.ensure_ndarray(B, kind='i')
-    tptobj = tpt_factory(T, A, B, mu=mu)
-    return tptobj
+
+    if len(A) == 0 or len(B) == 0:
+        raise ValueError('set A or B is empty')
+    n = T.shape[0]
+    if len(A) > n or len(B) > n or max(A) > n or max(B) > n:
+        raise ValueError('set A or B defines more states, than given transition matrix.')
+
+    # forward committor
+    qplus = msmana.committor(T, A, B, forward=True)
+    # backward committor
+    if msmana.is_reversible(T, mu=mu):
+        qminus = 1.0 - qplus
+    else:
+        qminus = msmana.committor(T, A, B, forward=False, mu=mu)
+    # gross flux
+    grossflux = flux_matrix(T, mu, qminus, qplus, netflux=False)
+    # net flux
+    netflux = to_netflux(grossflux)
+
+    # construct flux object
+    from .models.reactive_flux import ReactiveFlux
+
+    F = ReactiveFlux(A, B, netflux, mu=mu, qminus=qminus, qplus=qplus, gross_flux=grossflux)
+    return F

--- a/pyemma/msm/models/__init__.py
+++ b/pyemma/msm/models/__init__.py
@@ -23,3 +23,4 @@ from .msm import MSM
 from .msm_sampled import SampledMSM
 from .hmsm import HMSM
 from .hmsm_sampled import SampledHMSM
+from .reactive_flux import ReactiveFlux

--- a/pyemma/msm/models/reactive_flux.py
+++ b/pyemma/msm/models/reactive_flux.py
@@ -1,0 +1,378 @@
+
+# This file is part of PyEMMA.
+#
+# Copyright (c) 2016, 2014 Computational Molecular Biology Group, Freie Universitaet Berlin (GER)
+#
+# MSMTools is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+r"""This module contains function for the Transition Path Theory (TPT)
+analysis of Markov models.
+
+__moduleauthor__ = "Benjamin Trendelkamp-Schroer, Frank Noe"
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+import numpy as np
+
+from msmtools import flux as tptapi
+from six.moves import range
+
+from pyemma._base.model import Model
+
+__all__ = ['ReactiveFlux']
+
+
+class ReactiveFlux(Model):
+    r"""A->B reactive flux from transition path theory (TPT)
+
+    This object describes a reactive flux, i.e. a network of fluxes from a set of source states A, to a set of
+    sink states B, via a set of intermediate nodes. Every node has three properties: the stationary probability mu,
+    the forward committor qplus and the backward committor qminus. Every pair of edges has the following properties:
+    a flux, generally a net flux that has no unnecessary back-fluxes, and optionally a gross flux.
+
+    Flux objects can be used to compute transition pathways (and their weights) from A to B, the total flux, the
+    total transition rate or mean first passage time, and they can be coarse-grained onto a set discretization
+    of the node set.
+
+    Fluxes can be computed in EMMA using transition path theory - see :func:`msmtools.tpt`
+
+    Parameters
+    ----------
+    A : array_like
+        List of integer state labels for set A
+    B : array_like
+        List of integer state labels for set B
+    flux : (n,n) ndarray or scipy sparse matrix
+        effective or net flux of A->B pathways
+    mu : (n,) ndarray (optional)
+        Stationary vector
+    qminus : (n,) ndarray (optional)
+        Backward committor for A->B reaction
+    qplus : (n,) ndarray (optional)
+        Forward committor for A-> B reaction
+    gross_flux : (n,n) ndarray or scipy sparse matrix
+        gross flux of A->B pathways, if available
+
+    Notes
+    -----
+    Reactive flux contains a flux network from educt states (A) to product states (B).
+
+    See also
+    --------
+    msmtools.tpt
+
+    """
+
+    def __init__(self, A, B, flux,
+                 mu=None, qminus=None, qplus=None, gross_flux=None):
+        # set data
+        self._A = A
+        self._B = B
+        self._flux = flux
+        self._mu = mu
+        self._qminus = qminus
+        self._qplus = qplus
+        self._gross_flux = gross_flux
+        # compute derived quantities:
+        self._totalflux = tptapi.total_flux(flux, A)
+        self._kAB = tptapi.rate(self._totalflux, mu, qminus)
+
+    @property
+    def nstates(self):
+        r"""Returns the number of states.
+
+        """
+        return np.shape(self._flux)[0]
+
+    @property
+    def A(self):
+        r"""Returns the set of reactant (source) states.
+
+        """
+        return self._A
+
+    @A.setter
+    def A(self, val):
+        self._A = val
+
+    @property
+    def B(self):
+        r"""Returns the set of product (target) states
+
+        """
+        return self._B
+
+    @B.setter
+    def B(self, val):
+        self._B = val
+
+    @property
+    def I(self):
+        r"""Returns the set of intermediate states
+
+        """
+        return list(set(range(self.nstates)) - set(self._A) - set(self._B))
+
+    @property
+    def stationary_distribution(self):
+        r"""Returns the stationary distribution
+        """
+        return self._mu
+
+    @property
+    def flux(self):
+        r"""Returns the effective or net flux
+        """
+        return self._flux
+
+    @property
+    def net_flux(self):
+        r"""Returns the effective or net flux
+        """
+        return self._flux
+
+    @property
+    def gross_flux(self):
+        r"""Returns the gross A-->B flux
+        """
+        return self._gross_flux
+
+    @property
+    def committor(self):
+        r"""Returns the forward committor probability
+        """
+        return self._qplus
+
+    @property
+    def forward_committor(self):
+        r"""Returns the forward committor probability
+        """
+        return self._qplus
+
+    @property
+    def backward_committor(self):
+        r"""Returns the backward committor probability
+        """
+        return self._qminus
+
+    @property
+    def total_flux(self):
+        r"""Returns the total flux
+        """
+        return self._totalflux
+
+    @property
+    def rate(self):
+        r"""Returns the rate (inverse mfpt) of A-->B transitions
+        """
+        return self._kAB
+
+    @property
+    def mfpt(self):
+        r"""Returns the rate (inverse mfpt) of A-->B transitions
+        """
+        return 1.0 / self._kAB
+
+    def pathways(self, fraction=1.0, maxiter=1000):
+        r"""Decompose flux network into dominant reaction paths.
+
+        Parameters
+        ----------
+        fraction : float, optional
+            Fraction of total flux to assemble in pathway decomposition
+        maxiter : int, optional
+            Maximum number of pathways for decomposition
+
+        Returns
+        -------
+        paths : list
+            List of dominant reaction pathways
+        capacities: list
+            List of capacities corresponding to each reactions pathway in paths
+
+        References
+        ----------
+        .. [1] P. Metzner, C. Schuette and E. Vanden-Eijnden.
+            Transition Path Theory for Markov Jump Processes.
+            Multiscale Model Simul 7: 1192-1219 (2009)
+
+        """
+        return tptapi.pathways(self.net_flux, self.A, self.B,
+                               fraction=fraction, maxiter=maxiter)
+
+    def _pathways_to_flux(self, paths, pathfluxes, n=None):
+        r"""Sums up the flux from the pathways given
+
+        Parameters
+        -----------
+        paths : list of int-arrays
+        list of pathways
+
+        pathfluxes : double-array
+            array with path fluxes
+
+        n : int
+            number of states. If not set, will be automatically determined.
+
+        Returns
+        -------
+        flux : (n,n) ndarray of float
+            the flux containing the summed path fluxes
+
+        """
+        if (n is None):
+            n = 0
+            for p in paths:
+                n = max(n, np.max(p))
+            n += 1
+
+        # initialize flux
+        F = np.zeros((n, n))
+        for i in range(len(paths)):
+            p = paths[i]
+            for t in range(len(p) - 1):
+                F[p[t], p[t + 1]] += pathfluxes[i]
+        return F
+
+    def major_flux(self, fraction=0.9):
+        r"""Returns the main pathway part of the net flux comprising
+        at most the requested fraction of the full flux.
+
+        """
+        (paths, pathfluxes) = self.pathways(fraction=fraction)
+        return self._pathways_to_flux(paths, pathfluxes, n=self.nstates)
+
+    # this will be a private function in tpt. only Parameter left will be the sets to be distinguished
+    def _compute_coarse_sets(self, user_sets):
+        r"""Computes the sets to coarse-grain the tpt flux to.
+
+        Parameters
+        ----------
+            (tpt_sets, A, B) with
+                tpt_sets : list of int-iterables
+                sets of states that shall be distinguished in the coarse-grained flux.
+            A : int-iterable
+                set indexes in A
+            B : int-iterable
+                set indexes in B
+
+        Returns
+        -------
+        sets : list of int-iterables
+            sets to compute tpt on. These sets still respect the boundary between
+            A, B and the intermediate tpt states.
+
+        Notes
+        -----
+        Given the sets that the user wants to distinguish, the
+        algorithm will create additional sets if necessary
+
+           * If states are missing in user_sets, they will be put into a
+            separate set
+           * If sets in user_sets are crossing the boundary between A, B and the
+             intermediates, they will be split at these boundaries. Thus each
+             set in user_sets can remain intact or be split into two or three
+             subsets
+
+        """
+        # set-ify everything
+        setA = set(self.A)
+        setB = set(self.B)
+        setI = set(self.I)
+        raw_sets = [set(user_set) for user_set in user_sets]
+
+        # anything missing? Compute all listed states
+        set_all = set(range(self.nstates))
+        set_all_user = []
+        for user_set in raw_sets:
+            set_all_user += user_set
+        set_all_user = set(set_all_user)
+        # ... and add all the unlisted states in a separate set
+        set_rest = set_all - set_all_user
+        if len(set_rest) > 0:
+            raw_sets.append(set_rest)
+
+        # split sets
+        Asets = []
+        Isets = []
+        Bsets = []
+        for raw_set in raw_sets:
+            s = raw_set.intersection(setA)
+            if len(s) > 0:
+                Asets.append(s)
+            s = raw_set.intersection(setI)
+            if len(s) > 0:
+                Isets.append(s)
+            s = raw_set.intersection(setB)
+            if len(s) > 0:
+                Bsets.append(s)
+        tpt_sets = Asets + Isets + Bsets
+        Aindexes = list(range(0, len(Asets)))
+        Bindexes = list(range(len(Asets) + len(Isets), len(tpt_sets)))
+
+        return (tpt_sets, Aindexes, Bindexes)
+
+    def coarse_grain(self, user_sets):
+        r"""Coarse-grains the flux onto user-defined sets.
+
+        Parameters
+        ----------
+        user_sets : list of int-iterables
+            sets of states that shall be distinguished in the coarse-grained flux.
+
+        Returns
+        -------
+        (sets, tpt) : (list of int-iterables, tpt-object)
+            sets contains the sets tpt is computed on. The tpt states of the new
+            tpt object correspond to these sets of states in this order. Sets might
+            be identical, if the user has already provided a complete partition that
+            respects the boundary between A, B and the intermediates. If not, Sets
+            will have more members than provided by the user, containing the
+            "remainder" states and reflecting the splitting at the A and B
+            boundaries.
+            tpt contains a new tpt object for the coarse-grained flux. All its
+            quantities (gross_flux, net_flux, A, B, committor, backward_committor)
+            are coarse-grained to sets.
+
+        Notes
+        -----
+        All user-specified sets will be split (if necessary) to
+        preserve the boundary between A, B and the intermediate
+        states.
+
+        """
+        # coarse-grain sets
+        (tpt_sets, Aindexes, Bindexes) = self._compute_coarse_sets(user_sets)
+        nnew = len(tpt_sets)
+
+        # coarse-grain fluxHere we should branch between sparse and dense implementations, but currently there is only a
+        F_coarse = tptapi.coarsegrain(self._gross_flux, tpt_sets)
+        Fnet_coarse = tptapi.to_netflux(F_coarse)
+
+        # coarse-grain stationary probability and committors - this can be done all dense
+        pstat_coarse = np.zeros((nnew))
+        forward_committor_coarse = np.zeros((nnew))
+        backward_committor_coarse = np.zeros((nnew))
+        for i in range(0, nnew):
+            I = list(tpt_sets[i])
+            muI = self._mu[I]
+            pstat_coarse[i] = np.sum(muI)
+            partialI = muI / pstat_coarse[i]  # normalized stationary probability over I
+            forward_committor_coarse[i] = np.dot(partialI, self._qplus[I])
+            backward_committor_coarse[i] = np.dot(partialI, self._qminus[I])
+
+        res = ReactiveFlux(Aindexes, Bindexes, Fnet_coarse, mu=pstat_coarse,
+                           qminus=backward_committor_coarse, qplus=forward_committor_coarse, gross_flux=F_coarse)
+        return (tpt_sets, res)

--- a/pyemma/msm/tests/test_reactive_flux.py
+++ b/pyemma/msm/tests/test_reactive_flux.py
@@ -1,0 +1,205 @@
+
+# This file is part of MSMTools.
+#
+# Copyright (c) 2015, 2014 Computational Molecular Biology Group, Freie Universitaet Berlin (GER)
+#
+# MSMTools is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+r"""Unit test for the ReactiveFlux object
+
+.. moduleauthor:: F.Noe <frank  DOT noe AT fu-berlin DOT de>
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+import unittest
+import numpy as np
+from msmtools.util.numeric import assert_allclose
+
+from msmtools.flux import api as msmapi
+import msmtools.analysis as msmana
+
+
+class TestReactiveFluxFunctions(unittest.TestCase):
+    def setUp(self):
+        # 5-state toy system
+        self.P = np.array([[0.8, 0.15, 0.05, 0.0, 0.0],
+                           [0.1, 0.75, 0.05, 0.05, 0.05],
+                           [0.05, 0.1, 0.8, 0.0, 0.05],
+                           [0.0, 0.2, 0.0, 0.8, 0.0],
+                           [0.0, 0.02, 0.02, 0.0, 0.96]])
+        self.A = [0]
+        self.B = [4]
+        self.I = [1, 2, 3]
+
+        # REFERENCE SOLUTION FOR PATH DECOMP
+        self.ref_committor = np.array([0., 0.35714286, 0.42857143, 0.35714286, 1.])
+        self.ref_backwardcommittor = np.array([1., 0.65384615, 0.53125, 0.65384615, 0.])
+        self.ref_grossflux = np.array([[0., 0.00771792, 0.00308717, 0., 0.],
+                                       [0., 0., 0.00308717, 0.00257264, 0.00720339],
+                                       [0., 0.00257264, 0., 0., 0.00360169],
+                                       [0., 0.00257264, 0., 0., 0.],
+                                       [0., 0., 0., 0., 0.]])
+        self.ref_netflux = np.array([[0.00000000e+00, 7.71791768e-03, 3.08716707e-03, 0.00000000e+00, 0.00000000e+00],
+                                     [0.00000000e+00, 0.00000000e+00, 5.14527845e-04, 0.00000000e+00, 7.20338983e-03],
+                                     [0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 3.60169492e-03],
+                                     [0.00000000e+00, 4.33680869e-19, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00],
+                                     [0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00, 0.00000000e+00]])
+        self.ref_totalflux = 0.0108050847458
+        self.ref_kAB = 0.0272727272727
+        self.ref_mfptAB = 36.6666666667
+
+        self.ref_paths = [[0, 1, 4], [0, 2, 4], [0, 1, 2, 4]]
+        self.ref_pathfluxes = np.array([0.00720338983051, 0.00308716707022, 0.000514527845036])
+        
+        self.ref_paths_95percent = [[0, 1, 4], [0, 2, 4]]
+        self.ref_pathfluxes_95percent = np.array([0.00720338983051, 0.00308716707022])
+        self.ref_majorflux_95percent = np.array([[0., 0.00720339, 0.00308717, 0., 0.],
+                                                 [0., 0., 0., 0., 0.00720339],
+                                                 [0., 0., 0., 0., 0.00308717],
+                                                 [0., 0., 0., 0., 0.],
+                                                 [0., 0., 0., 0., 0.]])
+
+        # Testing:
+        self.tpt1 = msmapi.tpt(self.P, self.A, self.B)
+
+        # 16-state toy system
+        P2_nonrev = np.array([[0.5, 0.2, 0.0, 0.0, 0.3, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                              [0.2, 0.5, 0.1, 0.0, 0.0, 0.2, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                              [0.0, 0.1, 0.5, 0.2, 0.0, 0.0, 0.2, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                              [0.0, 0.0, 0.1, 0.5, 0.0, 0.0, 0.0, 0.4, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                              [0.3, 0.0, 0.0, 0.0, 0.5, 0.1, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                              [0.0, 0.1, 0.0, 0.0, 0.2, 0.5, 0.1, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                              [0.0, 0.0, 0.1, 0.0, 0.0, 0.1, 0.5, 0.2, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0, 0.0],
+                              [0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.3, 0.5, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.0],
+                              [0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.0, 0.5, 0.1, 0.0, 0.0, 0.3, 0.0, 0.0, 0.0],
+                              [0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.2, 0.5, 0.1, 0.0, 0.0, 0.1, 0.0, 0.0],
+                              [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.1, 0.5, 0.1, 0.0, 0.0, 0.2, 0.0],
+                              [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.2, 0.5, 0.0, 0.0, 0.0, 0.2],
+                              [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.0, 0.0, 0.0, 0.5, 0.2, 0.0, 0.0],
+                              [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.0, 0.0, 0.3, 0.5, 0.1, 0.0],
+                              [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.2, 0.0, 0.0, 0.1, 0.5, 0.2],
+                              [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.3, 0.0, 0.0, 0.2, 0.5]])
+        pstat2_nonrev = msmana.statdist(P2_nonrev)
+        # make reversible
+        C = np.dot(np.diag(pstat2_nonrev), P2_nonrev)
+        Csym = C + C.T
+        self.P2 = Csym / np.sum(Csym, axis=1)[:, np.newaxis]
+        pstat2 = msmana.statdist(self.P2)
+        self.A2 = [0, 4]
+        self.B2 = [11, 15]
+        self.coarsesets2 = [[2, 3, 6, 7], [10, 11, 14, 15], [0, 1, 4, 5], [8, 9, 12, 13], ]
+
+        # REFERENCE SOLUTION CG
+        self.ref2_tpt_sets = [set([0, 4]), set([2, 3, 6, 7]), set([10, 14]), set([1, 5]), set([8, 9, 12, 13]),
+                              set([11, 15])]
+        self.ref2_cgA = [0]
+        self.ref2_cgI = [1, 2, 3, 4]
+        self.ref2_cgB = [5]
+        self.ref2_cgpstat = np.array([0.15995388, 0.18360442, 0.12990937, 0.11002342, 0.31928127, 0.09722765])
+        self.ref2_cgcommittor = np.array([0., 0.56060272, 0.73052426, 0.19770537, 0.36514272, 1.])
+        self.ref2_cgbackwardcommittor = np.array([1., 0.43939728, 0.26947574, 0.80229463, 0.63485728, 0.])
+        self.ref2_cggrossflux = np.array([[0., 0., 0., 0.00427986, 0.00282259, 0.],
+                                          [0., 0, 0.00234578, 0.00104307, 0., 0.00201899],
+                                          [0., 0.00113892, 0, 0., 0.00142583, 0.00508346],
+                                          [0., 0.00426892, 0., 0, 0.00190226, 0.],
+                                          [0., 0., 0.00530243, 0.00084825, 0, 0.],
+                                          [0., 0., 0., 0., 0., 0.]])
+        self.ref2_cgnetflux = np.array([[0., 0., 0., 0.00427986, 0.00282259, 0.],
+                                        [0., 0., 0.00120686, 0., 0., 0.00201899],
+                                        [0., 0., 0., 0., 0., 0.00508346],
+                                        [0., 0.00322585, 0., 0., 0.00105401, 0.],
+                                        [0., 0., 0.0038766, 0., 0., 0.],
+                                        [0., 0., 0., 0., 0., 0.]])
+
+        # Testing
+        self.tpt2 = msmapi.tpt(self.P2, self.A2, self.B2)
+
+
+    def test_nstates(self):
+        self.assertEqual(self.tpt1.nstates, np.shape(self.P)[0])
+
+    def test_A(self):
+        self.assertEqual(self.tpt1.A, self.A)
+
+    def test_I(self):
+        self.assertEqual(self.tpt1.I, self.I)
+
+    def test_B(self):
+        self.assertEqual(self.tpt1.B, self.B)
+
+    def test_flux(self):
+        assert_allclose(self.tpt1.flux, self.ref_netflux, rtol=1e-02, atol=1e-07)
+
+    def test_netflux(self):
+        assert_allclose(self.tpt1.net_flux, self.ref_netflux, rtol=1e-02, atol=1e-07)
+
+    def test_grossflux(self):
+        assert_allclose(self.tpt1.gross_flux, self.ref_grossflux, rtol=1e-02, atol=1e-07)
+
+    def test_committor(self):
+        assert_allclose(self.tpt1.committor, self.ref_committor, rtol=1e-02, atol=1e-07)
+
+    def test_forwardcommittor(self):
+        assert_allclose(self.tpt1.forward_committor, self.ref_committor, rtol=1e-02, atol=1e-07)
+
+    def test_backwardcommittor(self):
+        assert_allclose(self.tpt1.backward_committor, self.ref_backwardcommittor, rtol=1e-02, atol=1e-07)
+
+    def test_total_flux(self):
+        assert_allclose(self.tpt1.total_flux, self.ref_totalflux, rtol=1e-02, atol=1e-07)
+
+    def test_rate(self):
+        assert_allclose(self.tpt1.rate, self.ref_kAB, rtol=1e-02, atol=1e-07)
+        assert_allclose(1.0 / self.tpt1.rate, self.ref_mfptAB, rtol=1e-02, atol=1e-07)
+
+    """These tests are broken since the matrix is irreversible and no
+    pathway-decomposition can be computed for irreversible matrices"""
+    def test_pathways(self):
+        # all paths
+        (paths,pathfluxes) = self.tpt1.pathways()
+        self.assertEqual(len(paths), len(self.ref_paths))
+        for i in range(len(paths)):
+            self.assertTrue(np.all(np.array(paths[i]) == np.array(self.ref_paths[i])))
+        assert_allclose(pathfluxes, self.ref_pathfluxes, rtol=1e-02, atol=1e-07)
+        # major paths
+        (paths,pathfluxes) = self.tpt1.pathways(fraction = 0.95)
+        self.assertEqual(len(paths), len(self.ref_paths_95percent))
+        for i in range(len(paths)):
+            self.assertTrue(np.all(np.array(paths[i]) == np.array(self.ref_paths_95percent[i])))
+        assert_allclose(pathfluxes, self.ref_pathfluxes_95percent, rtol=1e-02, atol=1e-07)
+
+    def test_major_flux(self):
+        # all flux
+        assert_allclose(self.tpt1.major_flux(fraction=1.0), self.ref_netflux, rtol=1e-02, atol=1e-07)
+        # 0.99 flux
+        assert_allclose(self.tpt1.major_flux(fraction=0.95), self.ref_majorflux_95percent, rtol=1e-02, atol=1e-07)
+
+    def test_coarse_grain(self):
+        (tpt_sets, cgRF) = self.tpt2.coarse_grain(self.coarsesets2)
+        self.assertEqual(tpt_sets, self.ref2_tpt_sets)
+        self.assertEqual(cgRF.A, self.ref2_cgA)
+        self.assertEqual(cgRF.I, self.ref2_cgI)
+        self.assertEqual(cgRF.B, self.ref2_cgB)
+        assert_allclose(cgRF.stationary_distribution, self.ref2_cgpstat)
+        assert_allclose(cgRF.committor, self.ref2_cgcommittor)
+        assert_allclose(cgRF.forward_committor, self.ref2_cgcommittor)
+        assert_allclose(cgRF.backward_committor, self.ref2_cgbackwardcommittor)
+        assert_allclose(cgRF.flux, self.ref2_cgnetflux)
+        assert_allclose(cgRF.net_flux, self.ref2_cgnetflux)
+        assert_allclose(cgRF.gross_flux, self.ref2_cggrossflux)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyemma/msm/tests/test_reactive_flux.py
+++ b/pyemma/msm/tests/test_reactive_flux.py
@@ -25,20 +25,20 @@ from __future__ import absolute_import
 from __future__ import division
 import unittest
 import numpy as np
-from msmtools.util.numeric import assert_allclose
+from numpy.testing import assert_allclose
 
-from msmtools.flux import api as msmapi
+from pyemma import msm as msmapi
 import msmtools.analysis as msmana
 
 
 class TestReactiveFluxFunctions(unittest.TestCase):
     def setUp(self):
         # 5-state toy system
-        self.P = np.array([[0.8, 0.15, 0.05, 0.0, 0.0],
+        self.P = msmapi.MSM(np.array([[0.8, 0.15, 0.05, 0.0, 0.0],
                            [0.1, 0.75, 0.05, 0.05, 0.05],
                            [0.05, 0.1, 0.8, 0.0, 0.05],
                            [0.0, 0.2, 0.0, 0.8, 0.0],
-                           [0.0, 0.02, 0.02, 0.0, 0.96]])
+                           [0.0, 0.02, 0.02, 0.0, 0.96]]))
         self.A = [0]
         self.B = [4]
         self.I = [1, 2, 3]
@@ -95,8 +95,7 @@ class TestReactiveFluxFunctions(unittest.TestCase):
         # make reversible
         C = np.dot(np.diag(pstat2_nonrev), P2_nonrev)
         Csym = C + C.T
-        self.P2 = Csym / np.sum(Csym, axis=1)[:, np.newaxis]
-        pstat2 = msmana.statdist(self.P2)
+        self.P2 = msmapi.MSM(Csym / np.sum(Csym, axis=1)[:, np.newaxis])
         self.A2 = [0, 4]
         self.B2 = [11, 15]
         self.coarsesets2 = [[2, 3, 6, 7], [10, 11, 14, 15], [0, 1, 4, 5], [8, 9, 12, 13], ]
@@ -126,9 +125,8 @@ class TestReactiveFluxFunctions(unittest.TestCase):
         # Testing
         self.tpt2 = msmapi.tpt(self.P2, self.A2, self.B2)
 
-
     def test_nstates(self):
-        self.assertEqual(self.tpt1.nstates, np.shape(self.P)[0])
+        self.assertEqual(self.tpt1.nstates, self.P.nstates)
 
     def test_A(self):
         self.assertEqual(self.tpt1.A, self.A)
@@ -196,9 +194,9 @@ class TestReactiveFluxFunctions(unittest.TestCase):
         assert_allclose(cgRF.committor, self.ref2_cgcommittor)
         assert_allclose(cgRF.forward_committor, self.ref2_cgcommittor)
         assert_allclose(cgRF.backward_committor, self.ref2_cgbackwardcommittor)
-        assert_allclose(cgRF.flux, self.ref2_cgnetflux)
-        assert_allclose(cgRF.net_flux, self.ref2_cgnetflux)
-        assert_allclose(cgRF.gross_flux, self.ref2_cggrossflux)
+        assert_allclose(cgRF.flux, self.ref2_cgnetflux, rtol=1.e-5, atol=1.e-8)
+        assert_allclose(cgRF.net_flux, self.ref2_cgnetflux, rtol=1.e-5, atol=1.e-8)
+        assert_allclose(cgRF.gross_flux, self.ref2_cggrossflux, rtol=1.e-5, atol=1.e-8)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
see #416 

In a follow up we should then remove the ReactiveFlux class from msmtools?
