### PR TITLE
[coor/FeatureReader] use mdtraj.Topology as top argument to avoid some hassle.

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -12,6 +12,7 @@ Changelog
 
 - coordinates: MiniBatchKmeans with MD-data is now memory efficient
   and successfully converges. It used to only one batch during iteration. #887 #890
+- coordinates: source and load function accept mdtraj.Trajectory objects to extract topology. #922. Thanks @jeiros
 - base: fix progress bars for modern joblib versions.
 - plots: fix regression in plot_markov_model with newer NumPy versions #907. Thanks @ghoti687.
 

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -159,8 +159,10 @@ def load(trajfiles, features=None, top=None, stride=1, chunk_size=None, **kw):
         a featurizer object specifying how molecular dynamics files should
         be read (e.g. intramolecular distances, angles, dihedrals, etc).
 
-    top : str, optional, default = None
-        A molecular topology file, e.g. in PDB (.pdb) format
+    top : str, mdtraj.Trajectory or mdtraj.Topology, optional, default = None
+        A molecular topology file, e.g. in PDB (.pdb) format or an already
+        loaded mdtraj.Topology object. If it is an mdtraj.Trajectory object, the topology
+        will be extracted from it.
 
     stride : int, optional, default = 1
         Load only every stride'th frame. By default, every frame is loaded
@@ -260,10 +262,12 @@ def source(inp, features=None, top=None, chunk_size=None, **kw):
         dynamics trajectories or data, and will otherwise create a warning and
         have no effect.
 
-    top : str, optional, default = None
+    top : str, mdtraj.Trajectory or mdtraj.Topology, optional, default = None
         A topology file name. This is needed when molecular dynamics
         trajectories are given and no featurizer is given.
-        In this case, only the Cartesian coordinates will be read.
+        In this case, only the Cartesian coordinates will be read. You can also pass an already
+        loaded mdtraj.Topology object. If it is an mdtraj.Trajectory object, the topology
+        will be extracted from it.
 
     chunk_size: int, optional, default = 100 for file readers and 5000 for
         already loaded data The chunk size at which the input file is being

--- a/pyemma/coordinates/data/feature_reader.py
+++ b/pyemma/coordinates/data/feature_reader.py
@@ -161,8 +161,9 @@ class FeatureReader(DataSource):
 
     def _assert_toptraj_consistency(self):
         r""" Check if the topology and the filenames of the reader have the same n_atoms"""
-        traj = mdtraj.load_frame(self.filenames[0], index=0, top=self.topfile)
-        desired_n_atoms = self.featurizer.topology.n_atoms
+        top = self.featurizer.topology
+        traj = mdtraj.load_frame(self.filenames[0], index=0, top=top)
+        desired_n_atoms = top.n_atoms
         assert traj.xyz.shape[1] == desired_n_atoms, "Mismatch in the number of atoms between the topology" \
                                                      " and the first trajectory file, %u vs %u" % \
                                                      (desired_n_atoms, traj.xyz.shape[1])
@@ -401,7 +402,7 @@ class FeatureReaderIterator(DataSourceIterator):
         self._closed = False
 
     def _create_patched_iter(self, filename, skip=0, stride=1, atom_indices=None):
-        return patches.iterload(filename, chunk=self.chunksize, top=self._data_source.topfile,
+        return patches.iterload(filename, chunk=self.chunksize, top=self._data_source.featurizer.topology,
                                 skip=skip, stride=stride, atom_indices=atom_indices)
 
     def reset(self):

--- a/pyemma/coordinates/data/featurization/featurizer.py
+++ b/pyemma/coordinates/data/featurization/featurizer.py
@@ -57,6 +57,8 @@ class MDFeaturizer(Loggable):
             self.topologyfile = topfile
         elif isinstance(topfile, mdtraj.Topology):
             self.topology = topfile
+        elif isinstance(topfile, mdtraj.Trajectory):
+            self.topology = topfile.topology
         else:
             raise ValueError("no valid topfile arg: type was %s, "
                              "but only string or mdtraj.Topology allowed." % type(topfile))

--- a/pyemma/coordinates/tests/test_api_load.py
+++ b/pyemma/coordinates/tests/test_api_load.py
@@ -110,5 +110,13 @@ class TestAPILoad(unittest.TestCase):
         with self.assertRaises(ValueError):
             load([], top=pdb_file)
 
+    def test_load_features_pass_trajectory_as_topology(self):
+        import mdtraj
+        t = mdtraj.load(pdb_file)
+        features = api.featurizer(t)
+
+        traj_files = [f for f in self.bpti_mini_files if f.endswith('.netcdf')]
+        load(traj_files, features=features)
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/util/patches.py
+++ b/pyemma/coordinates/util/patches.py
@@ -50,6 +50,8 @@ def _cache_mdtraj_topology(args):
     def wrap(top_file):
         if isinstance(top_file, Topology):
             return top_file
+        if isinstance(top_file, Trajectory):
+            return top_file.topology
         hasher = hashlib.md5()
         with open(top_file, 'rb') as f:
             hasher.update(f.read())


### PR DESCRIPTION
This allows also to pass mdtraj.Trajectory as top argument for load/source.
Fixes #922
