### PR TITLE
Travis build matrix numpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ env:
     - DEV_BUILD_N_KEEP=10 
     - secure: "YI89RGfpxB29XoyPzBGXsCWSgdhP4i+DS7gFmwaDoOz3R+ZW8yG3ZaexW15WUe7h0tb1L2aYvZCcqgaBrH2SNCiR0SRbhk3EBPg1C3baMVlVhDeQru9S/FrEJ1ZUGhnUitbEEIdG2MYexETjoGef6K+7dXBJWJMy/rNRm61PSJw="
   matrix:
-    # minimum possible numpy=1.8, because of mdtraj only built against np1.8 on omnia 
-    - CONDA_PY=2.7 CONDA_NPY=1.8
+    # minimum possible numpy=1.9, since we're requiring mdtraj>=1.7 (only built against np19) 
+    - CONDA_PY=2.7 CONDA_NPY=1.9
     - CONDA_PY=2.7 CONDA_NPY=1.11
     - CONDA_PY=3.4 CONDA_NPY=1.10
     - CONDA_PY=3.5 CONDA_NPY=1.11

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: c
 git:
   submodules: false
 os:
- - linux
  - osx
+ - linux
 
 sudo: false
 
@@ -16,19 +16,11 @@ env:
     - DEV_BUILD_N_KEEP=10 
     - secure: "YI89RGfpxB29XoyPzBGXsCWSgdhP4i+DS7gFmwaDoOz3R+ZW8yG3ZaexW15WUe7h0tb1L2aYvZCcqgaBrH2SNCiR0SRbhk3EBPg1C3baMVlVhDeQru9S/FrEJ1ZUGhnUitbEEIdG2MYexETjoGef6K+7dXBJWJMy/rNRm61PSJw="
   matrix:
-    # minimum possible numpy version = 1.8, because of mdtraj
-    - python=2.7  CONDA_PY=27  CONDA_NPY=19
-    - python=2.7  CONDA_PY=27  CONDA_NPY=110
-    - python=3.4  CONDA_PY=34  CONDA_NPY=19
-    - python=3.5  CONDA_PY=35  CONDA_NPY=110
-
-# exclude too verbose configs on osx, since these are dead slow.
-matrix:
-   exclude:
-     - os: osx
-       env: python=3.4  CONDA_PY=34  CONDA_NPY=19
-     - os: osx
-       env: python=2.7  CONDA_PY=27  CONDA_NPY=19
+    # minimum possible numpy=1.8, because of mdtraj only built against np1.8 on omnia 
+    - CONDA_PY=2.7 CONDA_NPY=1.8
+    - CONDA_PY=2.7 CONDA_NPY=1.11
+    - CONDA_PY=3.4 CONDA_NPY=1.10
+    - CONDA_PY=3.5 CONDA_NPY=1.11
 
 before_install:
 - devtools/ci/travis/install_miniconda.sh

--- a/devtools/ci/travis/dev_pkgs_del_old.py
+++ b/devtools/ci/travis/dev_pkgs_del_old.py
@@ -39,7 +39,5 @@ while len(sorted_by_version) > n_keep:
 for rel in to_delete:
     spec = rel['full_name']
     version = rel['version']
-    for dist in rel['distributions']:
-        b.remove_dist(org, package_name=pkg, release=version, basename=dist)
-        print("removed file %s" % dist)
-
+    b.remove_version(org, pkg, version)
+    print("removed version:", version)

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,6 +1,8 @@
 package:
   name: pyemma-dev
-  version: {{ environ.get('GIT_DESCRIBE_TAG','')+environ.get('GIT_BUILD_STR', 'unknown')[1:] }}
+  # version number: [base tag]+[commits-upstream]_[git_hash]
+  # eg. v2.0+0_g8824162
+  version: {{ GIT_DESCRIBE_TAG + '+' +GIT_BUILD_STR}}
 source:
   path: ../..
 


### PR DESCRIPTION
lowest numpy version to test against: 1.9
highest: 1.11

Do not exclude OSX builds.

Fix version number in conda recipe (faulty concatenation of base version tag number and upstream commits).
