### PR TITLE
Fix: support for numpy integers in TICA lag

### DIFF
--- a/pyemma/coordinates/data/_base/iterable.py
+++ b/pyemma/coordinates/data/_base/iterable.py
@@ -18,6 +18,7 @@
 from abc import ABCMeta, abstractmethod
 import six
 import numpy as np
+import numbers
 
 from pyemma._base.logging import Loggable
 from pyemma._base.progress import ProgressReporter
@@ -364,7 +365,7 @@ class _LaggedIterator(object):
     def __init__(self, it, lag, return_trajindex, actual_stride):
         self._it = it
         self._lag = lag
-        assert isinstance(lag, int)
+        assert isinstance(lag, numbers.Integral)
         self._return_trajindex = return_trajindex
         self._overlap = None
         self._actual_stride = actual_stride

--- a/pyemma/coordinates/data/_base/iterable.py
+++ b/pyemma/coordinates/data/_base/iterable.py
@@ -23,6 +23,7 @@ import numbers
 from pyemma._base.logging import Loggable
 from pyemma._base.progress import ProgressReporter
 from pyemma.util.contexts import attribute
+from pyemma.util.types import is_int
 
 
 class Iterable(six.with_metaclass(ABCMeta, ProgressReporter, Loggable)):
@@ -365,7 +366,7 @@ class _LaggedIterator(object):
     def __init__(self, it, lag, return_trajindex, actual_stride):
         self._it = it
         self._lag = lag
-        assert isinstance(lag, numbers.Integral)
+        assert is_int(lag)
         self._return_trajindex = return_trajindex
         self._overlap = None
         self._actual_stride = actual_stride


### PR DESCRIPTION
Take care when checking against `int`. It doesn't work for numpy ints. There are other solutions than the one with `import numbers`. For example casting to `int` and comparing to original value, but I think this is more intuitive.

``` python
In [18]: isinstance(5, int)
Out[18]: True

In [19]: isinstance(np.int64(5), int)
Out[19]: False

In [20]: isinstance(np.int64(5), numbers.Integral)
Out[20]: True

In [21]: isinstance(5, numbers.Integral)
Out[21]: True
```
