### PR TITLE
[reporter] allow to override description in force_finish

### DIFF
--- a/pyemma/_base/progress/reporter.py
+++ b/pyemma/_base/progress/reporter.py
@@ -191,7 +191,7 @@ class ProgressReporter(object):
             for callback in self._prog_rep_callbacks[stage]:
                 callback(stage, pg, **kw)
 
-    def _progress_force_finish(self, stage=0):
+    def _progress_force_finish(self, stage=0, description=None):
         """ forcefully finish the progress for given stage """
         if not self.show_progress:
             return
@@ -203,5 +203,11 @@ class ProgressReporter(object):
             return
         pg.numerator = pg.denominator
         pg._eta.eta_epoch = 0
-        _show_progressbar(pg, description=self._prog_rep_descriptions[stage])
+
+        if description is not None:
+            pg.description = description
+        else:
+            description = self._prog_rep_descriptions[stage]
+
+        _show_progressbar(pg, description=description)
         _hide_progressbar(pg)

--- a/pyemma/thermo/estimators/DTRAM_estimator.py
+++ b/pyemma/thermo/estimators/DTRAM_estimator.py
@@ -203,7 +203,7 @@ class DTRAM(_Estimator, _MEMM, _ProgressReporter):
                         therm_energies=self.therm_energies, conf_energies=self.conf_energies,
                         callback=_ConvergenceProgressIndicatorCallBack(
                             self, 'WHAM init.', self.init_maxiter, self.init_maxerr))
-                self._progress_force_finish(stage='WHAM init.')
+                self._progress_force_finish(stage='WHAM init.', description='WHAM init.')
 
         # run estimator
         self.therm_energies, self.conf_energies, self.log_lagrangian_mult, \
@@ -215,7 +215,7 @@ class DTRAM(_Estimator, _MEMM, _ProgressReporter):
                 save_convergence_info=self.save_convergence_info,
                 callback=_ConvergenceProgressIndicatorCallBack(
                     self, 'DTRAM', self.maxiter, self.maxerr))
-        self._progress_force_finish(stage='DTRAM')
+        self._progress_force_finish(stage='DTRAM', description='DTRAM')
 
         # compute models
         models = [_dtram.estimate_transition_matrix(

--- a/pyemma/thermo/estimators/TRAM_estimator.py
+++ b/pyemma/thermo/estimators/TRAM_estimator.py
@@ -246,7 +246,7 @@ class TRAM(_Estimator, _MEMM, _ProgressReporter):
                     callback=_ConvergenceProgressIndicatorCallBack(
                         self, 'MBAR init.', self.init_maxiter, self.init_maxerr),
                     n_conf_states=self.nstates_full)
-            self._progress_force_finish(stage='MBAR init.')
+            self._progress_force_finish(stage='MBAR init.', description='MBAR init.')
             self.biased_conf_energies = self.mbar_biased_conf_energies.copy()
 
         # run estimator
@@ -267,7 +267,7 @@ class TRAM(_Estimator, _MEMM, _ProgressReporter):
                 callback=_ConvergenceProgressIndicatorCallBack(
                     self, 'TRAM', self.maxiter, self.maxerr),
                 N_dtram_accelerations=self.N_dtram_accelerations)
-        self._progress_force_finish(stage='TRAM')
+        self._progress_force_finish(stage='TRAM', description='TRAM')
         self.btrajs = btrajs
 
         # compute models

--- a/pyemma/thermo/estimators/WHAM_estimator.py
+++ b/pyemma/thermo/estimators/WHAM_estimator.py
@@ -154,7 +154,7 @@ class WHAM(_Estimator, _MEMM, _ProgressReporter):
                 save_convergence_info=self.save_convergence_info,
                 callback=_ConvergenceProgressIndicatorCallBack(
                     self, 'WHAM', self.maxiter, self.maxerr))
-        self._progress_force_finish(stage='WHAM')
+        self._progress_force_finish(stage='WHAM', description='WHAM')
 
         # get stationary models
         models = [_StationaryModel(


### PR DESCRIPTION
discussed with @cwehmeyer 

The problem with custom templates introduced with thermotools v0.2 was that during forcefully finishing a progress the custom string format parameter could not been set via the interface. Now the force_finish method takes a pre-formatted string as optional argument.

This is a blocker for #798 (the tests there fail with the described problem).
