### PR TITLE
Refactor msm use properties

### DIFF
--- a/pyemma/_base/model.py
+++ b/pyemma/_base/model.py
@@ -185,6 +185,7 @@ class SampledModel(Model):
 
         """
         self._check_samples_available()
+        # TODO: can we use np.fromiter here? We would ne the same shape of every member for this!
         return [call_member(M, f, *args, **kwargs) for M in self.samples]
 
     def sample_mean(self, f, *args, **kwargs):

--- a/pyemma/msm/estimators/bayesian_hmsm.py
+++ b/pyemma/msm/estimators/bayesian_hmsm.py
@@ -198,7 +198,6 @@ class BayesianHMSM(_MaximumLikelihoodHMSM, _SampledHMSM, ProgressReporter):
 
         # here we blow up the output matrix (if needed) to the FULL state space because we want to use dtrajs in the
         # Bayesian HMM sampler. This is just an initialization.
-        import msmtools.estimation as msmest
         nstates_full = msmest.number_of_states(dtrajs)
         if self.nstates_obs < nstates_full:
             eps = 0.01 / nstates_full  # default output probability, in order to avoid zero columns

--- a/pyemma/msm/estimators/lagged_model_validators.py
+++ b/pyemma/msm/estimators/lagged_model_validators.py
@@ -397,7 +397,8 @@ class ChapmanKolmogorovValidator(LaggedModelValidator):
             p0sub /= p0sub.sum()  # renormalize
             pksub_samples = model.sample_f('propagate', p0sub, mlag)
             for j in range(self.nsets):
-                pk_on_set_samples = [np.dot(pksub, self.memberships[subset, j]) for pksub in pksub_samples]
+                pk_on_set_samples = np.fromiter((np.dot(pksub, self.memberships[subset, j])
+                                                 for pksub in pksub_samples), dtype=np.float, count=len(pksub_samples))
                 l[i, j], r[i, j] = confidence_interval(pk_on_set_samples, conf=self.conf)
         return l, r
 

--- a/pyemma/msm/models/hmsm.py
+++ b/pyemma/msm/models/hmsm.py
@@ -63,7 +63,7 @@ class HMSM(_MSM):
         """
         # construct superclass and check input
         _MSM.__init__(self, P, dt_model=dt_model)
-        self.set_model_params(pobs=pobs, pi=pi, dt_model=dt_model)
+        self.set_model_params(P=P, pobs=pobs, pi=pi, dt_model=dt_model)
 
     def set_model_params(self, P=None, pobs=None, pi=None, reversible=None, dt_model='1 step', neig=None):
         """

--- a/pyemma/msm/models/msm.py
+++ b/pyemma/msm/models/msm.py
@@ -26,12 +26,14 @@ and provides them for later access.
 """
 
 from __future__ import absolute_import
+
+from pyemma.util.annotators import aliased, alias
 from six.moves import range
 
 __docformat__ = "restructuredtext en"
 
 import copy
-import numpy as np
+import numpy as _np
 from math import ceil
 from pyemma._base.model import Model as _Model
 from pyemma.util import types as _types
@@ -39,7 +41,7 @@ from pyemma.util import types as _types
 
 # TODO: Explain concept of an active set
 
-
+@aliased
 class MSM(_Model):
     r"""Markov model with a given transition matrix"""
 
@@ -89,7 +91,7 @@ class MSM(_Model):
         self.ncv = ncv
 
     # TODO: maybe rename to parametrize in order to avoid confusion with set_params that has a different behavior?
-    def set_model_params(self, P=None, pi=None, reversible=None, dt_model='1 step', neig=None):
+    def set_model_params(self, P, pi=None, reversible=None, dt_model='1 step', neig=None):
         """ Call to set all basic model parameters.
 
         Sets or updates given model parameters. This argument list of this
@@ -135,50 +137,58 @@ class MSM(_Model):
         list of this function (by mandatory or keyword arguments)
 
         """
