### PR TITLE
[ci] use nose-randomly plugin to reset random seed for each test

### DIFF
--- a/devtools/conda-recipe/run_test.py
+++ b/devtools/conda-recipe/run_test.py
@@ -34,9 +34,13 @@ def coverage_report():
     with open(dest, 'w+') as fh:
        fh.write(data)
 
+# hacky but should work, install nose-randomly via pip in testing env
+subprocess.check_call("pip install nose-randomly".split(' '))
+
 nose_run = "nosetests {test_pkg} -vv" \
            " --with-coverage --cover-inclusive --cover-package={cover_pkg}" \
            " --with-doctest --doctest-options=+NORMALIZE_WHITESPACE,+ELLIPSIS" \
+           " --with-randomly" \
            .format(test_pkg=test_pkg, cover_pkg=cover_pkg).split(' ')
 
 res = subprocess.call(nose_run)


### PR DESCRIPTION
This should increase coverage and can also reveal different testing
failures which depend on the execution order.

In general this is a minor change.
