### PR TITLE
[clustering] Fix minRMSD assignment.

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -9,6 +9,9 @@ Changelog
 
 **Fixes**:
 
+- clustering: fixed serious bug in **minRMSD** distance calculation, which led to
+  lots of empty clusters. The bug was introduced in version 2.1. If you used
+  this metric, please re-assign your trajectories. #825
 - clustering: fixed KMeans with minRMSD metric. #814
 
 2.2 (5-17-16)

--- a/pyemma/coordinates/tests/test_assign.py
+++ b/pyemma/coordinates/tests/test_assign.py
@@ -263,6 +263,23 @@ class TestClusterAssign(unittest.TestCase):
 
         np.testing.assert_equal(assignment_mp, assignment_sp)
 
+    def test_min_rmsd(self):
+        import pyemma.datasets as data
+        d = data.get_bpti_test_data()
+        reader = coor.source(d['trajs'], top=d['top'])
+
+        N_centers = 9
+        centers = np.asarray((reader.ra_itraj_jagged[0, [0, 1, 7]],
+                              reader.ra_itraj_jagged[1, [32, 1, 23]],
+                              reader.ra_itraj_jagged[2, [17, 8, 15]])
+                             ).reshape((N_centers, -1))
+        dtraj = coor.assign_to_centers(reader, centers=centers, metric='minRMSD', return_dtrajs=True)
+
+        num_assigned_states = len(np.unique(np.concatenate(dtraj)))
+        self.assertEqual(num_assigned_states, N_centers,
+                         "assigned states=%s out of %s possible ones."
+                         % (num_assigned_states, N_centers))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Since version 2.1 only the first center has been pre-centered correctly, while
the rest was ignored.

Fixes #835.