-        import msmtools.analysis as msmana
-        # check input
-        if P is not None:
-            if not msmana.is_transition_matrix(P, tol=1e-8):
-                raise ValueError('T is not a transition matrix.')
-
-        # update all parameters
-        self.update_model_params(P=P, pi=pi, reversible=reversible, dt_model=dt_model, neig=neig)
-        # set ncv for consistency
-        if not hasattr(self, 'ncv'):
-            self.ncv = None
-        # update derived quantities
-        from pyemma.util.units import TimeUnit
-        self._timeunit_model = TimeUnit(self.dt_model)
-
-        # set P and derived quantities if available
-        if P is not None:
-            from scipy.sparse import issparse
-            # set states
-            self._nstates = np.shape(P)[0]
-            if self.reversible is None:
-                self.reversible = msmana.is_reversible(P)
-            self.sparse = issparse(P)
-
-            # set or correct eig param
-            if neig is None:
-                if self.sparse:
-                    self.neig = 10
-                else:
-                    self.neig = self._nstates
+        self.P = P
+        self.pi = pi
+        self.reversible = reversible
+        self.dt_model = dt_model
+        self.neig = neig
 
     ################################################################################
     # Basic attributes
     ################################################################################
 
     @property
-    def is_reversible(self):
-        """Returns whether the MSM is reversible """
-        return self.reversible
+    @alias('transition_matrix')
+    def P(self):
+        """ The transition matrix on the active set. """
+        return self._P
+
+    @P.setter
+    def P(self, value):
+        self._P = value
+        import msmtools.analysis as msmana
+        # check input
+        if self._P is not None:
+            if not msmana.is_transition_matrix(self._P, tol=1e-8):
+                raise ValueError('T is not a transition matrix.')
+            # set states
+            self.nstates = _np.shape(self._P)[0]
+            self.reversible = msmana.is_reversible(self._P, tol=1e-10)
+
+            from scipy.sparse import issparse
+            self.sparse = issparse(self._P)
+
+        # TODO: if spectral decomp etc. already has been computed, reset its state.
 
     @property
-    def is_sparse(self):
+    @alias('is_reversible')
+    def reversible(self):
+        """Returns whether the MSM is reversible """
+        return self._reversible
+
+    @reversible.setter
+    def reversible(self, value):
+        self._reversible = bool(value)
+
+    @property
+    @alias('is_sparse')
+    def sparse(self):
         """Returns whether the MSM is sparse """
-        return self.sparse
+        return self._sparse
+
+    @sparse.setter
+    def sparse(self, value):
+        self._sparse = bool(value)
 
     @property
     def timestep_model(self):
@@ -197,30 +207,60 @@ class MSM(_Model):
         self._nstates = n
 
     @property
-    def transition_matrix(self):
-        r"""
-        The transition matrix on the active set.
+    def neig(self):
+        """ number of eigenvalues to compute. """
+        return self._neig
 
-        """
-        try:
-            return self.P
-        except AttributeError:
-            raise AttributeError('MSM has not yet been parametrized.'
-                                 'Call "MSM(P)", set_model_params(P=P) or set transition matrix')
+    @neig.setter
+    def neig(self, value):
+        # set or correct eig param
+        if value is None:
+            if self.sparse:
+                value = 10
+            else:
+                value = self._nstates
+
+        # set ncv for consistency
+        if not hasattr(self, 'ncv'):
+            self.ncv = None
+
+        self._neig = value
+
+    @property
+    def dt_model(self):
+        return self._dt_model
+
+    @dt_model.setter
+    def dt_model(self, value):
+        self._dt_model = value
+
+        # this is only used internally?
+        from pyemma.util.units import TimeUnit
+        self._timeunit_model = TimeUnit(self.dt_model)
+
 
     ################################################################################
     # Spectral quantities
     ################################################################################
 
     @property
