### PR TITLE
[frames_from_files] handle case FeatureReader got passed with in_memory=True

### DIFF
--- a/pyemma/coordinates/data/util/frames_from_file.py
+++ b/pyemma/coordinates/data/util/frames_from_file.py
@@ -125,11 +125,15 @@ def frames_from_files(files, top, frames, chunksize=1000, stride=1, verbose=Fals
                 for _r in r:
                     _r._return_traj_obj = flag
 
-    # we want the FeatureReader to return mdtraj.Trajectory objects
-    set_reader_return_traj_objects(reader, True)
-
     try:
+        # If the reader got passed in, it could have the data already mapped to memory.
+        # In this case, we cannot force it to return trajectory objects, so we have to re-create it.
+        if reader.in_memory:
+            reader = source(reader.filenames, top=top, chunk_size=chunksize)
+        # we want the FeatureReader to return mdtraj.Trajectory objects
+        set_reader_return_traj_objects(reader, True)
         it = reader.iterator(chunk=chunksize, stride=sorted_inds, return_trajindex=False)
+
         with it:
             collected_frames = [f for f in it]
         dest = _preallocate_empty_trajectory(top, len(frames))

--- a/pyemma/coordinates/tests/test_frames_from_file.py
+++ b/pyemma/coordinates/tests/test_frames_from_file.py
@@ -164,5 +164,12 @@ class TestFramesFromFile(unittest.TestCase):
         matches = re.match(".*10\).*is larger than trajectory length.*\= 10", cm.exception.args[0])
         assert matches
 
+    def test_pass_reader(self):
+        from pyemma.coordinates import source
+        reader = source(self.trajfiles, top=self.pdbfile)
+        reader.in_memory=True
+        inds = np.vstack((np.random.randint(0,1),  np.random.randint(0, 100))).T
+        traj_test = _frames_from_file(reader.filenames, self.pdbfile, inds, reader=reader)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Since we need the reader/iterator to return mdtraj.Trajectory objects, we need to
re-create the reader in this case, because the original reader/iterator will return plain numpy arrays.