### PR TITLE
Serialization add version interpolation

### DIFF
--- a/pyemma/_base/estimator.py
+++ b/pyemma/_base/estimator.py
@@ -381,7 +381,9 @@ class Estimator(_BaseEstimator, SerializableMixIn, Loggable):
                 'Model has not yet been estimated. Call estimate(X) or fit(X) first')
 
     def __getstate__(self):
+        parent_state = super(Estimator, self).__getstate__()
         res = self.get_params()
+        res.update(parent_state)
         # remember if it has been estimated.
         res['_estimated'] = self._estimated
         # if this estimator has been estimated, store the model.
@@ -393,6 +395,7 @@ class Estimator(_BaseEstimator, SerializableMixIn, Loggable):
             else:
                 res['model'] = self.model
         else:
+            # TODO: some classes rely on the fact that the model is not set (raises AttributeError), if not estimated yet.
             res['model'] = None
 
         return res

--- a/pyemma/_base/model.py
+++ b/pyemma/_base/model.py
@@ -103,7 +103,9 @@ class Model(SerializableMixIn):
 
     #  serialization protocol
     def __getstate__(self):
+        parent_state = SerializableMixIn.__getstate__(self)
         state = self.get_model_params()
+        state.update(parent_state)
         return state
 
     def __setstate__(self, state):

--- a/pyemma/_base/serialization/serialization.py
+++ b/pyemma/_base/serialization/serialization.py
@@ -171,28 +171,23 @@ class SerializableMixIn(object):
 
     def _set_state_from_serializeable_fields_and_state(self, state, klass):
         """ set only fields from state, which are present in klass._serialize_fields """
+        if '_serialize_version' not in state:
+            raise DeveloperError("your class should define a _serialize_version attribute")
 
-        if (state['_serialize_version'] < klass._serialize_version
-            and hasattr(self, '_serialize_interpolation_map')):
+        if (state['_serialize_version'] < klass._serialize_version and
+                hasattr(self, '_serialize_interpolation_map')):
             self.__interpolate(state)
-            logger.debug("intepolated state: %s" % state)
 
-        logger.debug("serialize fields: %s" % str(klass._serialize_fields))
         for field in klass._serialize_fields:
             if field in state:
                 setattr(self, field, state[field])
             else:
-                logger.info("skipped %s, because it is not declared in _serialize_fields")
+                logger.debug("skipped %s, because it is not declared in _serialize_fields" % field)
 
     def __getstate__(self):
-        # we just dump the version number for comparison with the actual class.
+        # We just dump the version number for comparison with the actual class.
+        # Note: we do not want to set the version number in __setstate__,
+        # since we obtain it from the actual definition.
         if not hasattr(self, '_serialize_version'):
             raise DeveloperError("your class should define a _serialize_version attribute")
         return {'_serialize_version': self._serialize_version}
-                #, '_serialize_fields': self._serialize_fields}
-
-    def __setstate__(self, state):
-        pass
-        #self._serialize_fields = state.pop('_serialize_fields', ())
-
-

--- a/pyemma/_base/serialization/serialization.py
+++ b/pyemma/_base/serialization/serialization.py
@@ -24,6 +24,7 @@ import six
 import logging
 
 logger = logging.getLogger(__name__)
+_debug = True
 
 _reg_np_handler()
 
@@ -168,12 +169,15 @@ class SerializableMixIn(object):
         state_version = state['_serialize_version']
         for key in self._serialize_interpolation_map.keys():
             if not(self._serialize_version > key >= state_version):
-                logger.debug("skipped interpolation rules for version %s" % key)
+                if _debug:
+                    logger.debug("skipped interpolation rules for version %s" % key)
                 continue
-            logger.debug("processing rules for version %s" % key)
+            if _debug:
+                logger.debug("processing rules for version %s" % key)
             actions = self._serialize_interpolation_map[key]
             for a in actions:
-                logger.debug("processing rule: %s" % str(a))
+                if _debug:
+                    logger.debug("processing rule: %s" % str(a))
                 if a[0] == 'set':
                     state[a[1]] = a[2]
                 elif a[0] == 'mv':
