### PR TITLE
Ticafixes

### DIFF
--- a/pyemma/coordinates/data/_base/iterable.py
+++ b/pyemma/coordinates/data/_base/iterable.py
@@ -351,7 +351,7 @@ class LaggedIterator(object):
         return min(n1, n2)
 
     def __len__(self):
-        return int(min(self._it.trajectory_lengths(), self._it_lagged.trajectory_lengths()))
+        return min(self._it.trajectory_lengths().min(), self._it_lagged.trajectory_lengths().min())
 
     def __iter__(self):
         return self

--- a/pyemma/coordinates/data/_base/iterable.py
+++ b/pyemma/coordinates/data/_base/iterable.py
@@ -351,7 +351,7 @@ class LaggedIterator(object):
         return min(n1, n2)
 
     def __len__(self):
-        return min(self._it.trajectory_lengths(), self._it_lagged.trajectory_lengths())
+        return int(min(self._it.trajectory_lengths(), self._it_lagged.trajectory_lengths()))
 
     def __iter__(self):
         return self

--- a/pyemma/coordinates/transform/tica.py
+++ b/pyemma/coordinates/transform/tica.py
@@ -340,7 +340,7 @@ class TICA(StreamingTransformer):
         Y = np.dot(X_meanfree, self.eigenvectors[:, 0:self.dimension()])
         if self.kinetic_map:  # scale by eigenvalues
             Y *= self.eigenvalues[0:self.dimension()]
-        return Y
+        return Y.astype(self.output_type())
 
     @property
     def feature_TIC_correlation(self):


### PR DESCRIPTION
I cast the numpy array to python int to avoid the warning https://github.com/markovmodel/PyEMMA/issues/939#issuecomment-248850663

I directly cast to the correct dtype in transform to fix `tica.transform()` returning `float64` instead of `float32` like `get_output()`. https://github.com/markovmodel/PyEMMA/issues/939#issuecomment-248847992

That's it! I hope I'm forgiven for my false-issue :smile: 
