### PR TITLE
Fix fragmented reader skip handling

### DIFF
--- a/pyemma/coordinates/data/feature_reader.py
+++ b/pyemma/coordinates/data/feature_reader.py
@@ -306,9 +306,25 @@ class FeatureReaderIterator(DataSourceIterator):
         #self._cols = cols
         self._create_mditer()
 
-    @DataSourceIterator.chunksize.setter
-    def chunksize(self, val):
-        self._mditer._chunksize = int(val)
+    @property
+    def chunksize(self):
+        return self.state.chunk
+
+    @chunksize.setter
+    def chunksize(self, value):
+        self.state.chunk = value
+        if hasattr(self, '_mditer'):
+            self._mditer._chunksize = int(value)
+
+    @property
+    def skip(self):
+        return self.state.skip
+
+    @skip.setter
+    def skip(self, value):
+        self.state.skip = value
+        if hasattr(self, '_mditer'):
+            self._mditer._skip = value
 
     def close(self):
         if hasattr(self, '_mditer') and self._mditer is not None:

--- a/pyemma/coordinates/data/featurization/featurizer.py
+++ b/pyemma/coordinates/data/featurization/featurizer.py
@@ -29,6 +29,8 @@ from pyemma.coordinates.data.featurization.util import (_parse_pairwise_input,
 
 from .misc import CustomFeature
 import numpy as np
+from pyemma.coordinates.util.patches import load_topology_cached
+from mdtraj import load_topology as load_topology_uncached
 
 
 __author__ = 'Frank Noe, Martin Scherer'
@@ -38,7 +40,7 @@ __all__ = ['MDFeaturizer']
 class MDFeaturizer(Loggable):
     r"""Extracts features from MD trajectories."""
 
-    def __init__(self, topfile):
+    def __init__(self, topfile, use_cache=True):
         """extracts features from MD trajectories.
 
        Parameters
@@ -46,10 +48,12 @@ class MDFeaturizer(Loggable):
 
        topfile : str or mdtraj.Topology
            a path to a topology file (pdb etc.) or an mdtraj Topology() object
+       use_cache : boolean, default=True
+           cache already loaded topologies, if file contents match.
        """
         self.topologyfile = None
         if isinstance(topfile, six.string_types):
-            self.topology = (mdtraj.load(topfile)).topology
+            self.topology = load_topology_cached(topfile) if use_cache else load_topology_uncached(topfile)
             self.topologyfile = topfile
         elif isinstance(topfile, mdtraj.Topology):
             self.topology = topfile

--- a/pyemma/coordinates/data/util/traj_info_backends.py
+++ b/pyemma/coordinates/data/util/traj_info_backends.py
@@ -198,8 +198,8 @@ class SqliteDB(AbstractDB):
                      "VALUES (?, ?, ?, ?, ?, ?, ?)", values)
         try:
              self._database.execute(*statement)
-        except sqlite3.IntegrityError:
-            logger.exception()
+        except sqlite3.IntegrityError as ie:
+            logger.exception("insert failed: %s " % ie)
             return
         self._database.commit()
 

--- a/pyemma/coordinates/util/patches.py
+++ b/pyemma/coordinates/util/patches.py
@@ -25,13 +25,35 @@ Created on 13.03.2015
 from __future__ import absolute_import
 import numpy as np
 from mdtraj.utils.validation import cast_indices
-from mdtraj.core.trajectory import load, _parse_topology, _TOPOLOGY_EXTS, _get_extension, open
+from mdtraj.core.trajectory import load, _TOPOLOGY_EXTS, _get_extension, open as md_open, load_topology_cached
 
 from itertools import groupby
 from operator import itemgetter
 
 from pyemma.coordinates.data.util.reader_utils import copy_traj_attributes, preallocate_empty_trajectory
 from six.moves import map
+
+
+def _cache_mdtraj_topology(args):
+    import hashlib
+    from mdtraj import load_topology_cached as md_load_topology
+    _top_cache = {}
+
+    def wrap(top_file):
+        hasher = hashlib.md5()
+        with open(top_file) as f:
+            hasher.update(f.read())
+        hash = hasher.hexdigest()
+
+        if hash in _top_cache:
+            top = _top_cache[hash]
+        else:
+            top = md_load_topology(top_file)
+            _top_cache[hash] = top
+        return top
+    return wrap
+
+load_topology_cached = _cache_mdtraj_topology(load_topology_cached)
 
 
 class iterload(object):
@@ -90,29 +112,26 @@ class iterload(object):
         self._chunksize = chunk
         self._extension = _get_extension(self._filename)
         self._closed = False
