### PR TITLE
[featurizer.add_custom_func] fix describe

### DIFF
--- a/pyemma/coordinates/data/featurization/featurizer.py
+++ b/pyemma/coordinates/data/featurization/featurizer.py
@@ -674,13 +674,19 @@ class MDFeaturizer(Loggable):
         func : function
             a user-defined function, which accepts mdtraj.Trajectory object as
             first parameter and as many optional and named arguments as desired.
-            Has to return a numpy.ndarray
+            Has to return a numpy.ndarray ndim=2.
         dim : int
             output dimension of :py:obj:`function`
         args : any number of positional arguments
             these have to be in the same order as :py:obj:`func` is expecting them
         kwargs : dictionary
             named arguments passed to func
+
+        Notes
+        -----
+        You can pass a description list to describe the output of your function by element,
+        by passing a list of strings with the same lengths as dimensions.
+        Alternatively a single element list or str will be expanded to match the output dimension.
 
         """
         f = CustomFeature(func, dim=dim, *args, **kwargs)

--- a/pyemma/coordinates/data/featurization/misc.py
+++ b/pyemma/coordinates/data/featurization/misc.py
@@ -85,11 +85,11 @@ class CustomFeature(Feature):
             desc = [desc]
         self.id = next(CustomFeature._id)
         if not desc:
-            desc = ["CustomFeature[{id}][0] calling {func} with args {pos_args}, {kwargs}%".format(
+            arg_str = "{args}, {kw}" if self._kwargs else "{args}"
+            desc = ["CustomFeature[{id}][0] calling {func} with args {arg_str}".format(
                 id=self.id,
                 func=self._func,
-                pos_args=self._args,
-                kwargs=self._kwargs)]
+                arg_str=arg_str, args=self._args, kw=self._kwargs)]
             if self.dimension > 1:
                 desc.extend(('CustomFeature[{id}][{i}]'.format(id=self.id, i=i) for i in range(1, self.dimension)))
         elif desc and not (len(desc) == self._dim or len(desc) == 1):

--- a/pyemma/coordinates/tests/test_featurizer.py
+++ b/pyemma/coordinates/tests/test_featurizer.py
@@ -848,7 +848,43 @@ class TestCustomFeature(unittest.TestCase):
                                   self.means,
                                   self.U
                                   )
-        self.feat.describe()
+        desc = self.feat.describe()
+        self.assertEqual(len(desc), self.feat.dimension())
+
+    def test_describe_given(self):
+        self.feat.add_custom_func(some_call_to_mdtraj_some_operations_some_linalg, self.U.shape[1],
+                                  self.pairs,
+                                  self.means,
+                                  self.U, description=['foo']*self.U.shape[1]
+                                  )
+        desc = self.feat.describe()
+        self.assertIn('foo', desc)
+        self.assertEqual(len(desc), self.feat.dimension())
+
+    def test_describe_given_str(self):
+        self.feat.add_custom_func(some_call_to_mdtraj_some_operations_some_linalg, self.U.shape[1],
+                                  self.pairs,
+                                  self.means,
+                                  self.U, description='test')
+        desc = self.feat.describe()
+        self.assertIn('test', desc)
+        self.assertEqual(len(desc), self.feat.dimension())
+
+    def test_describe_given_wrong(self):
+        """ either a list matching input dim, or 1 element iterable allowed"""
+        with self.assertRaises(ValueError) as cm:
+            self.feat.add_custom_func(some_call_to_mdtraj_some_operations_some_linalg, self.U.shape[1]+1,
+                                      self.pairs,
+                                      self.means,
+                                      self.U, description=['ff', 'ff'])
+
+    def test_describe_1_element_expand(self):
+        self.feat.add_custom_func(some_call_to_mdtraj_some_operations_some_linalg, self.U.shape[1] + 1,
+                                  self.pairs,
+                                  self.means,
+                                  self.U, description=['test'])
+        desc = self.feat.describe()
+        self.assertEqual(desc, ['test']*3)
 
     def test_dimensionality(self):
         self.feat.add_custom_func(some_call_to_mdtraj_some_operations_some_linalg, self.U.shape[1],


### PR DESCRIPTION
Fixes #971

Allows to input a single string, [str] or [str_1, ..., str_n] as "description" argument. Single elements will be expanded with an running index for the amount of custom features and dimension indices.
