### PR TITLE
[coordinates] add skip parameter to estimators to skip initial n_frames of each file.

### DIFF
--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -361,7 +361,7 @@ def source(inp, features=None, top=None, chunk_size=None, skip=0, **kw):
     return reader
 
 
-def pipeline(stages, run=True, stride=1, chunksize=100):
+def pipeline(stages, run=True, stride=1, chunksize=1000):
     r""" Data analysis pipeline.
 
     Constructs a data analysis :class:`Pipeline <pyemma.coordinates.pipelines.Pipeline>` and parametrizes it
@@ -448,7 +448,7 @@ def discretizer(reader,
                 cluster=None,
                 run=True,
                 stride=1,
-                chunksize=100):
+                chunksize=1000):
     r""" Specialized pipeline: From trajectories to clustering.
 
     Constructs a pipeline that consists of three stages:
@@ -840,11 +840,12 @@ def _param_stage(previous_stage, this_stage, stride=1, chunk_size=None):
         input_stage.chunksize = chunk_size
     # parametrize transformer
     this_stage.data_producer = input_stage
+    # TODO: do we need stride here? since it is an estimation parameter (eg. ctor param)
     this_stage.estimate(X=input_stage, stride=stride)
     return this_stage
 
 
-def pca(data=None, dim=-1, var_cutoff=0.95, stride=1, mean=None):
+def pca(data=None, dim=-1, var_cutoff=0.95, stride=1, mean=None, skip=0):
     r""" Principal Component Analysis (PCA).
 
     PCA is a linear transformation method that finds coordinates of maximal
@@ -982,12 +983,12 @@ def pca(data=None, dim=-1, var_cutoff=0.95, stride=1, mean=None):
         import warnings
         warnings.warn("provided mean ignored", DeprecationWarning)
 
-    res = PCA(dim=dim, var_cutoff=var_cutoff, mean=None)
+    res = PCA(dim=dim, var_cutoff=var_cutoff, mean=None, skip=skip)
     return _param_stage(data, res, stride=stride)
 
 
 def tica(data=None, lag=10, dim=-1, var_cutoff=0.95, kinetic_map=True, stride=1,
-         force_eigenvalues_le_one=False, mean=None, remove_mean=True):
+         force_eigenvalues_le_one=False, mean=None, remove_mean=True, skip=0):
     r""" Time-lagged independent component analysis (TICA).
 
     TICA is a linear transformation method. In contrast to PCA, which finds
