### PR TITLE
Lagged iter avoid double io

### DIFF
--- a/pyemma/coordinates/data/_base/datasource.py
+++ b/pyemma/coordinates/data/_base/datasource.py
@@ -262,7 +262,7 @@ class IteratorState(object):
 
     def __init__(self, skip=0, chunk=0, return_trajindex=False, ntraj=0, cols=None):
         self.skip = skip
-        self.chunk = chunk
+        self._chunk = chunk
         self.return_trajindex = return_trajindex
         self.itraj = 0
         self.ntraj = ntraj
@@ -276,6 +276,14 @@ class IteratorState(object):
         self.ra_indices_for_traj_dict = {}
         self.cols = cols
         self.current_itraj = 0
+
+    @property
+    def chunk(self):
+        return self._chunk
+
+    @chunk.setter
+    def chunk(self, value):
+        self._chunk = value
 
     def ra_indices_for_traj(self, traj):
         """

--- a/pyemma/coordinates/data/_base/datasource.py
+++ b/pyemma/coordinates/data/_base/datasource.py
@@ -391,12 +391,22 @@ class DataSourceIterator(six.with_metaclass(ABCMeta)):
         """ closes the reader"""
         pass
 
+    @abstractmethod
+    def _select_file(self, itraj):
+        """ opens the next file defined by itraj.
+
+        Parameters
+        ----------
+        itraj : int
+            index of trajectory to open.
+        """
+        pass
+
     def reset(self):
         """
         Method allowing to reset the iterator so that it can iteration from beginning on again.
         """
-        self._t = 0
-        self._itraj = 0
+        self._select_file(0)
 
     @property
     def pos(self):
@@ -631,6 +641,7 @@ class DataSourceIterator(six.with_metaclass(ABCMeta)):
             while (self._itraj not in self.traj_keys or self._t >= self.ra_trajectory_length(self._itraj)) \
                     and self._itraj < self.number_of_trajectories():
                 self._itraj += 1
+            self._select_file(self._itraj)
         # we have to obtain the current index before invoking next_chunk (which increments itraj)
         self.state.current_itraj = self._itraj
         self.state.pos = self.state.pos_adv

--- a/pyemma/coordinates/data/_base/iterable.py
+++ b/pyemma/coordinates/data/_base/iterable.py
@@ -367,7 +367,7 @@ class LaggedIterator(object):
 
     def next(self):
         while (self._it.current_trajindex not in self._sufficent_long_trajectories
-               and self._it.ntraj > self._it.current_trajindex):
+               and self._it.number_of_trajectories() > self._it.current_trajindex):
             self._it.state._itraj += 1
             self._overlap = None
 

--- a/pyemma/coordinates/data/feature_reader.py
+++ b/pyemma/coordinates/data/feature_reader.py
@@ -304,8 +304,8 @@ class FeatureReaderIterator(DataSourceIterator):
                 return_trajindex=return_trajindex,
                 cols=cols
         )
-        #self._cols = cols
-        self._create_mditer()
+        self._selected_itraj = -1
+        self._select_file(0)
 
     @property
     def chunksize(self):
@@ -332,11 +332,12 @@ class FeatureReaderIterator(DataSourceIterator):
             self._mditer.close()
 
     def _select_file(self, itraj):
-        self.close()
-
-        self._t = 0
-        self._itraj = itraj
-        self._create_mditer()
+        if itraj != self._selected_itraj:
+            self.close()
+            self._t = 0
+            self._itraj = itraj
+            self._selected_itraj = itraj
+            self._create_mditer()
 
     def _next_chunk(self):
         """

--- a/pyemma/coordinates/data/feature_reader.py
+++ b/pyemma/coordinates/data/feature_reader.py
@@ -331,11 +331,11 @@ class FeatureReaderIterator(DataSourceIterator):
         if hasattr(self, '_mditer') and self._mditer is not None:
             self._mditer.close()
 
-    def _next_file(self):
+    def _select_file(self, itraj):
         self.close()
 
         self._t = 0
-        self._itraj += 1
+        self._itraj = itraj
         self._create_mditer()
 
     def _next_chunk(self):