-    def stationary_distribution(self):
+    @alias('stationary_distribution')
+    def pi(self):
+        return self._pi
+
+    @pi.setter
+    def pi(self, value):
         """The stationary distribution on the MSM states"""
-        if self.pi is not None:
-            return self.pi
-        else:
+        if value is None and self.P is not None:
             from msmtools.analysis import stationary_distribution as _statdist
-            self.pi = _statdist(self.transition_matrix)
-            return self.pi
+            value = _statdist(self.P)
+        elif self.P is not None:
+            pass
+            # check input
+            #_np.testing.assert_allclose(_np.dot(self.P, value), value,
+            #                            atol=1e-14, rtol=0.01, err_msg='given stationary distribution '
+            #                                                           'is not a valid unique measure.')
+        self._pi = value
 
     def _compute_eigenvalues(self, neig):
         """ Conducts the eigenvalue decomposition and stores k eigenvalues, left and right eigenvectors """
@@ -259,7 +299,7 @@ class MSM(_Model):
             self._L = self._L.real
         else:
             self._R, self._D, self._L = rdl_decomposition(self.transition_matrix, k=neig, norm='standard', ncv=self.ncv)
-        self._eigenvalues = np.diag(self._D)
+        self._eigenvalues = _np.diag(self._D)
 
     def _ensure_eigendecomposition(self, neig=None):
         """Ensures that eigendecomposition has been performed with at least neig eigenpairs
@@ -273,7 +313,7 @@ class MSM(_Model):
             neig = self.neig
         # ensure that eigenvalue decomposition with k components is done.
         try:
-            m = self._D.shape[0]  # this will raise and exception if self._D # doesn't exist yet.
+            m = self._D.shape[0]  # this will raise and exception if self._D doesn't exist yet.
             if m < neig:
                 # not enough eigenpairs present - recompute:
                 self._compute_eigendecomposition(neig)
@@ -400,9 +440,9 @@ class MSM(_Model):
             return p0 / p0.sum()
 
         if self.is_sparse:  # sparse: we don't have a full eigenvalue set, so just propagate
-            pk = np.array(p0)
+            pk = _np.array(p0)
             for i in range(k):
-                pk = np.dot(pk.T, self.transition_matrix)
+                pk = _np.dot(pk.T, self.transition_matrix)
         else:  # dense: employ eigenvalue decomposition
             self._ensure_eigendecomposition(self.nstates)
             from pyemma.util.linalg import mdot
@@ -426,7 +466,7 @@ class MSM(_Model):
         A : int or int array
             set of states
         """
-        assert np.max(A) < self._nstates, 'Chosen set contains states that are not included in the active set.'
+        assert _np.max(A) < self._nstates, 'Chosen set contains states that are not included in the active set.'
 
     def _mfpt(self, P, A, B, mu=None):
         self._assert_in_active(A)
@@ -509,7 +549,7 @@ class MSM(_Model):
         """
         # check input and go
         a = _types.ensure_ndarray(a, ndim=1, size=self.nstates, kind='numeric')
-        return np.dot(a, self.stationary_distribution)
+        return _np.dot(a, self.stationary_distribution)
 
     def correlation(self, a, b=None, maxtime=None, k=None, ncv=None):
         r"""Time-correlation for equilibrium experiment.
@@ -622,7 +662,7 @@ class MSM(_Model):
         if maxtime is None:
             # by default, use five times the longest relaxation time, because then we have relaxed to equilibrium.
             maxtime = 5 * self.timescales()[0]
-        steps = np.arange(int(ceil(float(maxtime) / self._timeunit_model.dt)))
+        steps = _np.arange(int(ceil(float(maxtime) / self._timeunit_model.dt)))
         # compute correlation
         from msmtools.analysis import correlation as _correlation
         # TODO: this could be improved. If we have already done an eigenvalue decomposition, we could provide it.
@@ -749,7 +789,7 @@ class MSM(_Model):
             # by default, use five times the longest relaxation time, because then we have relaxed to equilibrium.
             maxtime = 5 * self.timescales()[0]
         kmax = int(ceil(float(maxtime) / self._timeunit_model.dt))
