### PR TITLE
[conda-recipe] set version by git env variables exported by conda-build

### DIFF
--- a/devtools/conda-recipe/bld.bat
+++ b/devtools/conda-recipe/bld.bat
@@ -6,5 +6,4 @@ if not defined APPVEYOR (
     cmd /E:ON /V:ON /C %APPVEYOR_BUILD_FOLDER%\devtools\ci\appveyor\run_with_env.cmd "%PYTHON%" setup.py install
 )
 set build_status=%ERRORLEVEL%
-"%PYTHON%" devtools\conda-recipe\dev_version.py
 if %build_status% == 1 exit 1

--- a/devtools/conda-recipe/build.sh
+++ b/devtools/conda-recipe/build.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
 $PYTHON setup.py install
-$PYTHON devtools/conda-recipe/dev_version.py

--- a/devtools/conda-recipe/dev_version.py
+++ b/devtools/conda-recipe/dev_version.py
@@ -1,5 +1,0 @@
-from __future__ import print_function
-from pyemma import __version__ as version
-
-with open('__conda_version__.txt', 'w') as f:
-    f.write(version)

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pyemma-dev
-  #version: 0 
+  version: {{ environ.get('GIT_DESCRIBE_TAG','')+environ.get('GIT_BUILD_STR', 'unknown')[1:] }}
 source:
   path: ../..
 


### PR DESCRIPTION
This is needed since conda-build will deprecate the way we set the version currently.