@@ -185,11 +189,13 @@ class SerializableMixIn(object):
                                              "store an attribute named '{}'".format(a[1]))
                 elif a[0] == 'rm':
                     state.pop(a[1], None)
-        logger.debug("interpolated state: %s" % state)
+        if _debug:
+            logger.debug("interpolated state: %s" % state)
 
     def _set_state_from_serializeable_fields_and_state(self, state, klass):
         """ set only fields from state, which are present in klass._serialize_fields """
-        logger.debug("restoring state for class %s" % klass)
+        if _debug:
+            logger.debug("restoring state for class %s" % klass)
         if '_serialize_version' not in state:
             raise DeveloperError("your class should define a _serialize_version attribute")
 
@@ -201,7 +207,8 @@ class SerializableMixIn(object):
             if field in state:
                 setattr(self, field, state[field])
             else:
-                logger.debug("skipped %s, because it is not declared in _serialize_fields" % field)
+                if _debug:
+                    logger.debug("skipped %s, because it is not declared in _serialize_fields" % field)
 
     def __getstate__(self):
         # We just dump the version number for comparison with the actual class.
@@ -211,6 +218,4 @@ class SerializableMixIn(object):
             raise DeveloperError('The "{klass}" should define a static "_serialize_version" attribute.'
                                  .format(klass=self.__class__))
         res = {'_serialize_version': self._serialize_version}
-        #if hasattr(self, '_serialize_interpolation_map'):
-        #    res['_serialize_interpolation_map'] = self._serialize_interpolation_map
         return res

--- a/pyemma/_base/serialization/serialization.py
+++ b/pyemma/_base/serialization/serialization.py
@@ -122,6 +122,10 @@ class SerializableMixIn(object):
                 setattr(self, field, state[field])
 
     def __getstate__(self):
+        # TODO: this pattern (getting only the version in parent will omit all other attrs)!
+        if not hasattr(self, '_version'):
+            raise DeveloperError("your class should define a _version attribute")
+
         return {'_version': self._version}
 
     def __setstate__(self, state):

--- a/pyemma/_base/serialization/serialization.py
+++ b/pyemma/_base/serialization/serialization.py
@@ -189,5 +189,6 @@ class SerializableMixIn(object):
         # Note: we do not want to set the version number in __setstate__,
         # since we obtain it from the actual definition.
         if not hasattr(self, '_serialize_version'):
-            raise DeveloperError("your class should define a _serialize_version attribute")
+            raise DeveloperError('The "{klass}" should define a static "_serialize_version" attribute.'
+                                 .format(klass=self.__class__))
         return {'_serialize_version': self._serialize_version}

--- a/pyemma/_base/tests/test_serialization.py
+++ b/pyemma/_base/tests/test_serialization.py
@@ -10,7 +10,7 @@ from pyemma._base.serialization.serialization import SerializableMixIn
 from pyemma._ext.jsonpickle import dumps, loads
 
 
-class test_cls(SerializableMixIn):
+class test_cls_v1(SerializableMixIn):
     _serialize_fields = ('a', 'x', 'y')
     _serialize_version = 1
 
@@ -20,22 +20,22 @@ class test_cls(SerializableMixIn):
         self.y = 0.0
 
     def __getstate__(self):
-        state = super(test_cls, self).__getstate__()
-        state.update(self._get_state_of_serializeable_fields(klass=test_cls))
+        state = super(test_cls_v1, self).__getstate__()
+        state.update(self._get_state_of_serializeable_fields(klass=test_cls_v1))
         return state
 
     def __setstate__(self, state):
-        self._set_state_from_serializeable_fields_and_state(state, test_cls)
+        self._set_state_from_serializeable_fields_and_state(state, test_cls_v1)
 
     def __eq__(self, other):
         return np.allclose(self.a, other.a) and self.x == other.x and self.y == other.y
 
 
-class new_cls(SerializableMixIn):
+class test_cls_v2(SerializableMixIn):
     _serialize_fields = ('b', 'y', 'z')
     _serialize_version = 2
     # interpolate from version 1: add attr z with value 42
