### PR TITLE
[msm] added support for milestone counting

### DIFF
--- a/pyemma/msm/estimators/_dtraj_stats.py
+++ b/pyemma/msm/estimators/_dtraj_stats.py
@@ -18,7 +18,6 @@
 
 from __future__ import absolute_import
 from six.moves import range
-__author__ = 'noe'
 
 import numpy as np
 
@@ -26,6 +25,9 @@ from msmtools import estimation as msmest
 from pyemma.util.annotators import alias, aliased
 from pyemma.util.linalg import submatrix
 from pyemma.util.discrete_trajectories import visited_set
+
+__author__ = 'noe'
+
 
 @aliased
 class DiscreteTrajectoryStats(object):
@@ -53,6 +55,55 @@ class DiscreteTrajectoryStats(object):
         # not yet estimated
         self._counted_at_lag = False
 
+    def to_coreset(self, core_set, in_place=True):
+        """
+
+        Parameters
+        ----------
+        core_set: an array of micro-states to include as core-sets
+
+        in_place: boolean, default=True
+            if True, replace the current dtrajs
+            if False, return a copy
+
+        Returns
+        -------
+        dtrajs
+        """
+        import copy
+        dtrajs = self._dtrajs if in_place else copy.deepcopy(self._dtrajs)
+
+        core_set = np.array(core_set, dtype=int)
+        # build a boolean expression to create a mask of indices within the core set.
+        expr = ['(d == {i})'.format(i=i) for i in core_set]
+        expr = '|'.join(expr)
+
+        def to_ranges(a):
+            # return a list of consecutive ranges in array a.
+            cons = np.split(a, np.where(np.diff(a) != 1)[0] + 1)
+            ranges = [range(np.min(x), np.max(x)+1) if len(x) > 1
+                      else range(x[0], x[0]+1) for x in cons]
+            return ranges
+
+        for d in dtrajs:
+            within_core_set = eval(expr)
+            outside_core_set = np.logical_not(within_core_set)
+            inds_within_set = np.where(within_core_set)[0]
+            inds_outside_set = np.where(outside_core_set)[0]
+            # determine ranges to update, which lies outside the core set.
+            ranges = to_ranges(inds_outside_set)
+
+            # start with first valid core set value.
+            for r in ranges:
+                start, stop = r.start, r.stop
+                core_set = d[start - 1] if start > 0 else inds_within_set[0]
+                d[r] = core_set
+
+        # re-initialize
+        if in_place:
+            self.__init__(dtrajs)
+
+        return dtrajs
 
     def count_lagged(self, lag, count_mode='sliding'):
         r""" Counts transitions at given lag time

--- a/pyemma/msm/estimators/_dtraj_stats.py
+++ b/pyemma/msm/estimators/_dtraj_stats.py
@@ -46,7 +46,8 @@ class DiscreteTrajectoryStats(object):
 
         ## basic count statistics
         # histogram
-        self._hist = msmest.count_states(self._dtrajs)
+        from msmtools.dtraj import count_states
+        self._hist = count_states(self._dtrajs, ignore_negative=True)
         # total counts
         self._total_count = np.sum(self._hist)
         # number of states
@@ -96,7 +97,7 @@ class DiscreteTrajectoryStats(object):
             # start with first valid core set value.
             for r in ranges:
                 start, stop = r.start, r.stop
-                core_set = d[start - 1] if start > 0 else inds_within_set[0]
+                core_set = d[start - 1] if start > 0 else -1#inds_within_set[0]
                 d[r] = core_set
 
         # re-initialize

--- a/pyemma/msm/estimators/_dtraj_stats.py
+++ b/pyemma/msm/estimators/_dtraj_stats.py
@@ -82,23 +82,21 @@ class DiscreteTrajectoryStats(object):
         def to_ranges(a):
             # return a list of consecutive ranges in array a.
             cons = np.split(a, np.where(np.diff(a) != 1)[0] + 1)
-            ranges = [range(np.min(x), np.max(x)+1) if len(x) > 1
-                      else range(x[0], x[0]+1) for x in cons]
+            ranges = [(np.min(x), np.max(x)+1) if len(x) > 1
+                      else (x[0], x[0]+1) for x in cons]
             return ranges
 
         for d in dtrajs:
             within_core_set = eval(expr)
             outside_core_set = np.logical_not(within_core_set)
-            inds_within_set = np.where(within_core_set)[0]
             inds_outside_set = np.where(outside_core_set)[0]
             # determine ranges to update, which lies outside the core set.
             ranges = to_ranges(inds_outside_set)
 
             # start with first valid core set value.
-            for r in ranges:
-                start, stop = r.start, r.stop
-                core_set = d[start - 1] if start > 0 else -1#inds_within_set[0]
-                d[r] = core_set
+            for start, stop in ranges:
+                core_set = d[start - 1] if start > 0 else -1
+                d[start:stop] = core_set
 
         # re-initialize
         if in_place:

--- a/pyemma/msm/tests/test_dtraj_stats.py
+++ b/pyemma/msm/tests/test_dtraj_stats.py
@@ -57,13 +57,7 @@ class TestDtrajStats(unittest.TestCase):
             dtrajs = copy.deepcopy(dtrajs)
             newdiscretetraj = []
             for t, st in enumerate(dtrajs):
-                ws = []
-                for co in core_set:
-                    w = np.where(st == co)[0]
-                    if w.size > 0:
-                        w = min(w)
-                    ws.append(w)
-                oldmicro = min(ws)
+                oldmicro = -1
                 newtraj = []
                 for f, micro in enumerate(st):
                     newmicro = None

--- a/pyemma/msm/tests/test_dtraj_stats.py
+++ b/pyemma/msm/tests/test_dtraj_stats.py
@@ -1,0 +1,82 @@
+import unittest
+
+import numpy as np
+from pyemma.msm.estimators._dtraj_stats import DiscreteTrajectoryStats
+
+
+class TestDtrajStats(unittest.TestCase):
+    def test_core_sets(self):
+        dtrajs   = [np.array([0, 0, 2, 0, 0, 3, 0, 5, 5, 5, 0, 0, 6, 8, 4, 1, 2, 0, 3])]
+        expected = [np.array([2, 2, 2, 2, 2, 3, 3, 5, 5, 5, 5, 5, 6, 6, 4, 4, 2, 2, 3])]
+        core_set = np.arange(2, 7)
+        dts = DiscreteTrajectoryStats(dtrajs)
+        dts.to_coreset(core_set=core_set)
+
+        np.testing.assert_equal(dts.discrete_trajectories, expected)
+
+    def test_core_sets_2(self):
+        dtrajs = [np.array([0, 0, 2, 1, 2])]
+        dts = DiscreteTrajectoryStats(dtrajs)
+        dts.to_coreset(np.arange(1, 3))
+        np.testing.assert_equal(dts.discrete_trajectories,
+                                [np.array([2, 2, 2, 1, 2])])
+
+    def test_core_sets_3(self):
+        dtrajs = [np.array([2, 0, 1, 1, 2])]
+        dts = DiscreteTrajectoryStats(dtrajs)
+        dts.to_coreset(np.arange(1, 3))
+        np.testing.assert_equal(dts.discrete_trajectories,
+                                [np.array([2, 2, 1, 1, 2])])
+
+    def test_core_sets_4(self):
+        dtrajs = [np.array([2, 0, 0, 2, 0, 2, 0, 2])]
+        dts = DiscreteTrajectoryStats(dtrajs)
+        dts.to_coreset([2])
+        np.testing.assert_equal(dts.discrete_trajectories,
+                                [np.ones_like(dtrajs[0])*2])
+
+    def test_core_sets_5(self):
+        dtrajs = [np.array([2, 2, 2, 2, 2, 2, 2, 0])]
+        dts = DiscreteTrajectoryStats(dtrajs)
+        dts.to_coreset([2])
+        np.testing.assert_equal(dts.discrete_trajectories,
+                                [np.ones_like(dtrajs[0]) * 2])
+
+    def test_realistic_random(self):
+        n_states = 102
+        n_traj = 10
+        dtrajs = [np.random.randint(0, n_states, size=1000) for _ in range(n_traj)]
+        core_set = np.random.randint(0, n_states, size=30)
+        dts = DiscreteTrajectoryStats(dtrajs)
+        actual = dts.to_coreset(core_set, in_place=False)
+
+        def naive(dtrajs, core_set):
+            import copy
+            dtrajs = copy.deepcopy(dtrajs)
+            newdiscretetraj = []
+            for t, st in enumerate(dtrajs):
+                ws = []
+                for co in core_set:
+                    w = np.where(st == co)[0]
+                    if w.size > 0:
+                        w = min(w)
+                    ws.append(w)
+                oldmicro = min(ws)
+                newtraj = []
+                for f, micro in enumerate(st):
+                    newmicro = None
+                    for co in core_set:
+                        if micro == co:
+                            newmicro = micro
+                            oldmicro = micro
+                            break
+                    if newmicro is None and oldmicro is not None:
+                        newtraj.append(oldmicro)
+                    elif newmicro is not None:
+                        newtraj.append(newmicro)
+                newdiscretetraj.append(np.array(newtraj, dtype=int))
+
+            return newdiscretetraj
+
+        expected = naive(dtrajs, core_set)
+        np.testing.assert_equal(actual, expected)

--- a/pyemma/msm/tests/test_dtraj_stats.py
+++ b/pyemma/msm/tests/test_dtraj_stats.py
@@ -7,7 +7,7 @@ from pyemma.msm.estimators._dtraj_stats import DiscreteTrajectoryStats
 class TestDtrajStats(unittest.TestCase):
     def test_core_sets(self):
         dtrajs   = [np.array([0, 0, 2, 0, 0, 3, 0, 5, 5, 5, 0, 0, 6, 8, 4, 1, 2, 0, 3])]
-        expected = [np.array([2, 2, 2, 2, 2, 3, 3, 5, 5, 5, 5, 5, 6, 6, 4, 4, 2, 2, 3])]
+        expected = [np.array([-1, -1, 2, 2, 2, 3, 3, 5, 5, 5, 5, 5, 6, 6, 4, 4, 2, 2, 3])]
         core_set = np.arange(2, 7)
         dts = DiscreteTrajectoryStats(dtrajs)
         dts.to_coreset(core_set=core_set)
@@ -16,17 +16,19 @@ class TestDtrajStats(unittest.TestCase):
 
     def test_core_sets_2(self):
         dtrajs = [np.array([0, 0, 2, 1, 2])]
+        expected = [np.array([-1, -1, 2, 1, 2])]
         dts = DiscreteTrajectoryStats(dtrajs)
         dts.to_coreset(np.arange(1, 3))
         np.testing.assert_equal(dts.discrete_trajectories,
-                                [np.array([2, 2, 2, 1, 2])])
+                                expected)
 
     def test_core_sets_3(self):
         dtrajs = [np.array([2, 0, 1, 1, 2])]
+        expected = [np.array([2, 2, 1, 1, 2])]
         dts = DiscreteTrajectoryStats(dtrajs)
         dts.to_coreset(np.arange(1, 3))
         np.testing.assert_equal(dts.discrete_trajectories,
-                                [np.array([2, 2, 1, 1, 2])])
+                                expected)
 
     def test_core_sets_4(self):
         dtrajs = [np.array([2, 0, 0, 2, 0, 2, 0, 2])]
@@ -74,6 +76,9 @@ class TestDtrajStats(unittest.TestCase):
                         newtraj.append(oldmicro)
                     elif newmicro is not None:
                         newtraj.append(newmicro)
+                    else:
+                        print("hi there")
+                        newtraj.append(-1)
                 newdiscretetraj.append(np.array(newtraj, dtype=int))
 
             return newdiscretetraj

--- a/pyemma/msm/tests/test_dtraj_stats.py
+++ b/pyemma/msm/tests/test_dtraj_stats.py
@@ -79,3 +79,7 @@ class TestDtrajStats(unittest.TestCase):
 
         expected = naive(dtrajs, core_set)
         np.testing.assert_equal(actual, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This adds support to modify the discrete trajectories to only count transitions between core sets. It is currently not attached to the API of the MSM estimators, we should discuss how to this the best way.

Addresses #978, #930