-        steps = np.array(list(range(kmax)), dtype=int)
+        steps = _np.array(list(range(kmax)), dtype=int)
         # compute relaxation function
         from msmtools.analysis import relaxation as _relaxation
         # TODO: this could be improved. If we have already done an eigenvalue decomposition, we could provide it.
@@ -1012,6 +1052,8 @@ class MSM(_Model):
         self._assert_metastable()
         return self._metastable_assignments
 
+
+
     def simulate(self,  N, start=None, stop=None, dt=1):
         """
         Generates a realization of the Markov Model
@@ -1036,5 +1078,7 @@ class MSM(_Model):
         htraj: (N/dt, ) ndarray
             The state trajectory with length N/dt
         """
+
         import msmtools.generation as msmgen
+
         return msmgen.generate_traj(self.transition_matrix,  N, start=start, stop=stop, dt=dt)

--- a/pyemma/msm/models/msm.py
+++ b/pyemma/msm/models/msm.py
@@ -258,11 +258,17 @@ class MSM(_Model):
             from msmtools.analysis import stationary_distribution as _statdist
             value = _statdist(self.P)
         elif self.P is not None:
-            pass
             # check input
-            #_np.testing.assert_allclose(_np.dot(self.P, value), value,
-            #                            atol=1e-14, rtol=0.01, err_msg='given stationary distribution '
-            #                                                           'is not a valid unique measure.')
+            # this only holds for a unique measure...
+            try:
+                _np.testing.assert_allclose(_np.dot(self.P, value), value,
+                                        atol=1e-14, rtol=0.01, err_msg='given stationary distribution '
+                                                                           'is not a valid unique measure.')
+
+            except AssertionError:
+                import logging
+                logger = logging.getLogger('pyemma.msm')
+                logger.exception("pi not valid/unique")
         self._pi = value
 
     def _compute_eigenvalues(self, neig):