@@ -1056,6 +1057,8 @@ def tica(data=None, lag=10, dim=-1, var_cutoff=0.95, kinetic_map=True, stride=1,
     remove_mean: bool, optional, default True
         remove mean during covariance estimation. Should not be turned off.
 
+    skip : int, default=0
+        skip the first initial n frames per trajectory.
 
     Returns
     -------
@@ -1156,7 +1159,7 @@ def tica(data=None, lag=10, dim=-1, var_cutoff=0.95, kinetic_map=True, stride=1,
         warnings.warn("user provided mean for TICA is deprecated and its value is ignored.")
 
     res = TICA(lag, dim=dim, var_cutoff=var_cutoff, kinetic_map=kinetic_map,
-               mean=mean, remove_mean=remove_mean)
+               mean=mean, remove_mean=remove_mean, skip=skip)
     return _param_stage(data, res, stride=stride)
 
 
@@ -1167,7 +1170,7 @@ def tica(data=None, lag=10, dim=-1, var_cutoff=0.95, kinetic_map=True, stride=1,
 # =========================================================================
 
 def cluster_mini_batch_kmeans(data=None, k=100, max_iter=10, batch_size=0.2, metric='euclidean',
-                              init_strategy='kmeans++', n_jobs=None, chunk_size=5000):
+                              init_strategy='kmeans++', n_jobs=None, chunk_size=5000, skip=0):
     r"""k-means clustering with mini-batch strategy
 
     Mini-batch k-means is an approximation to k-means which picks a randomly
@@ -1206,12 +1209,13 @@ def cluster_mini_batch_kmeans(data=None, k=100, max_iter=10, batch_size=0.2, met
     """
     from pyemma.coordinates.clustering.kmeans import MiniBatchKmeansClustering
     res = MiniBatchKmeansClustering(n_clusters=k, max_iter=max_iter, metric=metric, init_strategy=init_strategy,
-                                    batch_size=batch_size, n_jobs=n_jobs)
+                                    batch_size=batch_size, n_jobs=n_jobs, skip=skip)
     return _param_stage(data, res, stride=1, chunk_size=chunk_size)
 
 
 def cluster_kmeans(data=None, k=None, max_iter=10, tolerance=1e-5, stride=1,
-                   metric='euclidean', init_strategy='kmeans++', fixed_seed=False, n_jobs=None, chunk_size=5000):
+                   metric='euclidean', init_strategy='kmeans++', fixed_seed=False,
+                   n_jobs=None, chunk_size=5000, skip=0):
     r"""k-means clustering
 
     If data is given, it performs a k-means clustering and then assigns the
@@ -1268,6 +1272,9 @@ def cluster_kmeans(data=None, k=None, max_iter=10, tolerance=1e-5, stride=1,
         Number of data frames to process at once. Choose a higher value here,
         to optimize thread usage and gain processing speed.
 
+    skip : int, default=0
+        skip the first initial n frames per trajectory.
+
     Returns
     -------
     kmeans : a :class:`KmeansClustering <pyemma.coordinates.clustering.KmeansClustering>` clustering object
@@ -1319,11 +1326,12 @@ def cluster_kmeans(data=None, k=None, max_iter=10, tolerance=1e-5, stride=1,
     """
     from pyemma.coordinates.clustering.kmeans import KmeansClustering
     res = KmeansClustering(n_clusters=k, max_iter=max_iter, metric=metric, tolerance=tolerance,
-                           init_strategy=init_strategy, fixed_seed=fixed_seed, n_jobs=n_jobs)
+                           init_strategy=init_strategy, fixed_seed=fixed_seed, n_jobs=n_jobs, skip=skip)
     return _param_stage(data, res, stride=stride, chunk_size=chunk_size)
 
 
-def cluster_uniform_time(data=None, k=None, stride=1, metric='euclidean', n_jobs=None, chunk_size=5000):
+def cluster_uniform_time(data=None, k=None, stride=1, metric='euclidean',
+                         n_jobs=None, chunk_size=5000, skip=0):
     r"""Uniform time clustering
 
     If given data, performs a clustering that selects data points uniformly in
@@ -1352,6 +1360,9 @@ def cluster_uniform_time(data=None, k=None, stride=1, metric='euclidean', n_jobs
         object is independent, so you can parametrize at a long stride, and
         still map all frames through the transformer.
 
+    metric : str
+        metric to use during clustering ('euclidean', 'minRMSD')
+
     n_jobs : int or None, default None
         Number of threads to use during assignment of the data.
         If None, all available CPUs will be used.
@@ -1359,6 +1370,9 @@ def cluster_uniform_time(data=None, k=None, stride=1, metric='euclidean', n_jobs
     chunk_size: int, default=5000
         Number of data frames to process at once. Choose a higher value here,
         to optimize thread usage and gain processing speed.
+
+    skip : int, default=0
+        skip the first initial n frames per trajectory.
 
     Returns
     -------
@@ -1383,11 +1397,12 @@ def cluster_uniform_time(data=None, k=None, stride=1, metric='euclidean', n_jobs
 
     """
     from pyemma.coordinates.clustering.uniform_time import UniformTimeClustering 
-    res = UniformTimeClustering(k, metric=metric, n_jobs=n_jobs)
+    res = UniformTimeClustering(k, metric=metric, n_jobs=n_jobs, skip=skip)
     return _param_stage(data, res, stride=stride, chunk_size=chunk_size)
 
 