-    _serialize_interpolation_map = {1 : [('set', 'z', 42),
+    _serialize_interpolation_map = {1: [('set', 'z', 42),
                                          ('mv', 'a', 'b'),
                                          ('rm', 'x')]}
 
@@ -45,15 +45,43 @@ class new_cls(SerializableMixIn):
         self.z = 42
 
     def __getstate__(self):
-        state = super(test_cls, self).__getstate__()
-        state.update(self._get_state_of_serializeable_fields(klass=new_cls))
+        state = super(test_cls_v2, self).__getstate__()
+        state.update(self._get_state_of_serializeable_fields(klass=test_cls_v2))
         return state
 
     def __setstate__(self, state):
-        self._set_state_from_serializeable_fields_and_state(state, new_cls)
+        self._set_state_from_serializeable_fields_and_state(state, test_cls_v2)
 
     def __eq__(self, other):
         return np.allclose(self.b, other.b) and self.y == other.y and self.z == other.z
+
+
+class test_cls_v3(SerializableMixIn):
+    # should fake the refactoring of new_cls
+    _serialize_fields = ('c', 'z')
+    _serialize_version = 3
+    # interpolate from version 1 and 2
+    _serialize_interpolation_map = {1: [('set', 'z', 42),
+                                        ('mv', 'a', 'b'),
+                                        ('rm', 'x')],
+                                    2: [('set', 'z', 23),
+                                        ('mv', 'b', 'c'),
+                                        ('rm', 'y')]}
+
+    def __init__(self):
+        self.c = np.random.random((3, 2))
+        self.z = 23
+
+    def __getstate__(self):
+        state = super(test_cls_v3, self).__getstate__()
+        state.update(self._get_state_of_serializeable_fields(klass=test_cls_v3))
+        return state
+
+    def __setstate__(self, state):
+        self._set_state_from_serializeable_fields_and_state(state, test_cls_v3)
+
+    def __eq__(self, other):
+        return np.allclose(self.c, other.c) and self.y == other.y and self.z == other.z
 
 
 class TestSerialisation(unittest.TestCase):
@@ -73,27 +101,95 @@ class TestSerialisation(unittest.TestCase):
             unregister_ndarray_npz_handler()
 
     def test_save_interface(self):
-        inst = test_cls()
+        inst = test_cls_v1()
         try:
             with tempfile.NamedTemporaryFile(delete=False) as fh:
                 inst.save(filename=fh.name)
-                new = test_cls.load(fh.name)
+                new = test_cls_v1.load(fh.name)
                 self.assertEqual(new, inst)
         finally:
             os.unlink(fh.name)
 
     def test_updated_class(self):
+        old_class = test_cls_v1
         try:
             f = tempfile.NamedTemporaryFile(delete=False)
-            inst = test_cls()
+            inst = test_cls_v1()
             inst.save(f.name)
 
-            global test_cls
-            test_cls = new_cls
+            global test_cls_v1
+            test_cls_v1 = test_cls_v2
 
             inst_restored = pyemma.load(f.name)
 
-            self.assertIsInstance(inst_restored, new_cls)
+            self.assertIsInstance(inst_restored, test_cls_v2)
             self.assertEqual(inst_restored.z, 42)
         finally:
             os.unlink(f.name)
+            test_cls_v1 = old_class
+
+    def test_updated_class_v2_to_v3(self):
+        old_class = test_cls_v2
+        try:
+            f = tempfile.NamedTemporaryFile(delete=False)
+            inst = test_cls_v2()
+            inst.save(f.name)
+
+            global test_cls_v2
+            test_cls_v2 = test_cls_v3
+
+            inst_restored = pyemma.load(f.name)
+
+            self.assertIsInstance(inst_restored, test_cls_v2)
+            self.assertEqual(inst_restored.z, 23)
+            self.assertFalse(hasattr(inst_restored, 'y'))
+        finally:
+            os.unlink(f.name)
+            test_cls_v2 = old_class
+
+    def test_updated_class_v1_to_v3(self):
+        old_class = test_cls_v1
+        try:
+            f = tempfile.NamedTemporaryFile(delete=False)
+            inst = test_cls_v1()
+            inst.save(f.name)
+
+            global test_cls_v1
+            test_cls_v1 = test_cls_v3
+
+            inst_restored = pyemma.load(f.name)
+
+            self.assertIsInstance(inst_restored, test_cls_v3)
+            self.assertEqual(inst_restored.z, 23)
+            np.testing.assert_equal(inst_restored.c, inst.a)
+            self.assertFalse(hasattr(inst_restored, 'y'))
+        finally:
+            os.unlink(f.name)
+            test_cls_v1 = old_class
+
+    def test_validate_map_order(self):
+        interpolation_map = {3: [('set', 'x', None)], 0: [('rm', 'x')]}
+        s = SerializableMixIn()
+        s._serialize_interpolation_map = interpolation_map
+        s._validate_interpolation_map()
+        is_sorted = lambda l: all(l[i] <= l[i+1] for i in xrange(len(l)-1))
+        self.assertTrue(is_sorted(s._serialize_interpolation_map.keys()))
+
+    def test_validate_map_invalid_op(self):
+        interpolation_map = {3: [('foo', 'x', None)]}
+        s = SerializableMixIn()
+        s._serialize_interpolation_map = interpolation_map
+        from pyemma._base.serialization.serialization import DeveloperError
+        with self.assertRaises(DeveloperError) as cm:
+            s._validate_interpolation_map()
+        self.assertIn('invalid operation', cm.exception.args[0])
+
+    def test_validate_map_invalid_container_for_actions(self):
+        interpolation_map = {3: "foo"}
+        s = SerializableMixIn()
+        s._serialize_interpolation_map = interpolation_map
+        from pyemma._base.serialization.serialization import DeveloperError
+        with self.assertRaises(DeveloperError) as cm:
+            s._validate_interpolation_map()
+
+        self.assertIn("contain", cm.exception.args[0])

--- a/pyemma/_base/tests/test_serialization.py
+++ b/pyemma/_base/tests/test_serialization.py
@@ -1,29 +1,59 @@
+import os
 import tempfile
 import unittest
 
 import numpy as np
-from pyemma._ext.jsonpickle import dumps, loads
 
+import pyemma
 from pyemma._base.serialization.jsonpickler_handlers import register_ndarray_handler, unregister_ndarray_npz_handler
 from pyemma._base.serialization.serialization import SerializableMixIn
+from pyemma._ext.jsonpickle import dumps, loads
 
 
 class test_cls(SerializableMixIn):
     _serialize_fields = ('a', 'x', 'y')
-    _version = 1
+    _serialize_version = 1
 
     def __init__(self):
         self.a = np.random.random((3, 2))
         self.x = 'foo'
-        self.y = None
+        self.y = 0.0
 
     def __getstate__(self):
         state = super(test_cls, self).__getstate__()
         state.update(self._get_state_of_serializeable_fields(klass=test_cls))
         return state
 
+    def __setstate__(self, state):
+        self._set_state_from_serializeable_fields_and_state(state, test_cls)
+
     def __eq__(self, other):
         return np.allclose(self.a, other.a) and self.x == other.x and self.y == other.y
+
+
+class new_cls(SerializableMixIn):
+    _serialize_fields = ('b', 'y', 'z')
+    _serialize_version = 2
+    # interpolate from version 1: add attr z with value 42
+    _serialize_interpolation_map = {1 : [('set', 'z', 42),
+                                         ('mv', 'a', 'b'),
+                                         ('rm', 'x')]}
+
+    def __init__(self):
+        self.b = np.random.random((3, 2))
+        self.y = 0.0
+        self.z = 42
+
+    def __getstate__(self):
+        state = super(test_cls, self).__getstate__()
+        state.update(self._get_state_of_serializeable_fields(klass=new_cls))
+        return state
+
+    def __setstate__(self, state):
+        self._set_state_from_serializeable_fields_and_state(state, new_cls)
+
+    def __eq__(self, other):
+        return np.allclose(self.b, other.b) and self.y == other.y and self.z == other.z
 
 
 class TestSerialisation(unittest.TestCase):
@@ -44,9 +74,26 @@ class TestSerialisation(unittest.TestCase):
 
     def test_save_interface(self):
         inst = test_cls()
-        with tempfile.NamedTemporaryFile(delete=False) as fh:
-            inst.save(filename=fh.name)
+        try:
+            with tempfile.NamedTemporaryFile(delete=False) as fh:
+                inst.save(filename=fh.name)
+                new = test_cls.load(fh.name)
+                self.assertEqual(new, inst)
+        finally:
+            os.unlink(fh.name)
 
-            new = test_cls.load(fh.name)
+    def test_updated_class(self):
+        try:
+            f = tempfile.NamedTemporaryFile(delete=False)
+            inst = test_cls()
+            inst.save(f.name)
 
-            self.assertEqual(new, inst)
+            global test_cls
+            test_cls = new_cls
+
+            inst_restored = pyemma.load(f.name)
+
+            self.assertIsInstance(inst_restored, new_cls)
+            self.assertEqual(inst_restored.z, 42)
+        finally:
+            os.unlink(f.name)

--- a/pyemma/_ext/jsonpickle/pickler.py
+++ b/pyemma/_ext/jsonpickle/pickler.py
@@ -336,7 +336,8 @@ class Pickler(object):
         if has_getstate:
             try:
                 state = obj.__getstate__()
-            except TypeError:
+            except TypeError as t:
+                print(t)
                 # Has getstate but it cannot be called, e.g. file descriptors
                 # in Python3
                 self._pickle_warning(obj)

--- a/pyemma/_ext/jsonpickle/unpickler.py
+++ b/pyemma/_ext/jsonpickle/unpickler.py
@@ -159,7 +159,7 @@ class Unpickler(object):
             restore = self._restore_dict
         else:
             restore = lambda x: x
-        print("restore function:", str(restore))
+        #print("restore function:", str(restore))
         return restore(obj)
 
     def _restore_base64(self, obj):

--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -816,6 +816,8 @@ class MaximumLikelihoodMSM(_MSM, _Estimator):
 
     def __getstate__(self):
         # get state of model and estimator
+        assert issubclass(self.__class__, _MSM)
+        assert issubclass(self.__class__, _Estimator)
         model_state = _MSM.__getstate__(self)
         estimator_state = _Estimator.__getstate__(self)
 
@@ -827,6 +829,8 @@ class MaximumLikelihoodMSM(_MSM, _Estimator):
         return model_state
 
     def __setstate__(self, state):
+        assert issubclass(self.__class__, _MSM)
+        assert issubclass(self.__class__, _Estimator)
         _Estimator.__setstate__(self, state)
         _MSM.__setstate__(self, state)
 

--- a/pyemma/msm/models/msm.py
+++ b/pyemma/msm/models/msm.py
@@ -1025,20 +1025,9 @@ class MSM(_Model):
 
     def __getstate__(self):
         parent_state = super(MSM, self).__getstate__()
-
-        # ML_MSM doesn't call init of MSM, so we do not have nstates
-        if hasattr(self, '_nstates'):
-            parent_state['_nstates'] = self._nstates
-
         parent_state.update(self._get_state_of_serializeable_fields(MSM))
-
         return parent_state
 
     def __setstate__(self, state):
         super(MSM, self).__setstate__(state)
-
-        # ML_MSM doesn't call init of MSM, so we do not have nstates
-        if '_nstates' in state:
-            self._nstates = state['_nstates']
-
         self._set_state_from_serializeable_fields_and_state(state, klass=MSM)


### PR DESCRIPTION
In order to facilitate the loading of older class versions, which might have new, renamed and deleted fields, we define a interpolation mapping like this:

``` python
    _serialize_interpolation_map = {1 : [('set', 'attr', value),
                                         ('mv', 'old', 'new'),
                                         ('rm', 'attr')]}
```

The key of the dict indicate the version number for which this mapping will be applied. So for version 2 of the class the mapping 1 will be applied.

Currently these operations work:
- We can set attributes to different values (eg. a new attribute has been added in a new version)
- Rename an attribute
- delete an attribute

This way we can track (all?) changes made to classes via versioning. To track class rename refactorings, we need to provide a renaming dictionary in the load function to translate the class name to its actual location. This just requires a simple rename in the JSON string.