--- a/pyemma/msm/models/msm.py
+++ b/pyemma/msm/models/msm.py
@@ -137,7 +137,8 @@ class MSM(_Model):
         list of this function (by mandatory or keyword arguments)
 
         """
-        self.P = P
+        if P is not None:
+            self.P = P
         self.pi = pi
         self.reversible = reversible
         self.dt_model = dt_model
@@ -155,6 +156,8 @@ class MSM(_Model):
 
     @P.setter
     def P(self, value):
+        if value is None:
+            print("P IS NOOONE!!!!!!!!!!!!11")
         self._P = value
         import msmtools.analysis as msmana
         # check input
@@ -299,6 +302,14 @@ class MSM(_Model):
             self._L = self._L.real
         else:
             self._R, self._D, self._L = rdl_decomposition(self.transition_matrix, k=neig, norm='standard', ncv=self.ncv)
+            # if the imaginary parts are zero, discard them.
+            if _np.all(self._R.imag == 0):
+                self._R = _np.real(self._R)
+            if _np.all(self._D.imag == 0):
+                self._D = _np.real(self._D)
+            if _np.all(self._L.imag == 0):
+                self._L = _np.real(self._L)
+
         self._eigenvalues = _np.diag(self._D)
 
     def _ensure_eigendecomposition(self, neig=None):

--- a/pyemma/msm/models/msm.py
+++ b/pyemma/msm/models/msm.py
@@ -156,8 +156,6 @@ class MSM(_Model):
 
     @P.setter
     def P(self, value):
-        if value is None:
-            print("P IS NOOONE!!!!!!!!!!!!11")
         self._P = value
         import msmtools.analysis as msmana
         # check input
@@ -262,13 +260,14 @@ class MSM(_Model):
             # this only holds for a unique measure...
             try:
                 _np.testing.assert_allclose(_np.dot(self.P, value), value,
-                                        atol=1e-14, rtol=0.01, err_msg='given stationary distribution '
+                                            atol=1e-14, rtol=0.01, err_msg='given stationary distribution '
                                                                            'is not a valid unique measure.')
 
             except AssertionError:
-                import logging
-                logger = logging.getLogger('pyemma.msm')
-                logger.exception("pi not valid/unique")
+                pass
+                # import logging
+                # logger = logging.getLogger('pyemma.msm')
+                # logger.exception("pi not valid/unique")
         self._pi = value
 
     def _compute_eigenvalues(self, neig):
@@ -280,6 +279,9 @@ class MSM(_Model):
                                        reversible=True, mu=self.stationary_distribution)
         else:
             self._eigenvalues = anaeig(self.transition_matrix, k=neig, ncv=self.ncv, reversible=False)
+
+        if _np.all(self._eigenvalues.imag == 0):
+            self._eigenvalues = self._eigenvalues.real
 
     def _ensure_eigenvalues(self, neig=None):
         """ Ensures that at least neig eigenvalues have been computed """

--- a/pyemma/msm/models/msm.py
+++ b/pyemma/msm/models/msm.py
@@ -259,7 +259,8 @@ class MSM(_Model):
             # check input
             # this only holds for a unique measure...
             try:
-                _np.testing.assert_allclose(_np.dot(self.P, value), value,
+                test_unique = self.P.dot(value)
+                _np.testing.assert_allclose(test_unique, value,
                                             atol=1e-14, rtol=0.01, err_msg='given stationary distribution '
                                                                            'is not a valid unique measure.')
 
@@ -268,6 +269,8 @@ class MSM(_Model):
                 # import logging
                 # logger = logging.getLogger('pyemma.msm')
                 # logger.exception("pi not valid/unique")
+            # check sum is one
+            _np.testing.assert_equal(_np.sum(value), 1)
         self._pi = value
 
     def _compute_eigenvalues(self, neig):

--- a/pyemma/msm/models/msm.py
+++ b/pyemma/msm/models/msm.py
@@ -467,7 +467,7 @@ class MSM(_Model):
             from pyemma.util.linalg import mdot
             pk = mdot(p0.T,
                       self.eigenvectors_right(),
-                      np.diag(np.power(self.eigenvalues(), k)),
+                      _np.diag(_np.power(self.eigenvalues(), k)),
                       self.eigenvectors_left()).real
         # normalize to 1.0 and return
         return pk / pk.sum()

--- a/pyemma/msm/models/msm.py
+++ b/pyemma/msm/models/msm.py
@@ -1074,8 +1074,6 @@ class MSM(_Model):
         self._assert_metastable()
         return self._metastable_assignments
 
-
-
     def simulate(self,  N, start=None, stop=None, dt=1):
         """
         Generates a realization of the Markov Model
@@ -1100,7 +1098,5 @@ class MSM(_Model):
         htraj: (N/dt, ) ndarray
             The state trajectory with length N/dt
         """
-
         import msmtools.generation as msmgen
-
         return msmgen.generate_traj(self.transition_matrix,  N, start=start, stop=stop, dt=dt)

--- a/pyemma/msm/models/msm.py
+++ b/pyemma/msm/models/msm.py
@@ -270,7 +270,7 @@ class MSM(_Model):
                 # logger = logging.getLogger('pyemma.msm')
                 # logger.exception("pi not valid/unique")
             # check sum is one
-            _np.testing.assert_equal(_np.sum(value), 1)
+            _np.testing.assert_allclose(_np.sum(value), 1, atol=1e-14)
         self._pi = value
 
     def _compute_eigenvalues(self, neig):


### PR DESCRIPTION
The attributes transition matrix, stationary_distribution used to be getters for P and pi respectively. This has been replaced by single properties, which set derived quantities and the prior long name getters are just aliases for these.

This simplifies the MSM class a bit, which is needed for #867.

It fully preserves the API.

It also adds discards imaginary parts of eigen decompositions, if all imaginary parts are zero, in order to avoid some problems.