-def cluster_regspace(data=None, dmin=-1, max_centers=1000, stride=1, metric='euclidean', n_jobs=None, chunk_size=5000):
+def cluster_regspace(data=None, dmin=-1, max_centers=1000, stride=1, metric='euclidean',
+                     n_jobs=None, chunk_size=5000, skip=0):
     r"""Regular space clustering
 
     If given data, it performs a regular space clustering [1]_ and returns a
@@ -1474,12 +1489,13 @@ def cluster_regspace(data=None, dmin=-1, max_centers=1000, stride=1, metric='euc
     if dmin == -1:
         raise ValueError("provide a minimum distance for clustering, e.g. 2.0")
     from pyemma.coordinates.clustering.regspace import RegularSpaceClustering as _RegularSpaceClustering
-    res = _RegularSpaceClustering(dmin, max_centers=max_centers, metric=metric, n_jobs=n_jobs)
+    res = _RegularSpaceClustering(dmin, max_centers=max_centers, metric=metric,
+                                  n_jobs=n_jobs, stride=stride, skip=skip)
     return _param_stage(data, res, stride=stride, chunk_size=chunk_size)
 
 
 def assign_to_centers(data=None, centers=None, stride=1, return_dtrajs=True,
-                      metric='euclidean', n_jobs=None, chunk_size=5000):
+                      metric='euclidean', n_jobs=None, chunk_size=5000, skip=0):
     r"""Assigns data to the nearest cluster centers
 
     Creates a Voronoi partition with the given cluster centers. If given
