### PR TITLE
Cleanup testing fixture

### DIFF
--- a/pyemma/__init__.py
+++ b/pyemma/__init__.py
@@ -38,9 +38,19 @@ from . import plots
 from . import thermo
 
 
-def setup_package():
-    # purpose is for nose testing only to silence progress bars etc.
-    import warnings
-    warnings.warn('You should never see this, only in unit testing!'
-                  ' This switches off progress bars')
+def _setup_testing():
+    # setup function for testing
+    from pyemma.util import config
+    # do not cache trajectory info in user directory (temp traj files)
+    config.use_trajectory_lengths_cache = False
     config.show_progress_bars = False
+
+import unittest as _unittest
+# override unittests base class constructor to achieve same behaviour without nose.
+_old_init = _unittest.TestCase.__init__
+def _new_init(self, *args, **kwargs):
+    _old_init(self, *args, **kwargs)
+    _setup_testing()
+
+_unittest.TestCase.__init__ = _new_init
+

--- a/pyemma/_base/tests/test_progress.py
+++ b/pyemma/_base/tests/test_progress.py
@@ -23,58 +23,27 @@ Created on 29.07.2015
 '''
 
 from __future__ import absolute_import
+
 import unittest
+
+from six.moves import range
+
 from pyemma._base.progress import ProgressReporter
 from pyemma._base.progress.bar import ProgressBar
-from six.moves import range
+from pyemma import config
 
 
 class TestProgress(unittest.TestCase):
 
-    # FIXME: does not work with nose (because nose already captures stdout)
-    """
-    def test_silenced(self):
-        reporter = ProgressReporter()
-        reporter._register(1)
-        reporter.silence_progress = True
+    @classmethod
+    def setUpClass(cls):
+        config.show_progress_bars = True
 
-        from StringIO import StringIO
-
-        saved_stdout = sys.stdout
-        try:
-            out = StringIO()
-            sys.stdout = out
-            # call the update method to potentially create output
-            reporter._update(1)
-            output = out.getvalue().strip()
-            # in silence mode we do not want any output!
-            assert output == ''
-        finally:
-            sys.stdout = saved_stdout
-
-    def test_not_silenced(self):
-        reporter = ProgressReporter()
-        reporter._register(1)
-        reporter.silence_progress = False
-
-        from StringIO import StringIO
-
-        saved_stdout = sys.stdout
-        try:
-            out = StringIO()
-            sys.stdout = out
-            # call the update method to potentially create output
-            reporter._update(1)
-            output = out.getvalue().strip()
-            # in silence mode we do not want any output!
-            print output
-            assert output is not ''
-        finally:
-            sys.stdout = saved_stdout
-    """
+    @classmethod
+    def tearDownClass(cls):
+        config.show_progress_bars = False
 
     def test_callback(self):
-
         self.has_been_called = 0
 
         def call_back(stage, progressbar, *args, **kw):

--- a/pyemma/coordinates/__init__.py
+++ b/pyemma/coordinates/__init__.py
@@ -105,9 +105,3 @@ Find here a documentation how to extract features from them.
 
 """
 from .api import *
-
-
-def setup_package():
-    # do not use traj cache for tests
-    from pyemma import config
-    config['use_trajectory_lengths_cache'] = False

--- a/pyemma/coordinates/tests/__init__.py
+++ b/pyemma/coordinates/tests/__init__.py
@@ -16,12 +16,4 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
 from __future__ import absolute_import
-
-
-def setup_package():
-    # setup function for nose tests (for this package only)
-    from pyemma.util import config
-    # do not cache trajectory info in user directory (temp traj files)
-    config.use_trajectory_lengths_cache = False

--- a/pyemma/coordinates/tests/test_traj_info_cache.py
+++ b/pyemma/coordinates/tests/test_traj_info_cache.py
@@ -22,7 +22,6 @@ Created on 30.04.2015
 
 from __future__ import absolute_import
 
-from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
 
 
@@ -40,6 +39,7 @@ from pyemma.coordinates.data.util.traj_info_cache import TrajectoryInfoCache
 from pyemma.coordinates.tests.util import create_traj
 from pyemma.datasets import get_bpti_test_data
 from pyemma.util import config
+from pyemma.util.contexts import settings
 from pyemma.util.files import TemporaryDirectory
 import mdtraj
 import pkg_resources
@@ -56,8 +56,7 @@ class TestTrajectoryInfoCache(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.old_instance = TrajectoryInfoCache.instance()
-        cls.old_show_pg = config.show_progress_bars
-        config.show_progress_bars = False
+        config.use_trajectory_lengths_cache = True
 
     def setUp(self):
         self.work_dir = tempfile.mkdtemp("traj_cache_test")
@@ -77,7 +76,7 @@ class TestTrajectoryInfoCache(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         TrajectoryInfoCache._instance = cls.old_instance
-        config.show_progress_bars = cls.old_show_pg
+        config.use_trajectory_lengths_cache = False
 
     def test_get_instance(self):
         # test for exceptions in singleton creation
@@ -117,9 +116,8 @@ class TestTrajectoryInfoCache(unittest.TestCase):
 
     def test_featurereader_xtc(self):
         # cause cache failures
-        config['use_trajectory_lengths_cache'] = False
-        reader = FeatureReader(xtcfiles, pdbfile)
-        config['use_trajectory_lengths_cache'] = True
+        with settings(use_trajectory_lengths_cache=False):
+            reader = FeatureReader(xtcfiles, pdbfile)
 
         results = {}
         for f in xtcfiles:
@@ -265,16 +263,9 @@ class TestTrajectoryInfoCache(unittest.TestCase):
         data = [np.random.random((150, 10)) for _ in range(150)]
         max_size = 1
 
-        @contextmanager
-        def size_ctx(new_size):
-            old_size = config.traj_info_max_size
-            config.traj_info_max_size = new_size
-            yield
-            config.traj_info_max_size = old_size
-
         files = []
         config.show_progress_bars=False
-        with TemporaryDirectory() as td, size_ctx(max_size):
+        with TemporaryDirectory() as td, settings(traj_info_max_size=max_size):
             for i, arr in enumerate(data):
                 f = os.path.join(td, "%s.txt" % i)
                 # save as txt to enforce creation of offsets

--- a/pyemma/util/contexts.py
+++ b/pyemma/util/contexts.py
@@ -62,3 +62,25 @@ def random_seed(seed=42):
         yield
     finally:
         random.setstate(old_state)
+
+
+@contextmanager
+def settings(**kwargs):
+    """ apply given PyEMMA config values temporarily within the given context."""
+    from pyemma import config
+    # validate:
+    valid_keys = config.keys()
+    for k in kwargs.keys():
+        if k not in valid_keys:
+            raise ValueError("not a valid settings: {key}".format(key=k))
+
+    old_settings = {}
+    for k, v in kwargs.items():
+        old_settings[k] = getattr(config, k)
+        setattr(config, k, v)
+
+    yield
+
+    # restore old settings
+    for k, v in old_settings.items():
+        setattr(config, k, v)


### PR DESCRIPTION
Since the setup_package function is only nosetests specific and polluted the toplevel namespaces pyemma and pyemma.coordinates, we now patch the unittest.TestCase class.
