### PR TITLE
Estimator worker fix evaluate

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - numpy x.x
     - pyyaml
     - scipy
-    - six >= 1.10
+    - six >=1.10
     - psutil >=3.1.1
     - decorator >=4.0.0
     - progress_reporter

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -46,7 +46,7 @@ requirements:
     - numpy x.x
     - pyyaml
     - scipy
-    - six
+    - six >= 1.10
     - psutil >=3.1.1
     - decorator >=4.0.0
     - progress_reporter

--- a/pyemma/_base/estimator.py
+++ b/pyemma/_base/estimator.py
@@ -153,16 +153,19 @@ def _estimate_param_scan_worker(estimator, params, X, evaluate, evaluate_args,
     # we want to evaluate function(s) of the model
     elif _types.is_iterable(evaluate):
         values = []  # the function values the model
-        for ieval in range(len(evaluate)):
+        for ieval, name in enumerate(evaluate):
             # get method/attribute name and arguments to be evaluated
             name = evaluate[ieval]
-            args = None
+            args = ()
             if evaluate_args is not None:
                 args = evaluate_args[ieval]
+                # wrap single arguments in an iterable again to pass them.
+                if _types.is_string(args):
+                    args = (args, )
             # evaluate
             try:
                 # try calling method/property/attribute
-                value = _call_member(estimator.model, name, args=args)
+                value = _call_member(estimator.model, name, failfast, *args)
             # couldn't find method/property/attribute
             except AttributeError as e:
                 if failfast:
@@ -183,7 +186,7 @@ def _estimate_param_scan_worker(estimator, params, X, evaluate, evaluate_args,
 
 
 def estimate_param_scan(estimator, X, param_sets, evaluate=None, evaluate_args=None, failfast=True,
-                        return_estimators=False, n_jobs=1, progress_reporter=None):
+                        return_estimators=False, n_jobs=1, progress_reporter=None, show_progress=True):
     """ Runs multiple estimations using a list of parameter settings
 
     Parameters
@@ -202,15 +205,25 @@ def estimate_param_scan(estimator, X, param_sets, evaluate=None, evaluate_args=N
         parameters in estimate(X, **params). All other parameter settings will
         be taken from the default settings in the estimator object.
 
-    evaluate : str or list of str
+    evaluate : str or list of str, optional
         The given methods or properties will be called on the estimated
         models, and their results will be returned instead of the full models.
         This may be useful for reducing memory overhead.
+
+    evaluate_args: iterable of iterable, optional
+        Arguments to be passed to evaluated methods. Note, that size has to match to the size of evaluate.
 
     failfast : bool
         If True, will raise an exception when estimation failed with an exception
         or trying to calls a method that doesn't exist. If False, will simply
         return None in these cases.
+
+    return_estimators: bool
+        If True, return a list estimators in addition to the models.
+
+    show_progress: bool
+        if the given estimator supports show_progress interface, we set the flag
+        prior doing estimations.
 
     Return
     ------
@@ -227,25 +240,32 @@ def estimate_param_scan(estimator, X, param_sets, evaluate=None, evaluate_args=N
 
     Estimate a maximum likelihood Markov model at lag times 1, 2, 3.
 
-    >>> from pyemma.msm.estimators import MaximumLikelihoodMSM
+    >>> from pyemma.msm.estimators import MaximumLikelihoodMSM, BayesianMSM
     >>>
     >>> dtraj = [0,0,1,2,1,0,1,0,1,2,2,0,0,0,1,1,2,1,0,0,1,2,1,0,0,0,1,1,0,1,2]  # mini-trajectory
     >>> param_sets=param_grid({'lag': [1,2,3]})
     >>>
     >>> estimate_param_scan(MaximumLikelihoodMSM, dtraj, param_sets, evaluate='timescales')
-    [array([ 1.24113167,  0.77454377]), array([ 2.65266703,  1.42909841]), array([ 5.34810395,  1.14784446])]
+    [array([ 1.24113168,  0.77454377]), array([ 2.48226337,  1.54908754]), array([ 3.72339505,  2.32363131])]
 
-    Try also getting samples of the timescales
-
-    >>> estimate_param_scan(MaximumLikelihoodMSM, dtraj, param_sets, evaluate=['timescales', 'timescales_samples'])
-    [[array([ 1.24113167,  0.77454377]), None], [array([ 2.65266703,  1.42909841]), None], [array([ 5.34810395,  1.14784446]), None],
+    Now we also want to get samples of the timescales using the BayesianMSM.
+    >>> estimate_param_scan(MaximumLikelihoodMSM, dtraj, param_sets, failfast=False,
+    ...     evaluate=['timescales', 'timescales_samples']) # doctest: +SKIP
+    [[array([ 1.24113168,  0.77454377]), None], [array([ 2.48226337,  1.54908754]), None], [array([ 3.72339505,  2.32363131]), None]]
 
     We get Nones because the MaximumLikelihoodMSM estimator doesn't provide timescales_samples. Use for example
     a Bayesian estimator for that.
 
+    Now we also want to get samples of the timescales using the BayesianMSM.
+    >>> estimate_param_scan(BayesianMSM, dtraj, param_sets, show_progress=False,
+    ...     evaluate=['timescales', 'sample_f'], evaluate_args=((), ('timescales', ))) # doctest: +SKIP
+    [[array([ 1.24357685,  0.77609028]), [array([ 1.5963252 ,  0.73877883]), array([ 1.29915847,  0.49004912]), array([ 0.90058583,  0.73841786]), ... ]]
+
     """
     # make sure we have an estimator object
     estimator = get_estimator(estimator)
+    if hasattr(estimator, 'show_progress'):
+        estimator.show_progress = show_progress
     # if we want to return estimators, make clones. Otherwise just copy references.
     # For parallel processing we always need clones
     if return_estimators or n_jobs > 1 or n_jobs is None:
@@ -256,9 +276,14 @@ def estimate_param_scan(estimator, X, param_sets, evaluate=None, evaluate_args=N
     # if we evaluate, make sure we have a list of functions to evaluate
     if _types.is_string(evaluate):
         evaluate = [evaluate]
+    if _types.is_string(evaluate_args):
+        evaluate_args = [evaluate_args]
+
+    if evaluate is not None and evaluate_args is not None and len(evaluate) != len(evaluate_args):
+        raise ValueError("length mismatch: evaluate ({}) and evaluate_args ({})".format(len(evaluate), len(evaluate_args)))
 
     # set call back for joblib
-    if progress_reporter is not None:
+    if progress_reporter is not None and show_progress:
         progress_reporter._progress_register(len(estimators), stage=0,
                                              description="estimating %s" % str(estimator.__class__.__name__))
 
@@ -337,10 +362,10 @@ def estimate_param_scan(estimator, X, param_sets, evaluate=None, evaluate_args=N
         for i, param in enumerate(param_sets):
             res.append(_estimate_param_scan_worker(estimators[i], param, X,
                                                    evaluate, evaluate_args, failfast))
-            if progress_reporter is not None:
+            if progress_reporter is not None and show_progress:
                 progress_reporter._progress_update(1, stage=0)
 
-    if progress_reporter is not None:
+    if progress_reporter is not None and show_progress:
         progress_reporter._progress_force_finish(0)
 
     # done

--- a/pyemma/msm/tests/test_estimator.py
+++ b/pyemma/msm/tests/test_estimator.py
@@ -20,32 +20,71 @@ import mock
 from pyemma import msm
 from functools import wraps
 
+from pyemma._base.estimator import param_grid, estimate_param_scan
+
 
 class TestCK_MSM(unittest.TestCase):
-
     def test_failfast_true(self):
         """ test that exception is thrown for failfast=True"""
         from pyemma._base.estimator import _estimate_param_scan_worker
         failfast = True
+
         @wraps(_estimate_param_scan_worker)
         def worker_wrapper(*args):
             args = list(args)
             args[5] = failfast
             return _estimate_param_scan_worker(*args)
+
         with self.assertRaises(NotImplementedError):
             with mock.patch('pyemma._base.estimator._estimate_param_scan_worker', worker_wrapper):
-                hmm = msm.estimate_hidden_markov_model([0, 0, 0, 1, 1, 1, 0, 0], 2, 1,)
+                hmm = msm.estimate_hidden_markov_model([0, 0, 0, 1, 1, 1, 0, 0], 2, 1, )
                 hmm.cktest()
 
     def test_failfast_false(self):
         """ test, that no exception is raised during estimation"""
         from pyemma._base.estimator import _estimate_param_scan_worker
         failfast = False
+
         @wraps(_estimate_param_scan_worker)
         def worker_wrapper(*args):
             args = list(args)
             args[5] = failfast
             return _estimate_param_scan_worker(*args)
+
         with mock.patch('pyemma._base.estimator._estimate_param_scan_worker', worker_wrapper):
-            hmm = msm.estimate_hidden_markov_model([0, 0, 0, 1, 1, 1, 0, 0], 2, 1,)
+            hmm = msm.estimate_hidden_markov_model([0, 0, 0, 1, 1, 1, 0, 0], 2, 1, )
             hmm.cktest()
+
+    def test_evaluate_msm(self):
+        from pyemma.msm.estimators import MaximumLikelihoodMSM
+        dtraj = [0, 0, 1, 2, 1, 0, 1, 0, 1, 2, 2, 0, 0, 0, 1, 1, 2, 1, 0, 0, 1, 2, 1, 0, 0, 0, 1, 1, 0, 1,
+                 2]  # mini-trajectory
+        param_sets = param_grid({'lag': [1, 2, 3]})
+        res = estimate_param_scan(MaximumLikelihoodMSM, dtraj, param_sets, evaluate='timescales')
+        self.assertIsInstance(res, list)
+
+    def test_evaluate_bmsm_single_arg(self):
+        from pyemma.msm.estimators import BayesianMSM
+        dtraj = [0, 0, 1, 2, 1, 0, 1, 0, 1, 2, 2, 0, 0, 0, 1, 1, 2, 1, 0, 0, 1, 2, 1, 0, 0, 0, 1, 1, 0, 1,
+                 2]  # mini-trajectory
+        n_samples = 52
+        param_sets = param_grid({'lag': [1, 2, 3], 'show_progress': (False, ), 'nsamples': (n_samples, )})
+        res = estimate_param_scan(BayesianMSM, dtraj, param_sets,
+                                  evaluate='sample_f', evaluate_args='timescales')
+        self.assertIsInstance(res, list)
+        self.assertEqual(len(res), 3)  # three lag times
+        self.assertEqual(len(res[0]), n_samples)
+
+    def test_evaluate_msm_multi_arg(self):
+        from pyemma.msm.estimators import MaximumLikelihoodMSM
+        dtraj = [0, 0, 1, 2, 1, 0, 1, 0, 1, 2, 2, 0, 0, 0, 1, 1, 2, 1, 0, 0, 1, 2, 1, 0, 0, 0, 1, 1, 0, 1,
+                 2]  # mini-trajectory
+        traj_len = 10
+        param_sets = param_grid({'lag': [1, 2, 3]})
+        #     def generate_traj(self, N, start=None, stop=None, stride=1):
+
+        res = estimate_param_scan(MaximumLikelihoodMSM, dtraj, param_sets,
+                                  evaluate='generate_traj', evaluate_args=((traj_len, 2, None, 2), ))
+        self.assertIsInstance(res, list)
+        self.assertEqual(len(res), 3)  # three lag times
+        self.assertTrue(all(len(x) == traj_len for x in res))


### PR DESCRIPTION
This feature used to be broken. Now the arguments for evaluate are correctly handled. Added some tests also.

six has to be at least 1.10 for "PY34" attribute.