+        self._seeked = False
         if self._extension not in _TOPOLOGY_EXTS:
-            self._topology = _parse_topology(self._top)
+            self._topology = load_topology_cached(self._top)
         else:
             self._topology = self._top
 
         self._mode = None
-        if self._chunksize > 0 and self._extension in ('.pdb', '.pdb.gz'):
-            self._mode = 'pdb'
-            self._t = load(self._filename, stride=self._stride, atom_indices=self._atom_indices)
-            self._i = 0
-        elif isinstance(self._stride, np.ndarray):
+        if isinstance(self._stride, np.ndarray):
             self._mode = 'random_access'
             self._f = (lambda x:
-                       open(x, n_atoms=self._topology.n_atoms)
+                       md_open(x, n_atoms=self._topology.n_atoms)
                        if self._extension in ('.crd', '.mdcrd')
-                       else open(self._filename))(self._filename)
+                       else md_open(self._filename))(self._filename)
             self._ra_it = self._random_access_generator(self._f)
         else:
             self._mode = 'traj'
             self._f = (
-                lambda x: open(x, n_atoms=self._topology.n_atoms)
+                lambda x: md_open(x, n_atoms=self._topology.n_atoms)
                 if self._extension in ('.crd', '.mdcrd')
-                else open(self._filename)
+                else md_open(self._filename)
             )(self._filename)
 
             # offset array handling
@@ -120,16 +139,20 @@ class iterload(object):
             if hasattr(self._f, 'offsets') and offsets is not None:
                 self._f.offsets = offsets
 
-            if self._skip > 0:
-                self._f.seek(self._skip)
+    @property
+    def skip(self):
+        return self._skip
+
+    @skip.setter
+    def skip(self, value):
+        assert self._mode == 'traj'
+        self._skip = value
 
     def __iter__(self):
         return self
 
     def close(self):
-        if hasattr(self, '_t'):
-            self._t.close()
-        elif hasattr(self, '_f'):
+        if hasattr(self, '_f'):
             self._f.close()
         self._closed = True
 
@@ -139,6 +162,11 @@ class iterload(object):
     def next(self):
         if self._closed:
             raise StopIteration()
+
+        if not self._seeked:
+            self._f.seek(self.skip)
+            self._seeked = True
+
         if not isinstance(self._stride, np.ndarray) and self._chunksize == 0:
             # If chunk was 0 then we want to avoid filetype-specific code
             # in case of undefined behavior in various file parsers.
@@ -146,21 +174,15 @@ class iterload(object):
             if self._extension not in _TOPOLOGY_EXTS:
                 self._kwargs['top'] = self._top
             return load(self._filename, stride=self._stride, **self._kwargs)[self._skip:]
-        elif self._mode is 'pdb':
-            # the PDBTrajectortFile class doesn't follow the standard API. Fixing it
-            # to support iterload could be worthwhile, but requires a deep refactor.
-            X = self._t[self._i:self._i+self._chunksize]
-            self._i += self._chunksize
-            return X
         elif isinstance(self._stride, np.ndarray):
             return next(self._ra_it)
         else:
             if self._extension not in _TOPOLOGY_EXTS:
                 traj = self._f.read_as_traj(self._topology, n_frames=self._chunksize*self._stride,
-                                      stride=self._stride, atom_indices=self._atom_indices, **self._kwargs)
+                                            stride=self._stride, atom_indices=self._atom_indices, **self._kwargs)
             else:
                 traj = self._f.read_as_traj(n_frames=self._chunksize*self._stride,
-                                      stride=self._stride, atom_indices=self._atom_indices, **self._kwargs)
+                                            stride=self._stride, atom_indices=self._atom_indices, **self._kwargs)
 
             if len(traj) == 0:
                 raise StopIteration()

--- a/pyemma/coordinates/util/patches.py
+++ b/pyemma/coordinates/util/patches.py
@@ -44,7 +44,7 @@ def _cache_mdtraj_topology(args):
         if isinstance(top_file, Topology):
             return top_file
         hasher = hashlib.md5()
-        with open(top_file) as f:
+        with open(top_file, 'rb') as f:
             hasher.update(f.read())
         hash = hasher.hexdigest()
 


### PR DESCRIPTION
- The skip argument has not been passed correctly to the underlying iterator implementation, a feature on which the FragmentedTrajectoryReader is dependent. Thanks to @clonker for his help during debugging.
- added caching of expensive to create mdtraj.Topology objects. First the content of the topology file is hashed via md5 and then stored in a dictionary for later lookups. This reduces creation times of iterators and FragmentedTrajReaders (since a FeatureReader is constructed for every fragment (and the topology is parsed again).
