### PR TITLE
Chunksize in transformers

### DIFF
--- a/pyemma/coordinates/tests/test_tica.py
+++ b/pyemma/coordinates/tests/test_tica.py
@@ -33,6 +33,7 @@ from pyemma.coordinates import api
 
 from pyemma.coordinates.data.data_in_memory import DataInMemory
 from pyemma.coordinates import source, tica
+from pyemma.coordinates.transform import TICA as _internal_tica
 from pyemma.util.contexts import numpy_random_seed
 from logging import getLogger
 import pyemma.util.types as types
@@ -91,6 +92,12 @@ class TestTICA_Basic(unittest.TestCase):
 
         assert tica_obj.eigenvectors.dtype == np.float64
         assert tica_obj.eigenvalues.dtype == np.float64
+
+    def test_fit_transform(self):
+        X = np.random.randn(100, 2)
+        tica = _internal_tica(1, 1)
+        out = tica.fit_transform(X)
+        np.testing.assert_array_almost_equal(out, api.tica(data=X, lag=1, dim=1).get_output()[0])
 
     def test_duplicated_data_in_fit_transform(self):
         X = np.random.randn(100, 2)

--- a/pyemma/coordinates/transform/transformer.py
+++ b/pyemma/coordinates/transform/transformer.py
@@ -214,6 +214,8 @@ class StreamingTransformer(Transformer, Estimator, DataSource, NotifyOnChangesMi
     @property
     def chunksize(self):
         """chunksize defines how much data is being processed at once."""
+        if not self.data_producer:
+            return self._default_chunksize
         return self.data_producer.chunksize
 
     @chunksize.setter


### PR DESCRIPTION
Changed the behavior of the chunksize property in transformers, such that they return the `_default_chunksize` if no `data_producer` is given and added a test case for that. Should fix issue #830.