@@ -1562,7 +1578,7 @@ def assign_to_centers(data=None, centers=None, stride=1, return_dtrajs=True,
         raise ValueError('You have to provide centers in form of a filename'
                          ' or NumPy array or a reader created by source function')
     from pyemma.coordinates.clustering.assign import AssignCenters
-    res = AssignCenters(centers, metric=metric, n_jobs=n_jobs)
+    res = AssignCenters(centers, metric=metric, n_jobs=n_jobs, skip=skip)
 
     parametrized_stage = _param_stage(data, res, stride=stride, chunk_size=chunk_size)
     if return_dtrajs and data is not None:

--- a/pyemma/coordinates/clustering/assign.py
+++ b/pyemma/coordinates/clustering/assign.py
@@ -41,11 +41,15 @@ class AssignCenters(AbstractClustering):
     ----------
     clustercenters : path to file (csv) or npyfile or ndarray
         cluster centers to use in assignment of data
-
     metric : str
         metric to use during clustering ('euclidean', 'minRMSD')
-
-
+    stride : int
+        stride
+    n_jobs : int or None, default None
+        Number of threads to use during assignment of the data.
+        If None, all available CPUs will be used.
+    skip : int, default=0
+        skip the first initial n frames per trajectory.
     Examples
     --------
     Assuming you have stored your centers in a CSV file:
@@ -59,7 +63,7 @@ class AssignCenters(AbstractClustering):
 
     """
 
-    def __init__(self, clustercenters, metric='euclidean', stride=1, n_jobs=None):
+    def __init__(self, clustercenters, metric='euclidean', stride=1, n_jobs=None, skip=0):
         super(AssignCenters, self).__init__(metric=metric, n_jobs=n_jobs)
 
         if isinstance(clustercenters, six.string_types):
@@ -73,9 +77,9 @@ class AssignCenters(AbstractClustering):
         if not clustercenters.ndim == 2:
             raise ValueError('cluster centers have to be 2d')
 
-        self.set_params(clustercenters=clustercenters, metric=metric, stride=stride)
+        self.set_params(clustercenters=clustercenters, metric=metric, stride=stride, skip=skip)
 
-        # since we provided centers, this transformer is already parametrized.
+        # since we provided centers, no estimation is required.
         self._estimated = True
 
     def describe(self):

--- a/pyemma/coordinates/clustering/interface.py
+++ b/pyemma/coordinates/clustering/interface.py
@@ -243,8 +243,9 @@ class AbstractClustering(StreamingTransformer, Model, ClusterMixin):
             if self._previous_stride is stride and len(self._dtrajs) > 0:
                 return self._dtrajs
             self._previous_stride = stride
+            skip = self.skip if hasattr(self, 'skip') else 0
             # map to column vectors
-            mapped = self.get_output(stride=stride, chunk=self.chunksize)
+            mapped = self.get_output(stride=stride, chunk=self.chunksize, skip=skip)
             # flatten and save
             self._dtrajs = [np.transpose(m)[0] for m in mapped]
             # return

--- a/pyemma/coordinates/clustering/regspace.py
+++ b/pyemma/coordinates/clustering/regspace.py
@@ -42,7 +42,7 @@ __all__ = ['RegularSpaceClustering']
 class RegularSpaceClustering(AbstractClustering):
     r"""Regular space clustering"""
 
-    def __init__(self, dmin, max_centers=1000, metric='euclidean', stride=1, n_jobs=None):
+    def __init__(self, dmin, max_centers=1000, metric='euclidean', stride=1, n_jobs=None, skip=0):
         """Clusters data objects in such a way, that cluster centers are at least in
         distance of dmin to each other according to the given metric.
         The assignment of data objects to cluster centers is performed by
@@ -81,7 +81,8 @@ class RegularSpaceClustering(AbstractClustering):
         """
         super(RegularSpaceClustering, self).__init__(metric=metric, n_jobs=n_jobs)
 
-        self.set_params(dmin=dmin, metric=metric, max_centers=max_centers, stride=stride)
+        self.set_params(dmin=dmin, metric=metric,
+                        max_centers=max_centers, stride=stride, skip=skip)
 
     def describe(self):
         return "[RegularSpaceClustering dmin=%f, inp_dim=%i]" % (self._dmin, self.data_producer.dimension())
@@ -132,10 +133,11 @@ class RegularSpaceClustering(AbstractClustering):
         ########
         # temporary list to store cluster centers
         clustercenters = []
-        it = iterable.iterator(return_trajindex=False)
         used_frames = 0
+        it = iterable.iterator(return_trajindex=False, stride=self.stride,
+                               chunk=self.chunksize, skip=self.skip)
         try:
-            with iterable.iterator(return_trajindex=False, stride=self.stride, chunk=self.chunksize) as it:
+            with it:
                 for X in it:
                     used_frames += len(X)
                     regspatial.cluster(X.astype(np.float32, order='C', copy=False),

--- a/pyemma/coordinates/data/_base/iterable.py
+++ b/pyemma/coordinates/data/_base/iterable.py
@@ -96,7 +96,7 @@ class Iterable(six.with_metaclass(ABCMeta, ProgressReporter, Loggable)):
         self._Y_source = DataInMemory(self._Y)
         self._mapping_to_mem_active = False
 
-    def iterator(self, stride=1, lag=0, chunk=None, return_trajindex=True, cols=None):
+    def iterator(self, stride=1, lag=0, chunk=None, return_trajindex=True, cols=None, skip=0):
         """ creates an iterator to stream over the (transformed) data.
 
         If your data is too large to fit into memory and you want to incrementally compute
@@ -117,6 +117,8 @@ class Iterable(six.with_metaclass(ABCMeta, ProgressReporter, Loggable)):
             a chunk of data if return_trajindex is False, otherwise a tuple of (trajindex, data).
         cols: array like, default=None
             return only the given columns.
+        skip: int, default=0
+            skip 'n' first frames of each trajectory.
 
         Returns
         -------
@@ -142,14 +144,14 @@ class Iterable(six.with_metaclass(ABCMeta, ProgressReporter, Loggable)):
         if self.in_memory:
             from pyemma.coordinates.data.data_in_memory import DataInMemory
             return DataInMemory(self._Y).iterator(
-                    lag=lag, chunk=chunk, stride=stride, return_trajindex=return_trajindex
+                    lag=lag, chunk=chunk, stride=stride, return_trajindex=return_trajindex, skip=skip
             )
         chunk = chunk if chunk is not None else self.default_chunksize
-        it = self._create_iterator(skip=0, chunk=chunk, stride=stride,
+        it = self._create_iterator(skip=skip, chunk=chunk, stride=stride,
                                    return_trajindex=return_trajindex, cols=cols)
         if lag > 0:
             it.return_traj_index = True
-            it_lagged = self._create_iterator(skip=lag, chunk=chunk, stride=stride,
+            it_lagged = self._create_iterator(skip=skip+lag, chunk=chunk, stride=stride,
                                               return_trajindex=True, cols=cols)
             return LaggedIterator(it, it_lagged, return_trajindex)
         return it

--- a/pyemma/coordinates/pipelines.py
+++ b/pyemma/coordinates/pipelines.py
@@ -79,8 +79,8 @@ class Pipeline(object):
         Appends the given element to the end of the current chain.
         """
         if not isinstance(e, Iterable):
-            raise TypeError("given element is not iterable in terms of "
-                            "PyEMMAs coordinate pipeline.")
+            raise TypeError("given element {} is not iterable in terms of "
+                            "PyEMMAs coordinate pipeline.".format(e))
 
         # only if we have more than one element
         if not e.is_reader and len(self._chain) >= 1:

--- a/pyemma/coordinates/tests/test_coordinates_iterator.py
+++ b/pyemma/coordinates/tests/test_coordinates_iterator.py
@@ -1,33 +1,31 @@
-import os
-import tempfile
 import unittest
-from glob import glob
+from abc import abstractmethod
 
 import numpy as np
+
 from pyemma.coordinates.data import DataInMemory
 from pyemma.coordinates.tests.util import create_top, create_traj_given_xyz
 from pyemma.util.files import TemporaryDirectory
+import os
+from glob import glob
 
 
-class CoordinatesIteratorBase(object):
+class TestCoordinatesIteratorBase(unittest.TestCase):
     rtol = 1e-7
     atol = 0
 
     def __init__(self, *args, **kwargs):
-        super(CoordinatesIteratorBase, self).__init__(*args, **kwargs)
+        super(TestCoordinatesIteratorBase, self).__init__(*args, **kwargs)
         self.helper = None
         # Kludge alert: We want this class to carry test cases without being run
         # by the unit test framework, so the `run' method is overridden to do
         # nothing.  But in order for sub-classes to be able to do something when
         # run is invoked, the constructor will rebind `run' from TestCase.
-        if self.__class__ != CoordinatesIteratorBase:
+        if self.__class__ != TestCoordinatesIteratorBase:
             # Rebind `run' from the parent class.
             self.run = unittest.TestCase.run.__get__(self, self.__class__)
         else:
-            def fake_run(*args, **kw):
-                pass
-
-            self.run = fake_run
+            self.run = lambda self, *args, **kwargs: None
 
     @classmethod
     def setUpClass(cls):
@@ -68,10 +66,6 @@ class CoordinatesIteratorBase(object):
         # 3 full chunks and 1 chunk of 5 frames per trajectory
         self.assertEqual(it4._n_chunks, 3 * 4)
 
-        it42 = self.reader.iterator(chunk=30, stride=2)
-        for itraj, X in it42:
-            print(itraj, X.shape)
-
         # test for lagged iterator
         for stride in range(1, 5):
             for lag in range(0, 18):
@@ -108,7 +102,7 @@ class CoordinatesIteratorBase(object):
             out[itraj].append(X)
 
         out = [np.concatenate(chunks) for chunks in out.values()]
-        np.testing.assert_allclose(out, desired, atol=self.atol, rtol=self.rtol)
+        np.testing.assert_allclose(out, desired)
 
     def test_chunksize(self):
         cs = np.arange(1, 17)
@@ -152,14 +146,14 @@ class CoordinatesIteratorBase(object):
         assert it.return_traj_index is False
         itraj = 0
         for tup in it:
-            np.testing.assert_allclose(tup, self.d[itraj], atol=self.atol, rtol=self.rtol)
+            np.testing.assert_allclose(tup, self.d[itraj])
             itraj += 1
 
         for tup in self.reader.iterator(return_trajindex=True):
             self.assertEqual(len(tup), 2)
         itraj = 0
         for tup in self.reader.iterator(return_trajindex=False):
-            np.testing.assert_allclose(tup, self.d[itraj], atol=self.atol, rtol=self.rtol)
+            np.testing.assert_allclose(tup, self.d[itraj])
             itraj += 1
 
     def test_pos(self):
@@ -173,7 +167,7 @@ class CoordinatesIteratorBase(object):
                 t = 0
 
 
-class DataInMem(CoordinatesIteratorBase, unittest.TestCase):
+class TestDataInMem(TestCoordinatesIteratorBase, unittest.TestCase):
     def setUp(self):
         self.reader = DataInMemory(self.d)
 
@@ -199,28 +193,31 @@ class DataInMem(CoordinatesIteratorBase, unittest.TestCase):
             actual = source(list(s.replace('.npy', '.exotic') for s in fns)).get_output()
             self.assertEqual(len(actual), len(fns))
             for a, e in zip(actual, expected):
-                np.testing.assert_allclose(a, e, atol=self.atol, rtol=self.rtol)
+                np.testing.assert_allclose(a, e)
 
 
 class TestTrajectoryFormatAbstract(object):
     _format = None
-    atol = 1e-8
-    rtol = 1e-6
 
     @classmethod
     def setUpClass(cls):
+        cls.d = [np.random.random((100, 3)) for _ in range(3)]
+
         super(TestTrajectoryFormatAbstract, cls).setUpClass()
+        import tempfile
         cls.tdir = tempfile.mkdtemp("test_coor_iter_{}".format(cls._format))
         cls.top = create_top(1)
+        cls._trajs = []
 
     @classmethod
     def tearDownClass(cls):
         import shutil
+        print("rm")
         shutil.rmtree(cls.tdir)
 
     @property
     def trajs(self):
-        if self._format is not None and not hasattr(self, '_trajs'):
+        if self._format is not None:
             self._trajs = [create_traj_given_xyz(xyz=xyz, top=self.top,
                                                  format=self._format, directory=self.tdir) for
                            xyz in self.d]
@@ -231,19 +228,19 @@ class TestTrajectoryFormatAbstract(object):
         self.reader = FeatureReader(self.trajs, self.top)
 
 
-class XTC(TestTrajectoryFormatAbstract, CoordinatesIteratorBase, unittest.TestCase):
+class TestXTC(TestTrajectoryFormatAbstract, TestCoordinatesIteratorBase, unittest.TestCase):
     _format = '.xtc'
 
 
-class DCD(TestTrajectoryFormatAbstract, CoordinatesIteratorBase, unittest.TestCase):
+class TestDCD(TestTrajectoryFormatAbstract, TestCoordinatesIteratorBase, unittest.TestCase):
     _format = '.dcd'
 
 
-class H5(TestTrajectoryFormatAbstract, CoordinatesIteratorBase, unittest.TestCase):
+class TestH5(TestTrajectoryFormatAbstract, TestCoordinatesIteratorBase, unittest.TestCase):
     _format = '.h5'
 
 
-class BinPos(TestTrajectoryFormatAbstract, CoordinatesIteratorBase, unittest.TestCase):
+class TestBinPos(TestTrajectoryFormatAbstract, TestCoordinatesIteratorBase, unittest.TestCase):
     _format = '.binpos'
 
 

--- a/pyemma/coordinates/tests/test_coordinates_iterator.py
+++ b/pyemma/coordinates/tests/test_coordinates_iterator.py
@@ -102,7 +102,7 @@ class TestCoordinatesIteratorBase(unittest.TestCase):
             out[itraj].append(X)
 
         out = [np.concatenate(chunks) for chunks in out.values()]
-        np.testing.assert_allclose(out, desired)
+        np.testing.assert_allclose(out, desired, atol=self.atol, rtol=self.rtol)
 
     def test_chunksize(self):
         cs = np.arange(1, 17)
@@ -146,14 +146,14 @@ class TestCoordinatesIteratorBase(unittest.TestCase):
         assert it.return_traj_index is False
         itraj = 0
         for tup in it:
-            np.testing.assert_allclose(tup, self.d[itraj])
+            np.testing.assert_allclose(tup, self.d[itraj], atol=self.atol, rtol=self.rtol)
             itraj += 1
 
         for tup in self.reader.iterator(return_trajindex=True):
             self.assertEqual(len(tup), 2)
         itraj = 0
         for tup in self.reader.iterator(return_trajindex=False):
-            np.testing.assert_allclose(tup, self.d[itraj])
+            np.testing.assert_allclose(tup, self.d[itraj], atol=self.atol, rtol=self.rtol)
             itraj += 1
 
     def test_pos(self):
@@ -193,11 +193,13 @@ class TestDataInMem(TestCoordinatesIteratorBase, unittest.TestCase):
             actual = source(list(s.replace('.npy', '.exotic') for s in fns)).get_output()
             self.assertEqual(len(actual), len(fns))
             for a, e in zip(actual, expected):
-                np.testing.assert_allclose(a, e)
+                np.testing.assert_allclose(a, e, atol=self.atol, rtol=self.rtol)
 
 
 class TestTrajectoryFormatAbstract(object):
     _format = None
+    atol = 1e-8
+    rtol= 1e-6
 
     @classmethod
     def setUpClass(cls):
@@ -212,7 +214,6 @@ class TestTrajectoryFormatAbstract(object):
     @classmethod
     def tearDownClass(cls):
         import shutil
-        print("rm")
         shutil.rmtree(cls.tdir)
 
     @property

--- a/pyemma/coordinates/tests/test_kmeans.py
+++ b/pyemma/coordinates/tests/test_kmeans.py
@@ -175,5 +175,8 @@ class TestKmeans(unittest.TestCase):
     def test_with_n_jobs_minrmsd(self):
         kmeans = cluster_kmeans(np.random.rand(500,3), 10, metric='minRMSD')
 
+    def test_skip(self):
+        cluster_kmeans(np.random.rand(100, 3), skip=42)
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/tests/test_tica.py
+++ b/pyemma/coordinates/tests/test_tica.py
@@ -155,6 +155,10 @@ class TestTICA_Basic(unittest.TestCase):
         with self.assertRaises(ValueError):
             tica(trajs, lag=100)
 
+    def test_with_skip(self):
+        data = np.random.random((100, 10))
+        tica_obj = api.tica(lag=10, dim=1, skip=1)
+
 
 class TestTICAExtensive(unittest.TestCase):
     @classmethod

--- a/pyemma/coordinates/tests/test_uniform_time.py
+++ b/pyemma/coordinates/tests/test_uniform_time.py
@@ -54,6 +54,16 @@ class TestUniformTimeClustering(unittest.TestCase):
         c.data_producer = reader
         c.parametrize()
 
+    def test_2d_skip(self):
+        x = np.random.random((300, 3))
+        reader = DataInMemory(x)
+
+        k = 2
+        c = api.cluster_uniform_time(k=k, skip=100)
+
+        c.data_producer = reader
+        c.parametrize()
+
     def test_big_k(self):
         x = np.random.random((300, 3))
         reader = DataInMemory(x)

--- a/pyemma/coordinates/transform/pca.py
+++ b/pyemma/coordinates/transform/pca.py
@@ -55,7 +55,7 @@ class PCAModel(Model):
 class PCA(StreamingTransformer, ProgressReporter):
     r""" Principal component analysis."""
 
-    def __init__(self, dim=-1, var_cutoff=0.95, mean=None, stride=1):
+    def __init__(self, dim=-1, var_cutoff=0.95, mean=None, stride=1, skip=0):
         r""" Principal component analysis.
 
         Given a sequence of multivariate data :math:`X_t`,
@@ -99,8 +99,7 @@ class PCA(StreamingTransformer, ProgressReporter):
             raise ValueError('Trying to set both the number of dimension and the subspace variance. Use either or.')
 
         self._model = PCAModel()
-        self.set_params(dim=dim, var_cutoff=var_cutoff, mean=mean)
-        self._model = PCAModel()
+        self.set_params(dim=dim, var_cutoff=var_cutoff, mean=mean, stride=stride, skip=skip)
 
     def describe(self):
         return "[PCA, output dimension = %i]" % self.dim
@@ -199,7 +198,8 @@ class PCA(StreamingTransformer, ProgressReporter):
     def _estimate(self, iterable, **kw):
         partial_fit = 'partial' in kw
 
-        with iterable.iterator(return_trajindex=False, chunk=self.chunksize) as it:
+        with iterable.iterator(return_trajindex=False, chunk=self.chunksize,
+                               stride=self.stride, skip=self.skip) as it:
             n_chunks = it._n_chunks
             self._progress_register(n_chunks, "calc mean+cov", 0)
             self._init_covar(partial_fit, n_chunks)

--- a/pyemma/coordinates/transform/tica.py
+++ b/pyemma/coordinates/transform/tica.py
@@ -59,7 +59,7 @@ class TICA(StreamingTransformer):
     r""" Time-lagged independent component analysis (TICA)"""
 
     def __init__(self, lag, dim=-1, var_cutoff=0.95, kinetic_map=True, epsilon=1e-6,
-                 mean=None, stride=1, remove_mean=True):
+                 mean=None, stride=1, remove_mean=True, skip=0):
         r""" Time-lagged independent component analysis (TICA) [1]_, [2]_, [3]_.
 
         Parameters
@@ -85,6 +85,8 @@ class TICA(StreamingTransformer):
             This option is deprecated
         remove_mean: bool, optional, default True
             remove mean during covariance estimation. Should not be turned off.
+        skip : int, default=0
+            skip the first initial n frames per trajectory.
 
         Notes
         -----
@@ -137,7 +139,7 @@ class TICA(StreamingTransformer):
         # empty dummy model instance
         self._model = TICAModel()
         self.set_params(lag=lag, dim=dim, var_cutoff=var_cutoff, kinetic_map=kinetic_map,
-                        epsilon=epsilon, mean=mean, stride=stride, remove_mean=remove_mean)
+                        epsilon=epsilon, mean=mean, stride=stride, remove_mean=remove_mean, skip=skip)
 
     @property
     def lag(self):
@@ -270,17 +272,20 @@ class TICA(StreamingTransformer):
             self._logger.debug("Running TICA with tau=%i; Estimating two covariance matrices"
                                " with dimension (%i, %i)" % (self._lag, indim, indim))
 
-        if not any(iterable.trajectory_lengths(stride=self.stride, skip=self.lag) > 0):
+        if not any(iterable.trajectory_lengths(stride=self.stride, skip=self.lag+self.skip) > 0):
             if partial_fit:
                 self.logger.warn("Could not use data passed to partial_fit(), "
                                  "because no single data set [longest=%i] is longer than lag time [%i]"
-                                 % (max(iterable.trajectory_lengths(self.stride)), self.lag))
+                                 % (max(iterable.trajectory_lengths(self.stride, skip=self.skip)), self.lag))
                 return self
             else:
                 raise ValueError("None single dataset [longest=%i] is longer than"
-                                 " lag time [%i]." % (max(iterable.trajectory_lengths(self.stride)), self.lag))
+                                 " lag time [%i]." % (max(iterable.trajectory_lengths(self.stride, skip=self.skip)), self.lag))
 
-        it = iterable.iterator(lag=self.lag, return_trajindex=False, chunk=self.chunksize)
+        self.logger.debug("will use {} total frames for {}".
+                          format(iterable.trajectory_lengths(self.stride, skip=self.skip), self.name))
+
+        it = iterable.iterator(lag=self.lag, return_trajindex=False, chunk=self.chunksize, skip=self.skip)
         with it:
             self._progress_register(it._n_chunks, "calculate mean+cov", 0)
             self._init_covar(partial_fit, it._n_chunks)

--- a/pyemma/coordinates/transform/transformer.py
+++ b/pyemma/coordinates/transform/transformer.py
@@ -236,8 +236,8 @@ class StreamingTransformer(Transformer, Estimator, DataSource, NotifyOnChangesMi
     def trajectory_lengths(self, stride=1, skip=0):
         return self.data_producer.trajectory_lengths(stride=stride, skip=skip)
 
-    def n_frames_total(self, stride=1):
-        return self.data_producer.n_frames_total(stride=stride)
+    def n_frames_total(self, stride=1, skip=0):
+        return self.data_producer.n_frames_total(stride=stride, skip=skip)
 
 
 class StreamingTransformerIterator(DataSourceIterator):


### PR DESCRIPTION
The interface seems redundant at the first view (eg. for a pipeline one has to give the same skip parameter for each element in the pipeline), ... but it totally fits into the logic of separating the IteratorState from the actual DataSource.

It also makes sense to store skip as estimation parameter, since it behaves like stride: it manipulates how much data we are using.

PS: I hope I have not forgotten to pass any "skip"
