### PR TITLE
[coordinates/FeatureReader|xtc] in case of a too large seek argument stop iteration

### DIFF
--- a/pyemma/coordinates/tests/test_featurereader.py
+++ b/pyemma/coordinates/tests/test_featurereader.py
@@ -62,7 +62,7 @@ class TestFeatureReader(unittest.TestCase):
         cls.trajfile2, cls.xyz2, cls.n_frames2 = create_traj(cls.topfile, dir=cls.tmpdir)
         traj = mdtraj.load(cls.trajfile, top=cls.topfile)
         for fo in traj._savers():
-            if fo in ('.crd', '.mdcrd', '.h5', '.ncrst', '.lh5'):
+            if fo in ('.crd', '.mdcrd', '.h5', '.ncrst', '.lh5',):
                 continue
             log.debug("creating traj for " + fo)
             traj_file = create_traj(cls.topfile, format=fo, dir=cls.tmpdir)[0]
@@ -94,6 +94,14 @@ class TestFeatureReader(unittest.TestCase):
         data.reshape(self.xyz.shape)
 
         self.assertTrue(np.allclose(data, self.xyz.reshape(-1, 9)))
+
+    def test_lagged_iterator_short_trajs(self):
+        trajs = [create_traj(self.topfile, '.xtc', dir=self.tmpdir, length=20)[0],
+                 create_traj(self.topfile, '.xtc', dir=self.tmpdir, length=25)[0]
+                 ]
+        reader = api.source(trajs, top=self.topfile)
+        for itraj, X, Y in reader.iterator(lag=22):
+            raise RuntimeError("should never get here!!!")
 
     def testIteratorAccess2(self):
         reader = FeatureReader([self.trajfile, self.trajfile2], self.topfile)

--- a/pyemma/coordinates/util/patches.py
+++ b/pyemma/coordinates/util/patches.py
@@ -169,8 +169,11 @@ class iterload(object):
         # apply skip offset only once.
         # (we want to do this here, since we want to be able to re-set self.skip)
         if not self._seeked:
-            self._f.seek(self.skip)
-            self._seeked = True
+            try:
+                self._f.seek(self.skip)
+                self._seeked = True
+            except IndexError:
+                raise StopIteration("too short trajectory")
 
         if not isinstance(self._stride, np.ndarray) and self._chunksize == 0:
             # If chunk was 0 then we want to avoid filetype-specific code


### PR DESCRIPTION
This is important for time correlation (eg. tica) to skip too short trajectories.
Fixes #880