@@ -352,7 +352,8 @@ class FeatureReaderIterator(DataSourceIterator):
                 we have to return an empty iterable, so that LaggedIterator will continue to process.
             """
             if si.args and "too short" in si.args[0] and self._itraj < self._data_source.ntraj - 1:
-                self._next_file()
+                self._itraj += 1
+                self._select_file(self._itraj)
                 return ()
             else:
                 raise
@@ -362,7 +363,8 @@ class FeatureReaderIterator(DataSourceIterator):
         self._t += shape[0]
 
         if self._t >= self.trajectory_length() and self._itraj < len(self._data_source.filenames) - 1:
-            self._next_file()
+            self._itraj += 1
+            self._select_file(self._itraj)
 
         if not self.uniform_stride:
             traj_len = self.ra_trajectory_length(self._itraj)
@@ -405,8 +407,3 @@ class FeatureReaderIterator(DataSourceIterator):
         return patches.iterload(filename, chunk=self.chunksize, top=self._data_source.featurizer.topology,
                                 skip=skip, stride=stride, atom_indices=atom_indices)
 
-    def reset(self):
-        super(FeatureReaderIterator, self).reset()
-        # re-create the underlying mditer
-        self.close()
-        self._create_mditer()

--- a/pyemma/coordinates/data/fragmented_trajectory_reader.py
+++ b/pyemma/coordinates/data/fragmented_trajectory_reader.py
@@ -286,6 +286,12 @@ class FragmentIterator(DataSourceIterator):
         else:
             self._it = None
 
+    @DataSourceIterator.chunksize.setter
+    def chunksize(self, value):
+        self.state.chunk = value
+        if self._it is not None:
+            self._it._chunksize = value
+
     def reset(self):
         self._select_file(0)
 

--- a/pyemma/coordinates/data/fragmented_trajectory_reader.py
+++ b/pyemma/coordinates/data/fragmented_trajectory_reader.py
@@ -274,13 +274,25 @@ class FragmentIterator(DataSourceIterator):
         self._it = None
         self._itraj = 0
 
+    def _select_file(self, itraj):
+        self.close()
+        self._t = 0
+        self._itraj = itraj
+        if itraj < self.number_of_trajectories():
+            self._it = _FragmentedTrajectoryIterator(self._data_source, self._data_source._readers[itraj],
+                                                     self.chunksize, self.stride, self.skip)
+            if not self.uniform_stride:
+                self._it.ra_indices = self.ra_indices_for_traj(self._itraj)
+        else:
+            self._it = None
+
+    def reset(self):
+        self._select_file(0)
+
     def _next_chunk(self):
         if self._it is None:
             if self._itraj < self.number_of_trajectories():
-                self._it = _FragmentedTrajectoryIterator(self._data_source, self._data_source._readers[self._itraj],
-                                                         self.chunksize, self.stride, self.skip)
-                if not self.uniform_stride:
-                    self._it.ra_indices = self.ra_indices_for_traj(self._itraj)
+                self._select_file(0)
             else:
                 raise StopIteration()
 
@@ -290,12 +302,11 @@ class FragmentIterator(DataSourceIterator):
         self._t += len(X)
         if self._t >= self._data_source.trajectory_length(self._itraj, stride=self.stride, skip=self.skip):
             self._itraj += 1
-            self._it.close()
-            self._it = None
-            self._t = 0
+            self._select_file(self._itraj)
         while (not self.uniform_stride) and (self._itraj not in self.traj_keys or self._t >= self.ra_trajectory_length(self._itraj)) \
                 and self._itraj < self.number_of_trajectories():
             self._itraj += 1
+            self._select_file(self._itraj)
         return X
 
     def close(self):

--- a/pyemma/coordinates/data/numpy_filereader.py
+++ b/pyemma/coordinates/data/numpy_filereader.py
@@ -116,20 +116,24 @@ class NPYIterator(DataInMemoryIterator):
                                           chunk=chunk, stride=stride,
                                           return_trajindex=return_trajindex,
                                           cols=cols)
-        self._select_file(0)
 
     def close(self):
         if not hasattr(self, 'data') or self.data is None:
             return
+        # delete the memmap to close it.
+        # https://docs.scipy.org/doc/numpy-1.10.1/reference/generated/numpy.memmap.html
         del self.data
         self.data = None
 
     def _select_file(self, itraj):
-        self.close()
-        self._t = 0
-        self._itraj = itraj
-        if itraj < self.number_of_trajectories():
-            self.data = self._data_source._load_file(itraj)
+        if self._selected_itraj != itraj:
+            self._first_file_opened = True
+            self.close()
+            self._t = 0
+            self._itraj = itraj
+            self._selected_itraj = self._itraj
+            if itraj < self.number_of_trajectories():
+                self.data = self._data_source._load_file(itraj)
 
     def _next_chunk(self):
         return self._next_chunk_impl(self.data)

--- a/pyemma/coordinates/data/py_csv_reader.py
+++ b/pyemma/coordinates/data/py_csv_reader.py
@@ -56,11 +56,6 @@ class PyCSVIterator(DataSourceIterator):
         if self._file_handle is not None:
             self._file_handle.close()
 
-    def reset(self):
-        super(PyCSVIterator, self).reset()
-        self._itraj = -1
-        self._next_traj()
-
     def _next_chunk(self):
         if not self._file_handle or self._itraj >= self.number_of_trajectories():
             self.close()
@@ -83,10 +78,12 @@ class PyCSVIterator(DataSourceIterator):
                 result = self._convert_to_np_chunk(lines)
                 del lines[:]  # free some space
                 if self._t >= traj_len:
-                    self._next_traj()
+                    self._itraj += 1
+                    self._select_file(self._itraj)
                 return result
 
-        self._next_traj()
+        self._itraj += 1
+        self._select_file(self._itraj)
         # last chunk
         if len(lines) > 0:
             result = self._convert_to_np_chunk(lines)
@@ -94,8 +91,8 @@ class PyCSVIterator(DataSourceIterator):
 
         self.close()
 
-    def _next_traj(self):
-        self._itraj += 1
+    def _select_file(self, itraj):
+        self._itraj = itraj
         while not self.uniform_stride and self._itraj not in self.traj_keys \
                 and self._itraj < self.number_of_trajectories():
             self._itraj += 1

--- a/pyemma/coordinates/tests/test_coordinates_iterator.py
+++ b/pyemma/coordinates/tests/test_coordinates_iterator.py
@@ -57,6 +57,9 @@ class TestCoordinatesIterator(unittest.TestCase):
                 chunks = 0
                 for _ in it:
                     chunks += 1
+                np.testing.assert_equal(it._n_chunks, chunks,
+                                        err_msg="Expected number of chunks did not agree with what the iterator "
+                                                "returned for stride=%s, lag=%s" % (stride, lag))
                 assert chunks == it._n_chunks
 
     def test_chunksize(self):

--- a/pyemma/coordinates/tests/test_coordinates_iterator.py
+++ b/pyemma/coordinates/tests/test_coordinates_iterator.py
@@ -59,19 +59,6 @@ class TestCoordinatesIterator(unittest.TestCase):
                     chunks += 1
                 assert chunks == it._n_chunks
 
-    def test_skip(self):
-        r = DataInMemory(self.d)
-        lagged_it = r.iterator(lag=5)
-        assert lagged_it._it.skip == 0
-        assert lagged_it._it_lagged.skip == 5
-
-        it = r.iterator()
-        for itraj, X in it:
-            if itraj == 0:
-                it.skip = 5
-            if itraj == 1:
-                assert it.skip == 5
-
     def test_chunksize(self):
         r = DataInMemory(self.d)
         cs = np.arange(1, 17)

--- a/pyemma/coordinates/tests/test_csvreader.py
+++ b/pyemma/coordinates/tests/test_csvreader.py
@@ -203,7 +203,10 @@ class TestCSVReader(unittest.TestCase):
                 chunks = np.vstack(chunks)
                 chunks_lag = np.vstack(chunks_lag)
                 actual_lagged = self.data[t::s]
-                np.testing.assert_almost_equal(chunks, self.data[::s][0:len(actual_lagged)])
+                np.testing.assert_almost_equal(chunks, self.data[::s][0:len(actual_lagged)],
+                                               err_msg="output is not equal for"
+                                                       " lag %i and stride %i" % (t, s)
+                                               )
                 np.testing.assert_almost_equal(chunks_lag, self.data[t::s],
                                                err_msg="output is not equal for"
                                                        " lag %i and stride %i" % (t, s))

--- a/pyemma/coordinates/tests/test_datainmemory.py
+++ b/pyemma/coordinates/tests/test_datainmemory.py
@@ -174,8 +174,8 @@ class TestDataInMemory(unittest.TestCase):
 
     def test_lagged_iterator_1d(self):
         n = 57
-        chunksize = 10
-        lag = 1
+        chunksize = 7
+        lag = 2
 
         data = [np.arange(n), np.arange(50), np.arange(30)]
         input_lens = [x.shape[0] for x in data]
@@ -197,10 +197,13 @@ class TestDataInMemory(unittest.TestCase):
         lagged_trajs = [np.vstack(ichunks) for ichunks in chunked_lagged_trajs]
 
         # unlagged data
+        tttraj = 0
         for traj, input_traj in zip(trajs, data):
             # do not consider chunks that have no lagged counterpart
             input_shape = input_traj.shape
-            np.testing.assert_equal(traj.reshape((input_shape[0] - lag,)), input_traj[:len(input_traj) - lag])
+            np.testing.assert_equal(traj.reshape((input_shape[0] - lag,)), input_traj[:len(input_traj) - lag],
+                                    err_msg="failed for traj=%s"%tttraj)
+            tttraj += 1
 
         # lagged data
         lagged_0 = [d[lag:] for d in data]

--- a/pyemma/coordinates/tests/test_featurereader_and_tica.py
+++ b/pyemma/coordinates/tests/test_featurereader_and_tica.py
@@ -108,7 +108,7 @@ class TestFeatureReaderAndTICA(unittest.TestCase):
         for traj in output:
             partial.partial_fit(traj)
 
-        np.testing.assert_allclose(partial.eigenvalues, ref.eigenvalues)
+        np.testing.assert_allclose(partial.eigenvalues, ref.eigenvalues, atol=1e-3)
         # only compare first two eigenvectors, because we only have two metastable processes
         np.testing.assert_allclose(np.abs(partial.eigenvectors[:2]),
                                    np.abs(ref.eigenvectors[:2]), rtol=1e-3, atol=1e-3)

--- a/pyemma/coordinates/tests/test_fragmented_trajectory.py
+++ b/pyemma/coordinates/tests/test_fragmented_trajectory.py
@@ -28,7 +28,7 @@ from six.moves import range
 class TestFragmentedTrajectory(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        d = np.array([[i] for i in range(0, 100)])
+        d = np.array([[i] for i in range(0, 100)]) # np.atleast_2d(np.arange(100))
         cls.d = d
         return cls
 
@@ -139,7 +139,10 @@ class TestFragmentedTrajectory(unittest.TestCase):
                         for itraj, X, Y in reader.iterator(stride=stride, lag=lag):
                             collected = X if collected is None else np.vstack((collected, X))
                             collected_lagged = Y if collected_lagged is None else np.vstack((collected_lagged, Y))
-                        np.testing.assert_array_almost_equal(data[::stride][0:len(collected_lagged)], collected)
+                        np.testing.assert_array_almost_equal(data[::stride][0:len(collected_lagged)], collected,
+                                                             err_msg="lag={}, stride={}, cs={}".format(
+                                                                 lag, stride, chunksize
+                                                             ))
                         np.testing.assert_array_almost_equal(data[lag::stride], collected_lagged)
                     else:
                         collected = None

--- a/pyemma/coordinates/tests/test_numpyfilereader.py
+++ b/pyemma/coordinates/tests/test_numpyfilereader.py
@@ -192,7 +192,7 @@ class TestNumPyFileReader(unittest.TestCase):
 
     def test_usecols(self):
         reader = NumPyFileReader(self.f4)
-        cols=(0, 2)
+        cols = (0, 2)
         it = reader.iterator(chunk=0, return_trajindex=False, cols=cols)
         with it:
             for x in it:
@@ -200,7 +200,7 @@ class TestNumPyFileReader(unittest.TestCase):
 
     def test_different_shapes_value_error(self):
         with tempfile.NamedTemporaryFile(delete=False, suffix='.npy') as f:
-            x=np.zeros((3, 42))
+            x = np.zeros((3, 42))
             np.save(f.name, x)
             myfiles = self.files2d[:]
             myfiles.insert(1, f.name)
@@ -208,7 +208,6 @@ class TestNumPyFileReader(unittest.TestCase):
             with self.assertRaises(ValueError) as cm:
                 NumPyFileReader(myfiles)
             self.assertIn("different dimensions", cm.exception.args[0])
-            print (cm.exception.args)
 
 
 if __name__ == "__main__":

--- a/pyemma/coordinates/transform/tica.py
+++ b/pyemma/coordinates/transform/tica.py
@@ -285,7 +285,8 @@ class TICA(StreamingTransformer):
         self.logger.debug("will use {} total frames for {}".
                           format(iterable.trajectory_lengths(self.stride, skip=self.skip), self.name))
 
-        it = iterable.iterator(lag=self.lag, return_trajindex=False, chunk=self.chunksize, skip=self.skip)
+        it = iterable.iterator(lag=self.lag, return_trajindex=False,
+                               chunk=self.chunksize if not partial_fit else 0, skip=self.skip)
         with it:
             self._progress_register(it._n_chunks, "calculate mean+cov", 0)
             self._init_covar(partial_fit, it._n_chunks)

--- a/pyemma/coordinates/transform/transformer.py
+++ b/pyemma/coordinates/transform/transformer.py
@@ -253,6 +253,12 @@ class StreamingTransformerIterator(DataSourceIterator):
     def close(self):
         self._it.close()
 
+    def reset(self):
+        self._it.reset()
+
+    def _select_file(self, itraj):
+        self._it._select_file(0)
+
     def _next_chunk(self):
         X = self._it._next_chunk()
         return self._data_source._transform_array(X)

--- a/pyemma/coordinates/util/patches.py
+++ b/pyemma/coordinates/util/patches.py
@@ -188,21 +188,19 @@ class iterload(object):
             except (IOError, IndexError):
                 raise StopIteration("too short trajectory")
 
-        if not isinstance(self._stride, np.ndarray) and self._chunksize == 0:
-            # If chunk was 0 then we want to avoid filetype-specific code
-            # in case of undefined behavior in various file parsers.
-            # TODO: this will first apply stride, then skip!
-            if self._extension not in _TOPOLOGY_EXTS:
-                self._kwargs['top'] = self._top
-            traj = load(self._filename, stride=self._stride, **self._kwargs)[self.skip:]
-        elif isinstance(self._stride, np.ndarray):
+        if isinstance(self._stride, np.ndarray):
             return next(self._ra_it)
         else:
+            if self._chunksize == 0:
+                n_frames = None  # read all frames
+            else:
+                n_frames = self._chunksize * self._stride
+
             if self._extension not in _TOPOLOGY_EXTS:
-                traj = self._f.read_as_traj(self._topology, n_frames=self._chunksize * self._stride,
+                traj = self._f.read_as_traj(self._topology, n_frames=n_frames,
                                             stride=self._stride, atom_indices=self._atom_indices, **self._kwargs)
             else:
-                traj = self._f.read_as_traj(n_frames=self._chunksize * self._stride,
+                traj = self._f.read_as_traj(n_frames=n_frames,
                                             stride=self._stride, atom_indices=self._atom_indices, **self._kwargs)
 
         if len(traj) == 0:

--- a/pyemma/util/contexts.py
+++ b/pyemma/util/contexts.py
@@ -84,3 +84,14 @@ def settings(**kwargs):
     # restore old settings
     for k, v in old_settings.items():
         setattr(config, k, v)
+
+@contextmanager
+def attribute(obj, attr, val):
+    previous = getattr(obj, attr)
+    setattr(obj, attr, val)
+    try:
+        yield
+    except:
+        raise
+    finally:
+        setattr(obj, attr, previous)

--- a/pyemma/util/tests/test_attribute_context.py
+++ b/pyemma/util/tests/test_attribute_context.py
@@ -1,0 +1,33 @@
+import unittest
+
+from pyemma.util.contexts import attribute
+
+class TestContexts(unittest.TestCase):
+
+    def test_attribute_context(self):
+        class Foo:
+            def __init__(self):
+                self._x = 5
+
+            @property
+            def x(self):
+                return self._x
+
+            @x.setter
+            def x(self, value):
+                self._x = value
+        foo = Foo()
+        with attribute(foo, 'x', 10):
+            assert foo.x == 10
+        assert foo.x == 5
+
+        try:
+            with attribute(foo, 'x', 100):
+                assert foo.x == 100
+                raise RuntimeError()
+        except RuntimeError:
+            assert foo.x == 5
+        assert foo.x == 5
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
For lag <= chunk size these changes make the lagged iteration as efficient as reading everything into memory.

[naive_bpti_mem_req_h5.pdf](https://github.com/markovmodel/PyEMMA/files/527634/naive_bpti_mem_req_h5.pdf)
[streaming_bpti_mem_req_h5.pdf](https://github.com/markovmodel/PyEMMA/files/527635/streaming_bpti_mem_req_h5.pdf)
