### PR TITLE
[doc] removed references to msmtools and provide link to look up low-api

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -17,6 +17,7 @@ Changelog
   - ...
   - Featurizer: fix reshaping of AnglesFeature. #1018. Thanks @RobertArbon
 
+
 2.2.7 (10-21-16)
 ----------------
 

--- a/doc/source/api/msm.analysis.rst
+++ b/doc/source/api/msm.analysis.rst
@@ -1,4 +1,0 @@
-.. automodule:: msmtools.analysis
-
-.. toctree::
-   :maxdepth: 1

--- a/doc/source/api/msm.dtraj.rst
+++ b/doc/source/api/msm.dtraj.rst
@@ -1,4 +1,0 @@
-.. automodule:: msmtools.dtraj
-
-.. toctree::
-   :maxdepth: 1

--- a/doc/source/api/msm.estimation.rst
+++ b/doc/source/api/msm.estimation.rst
@@ -1,4 +1,0 @@
-.. automodule:: msmtools.estimation
-
-.. toctree::
-   :maxdepth: 1

--- a/doc/source/api/msm.flux.rst
+++ b/doc/source/api/msm.flux.rst
@@ -1,4 +1,0 @@
-.. automodule:: msmtools.flux
-
-.. toctree::
-   :maxdepth: 1

--- a/doc/source/api/msm.generation.rst
+++ b/doc/source/api/msm.generation.rst
@@ -1,4 +1,0 @@
-.. automodule:: msmtools.generation
-
-.. toctree::
-   :maxdepth: 1

--- a/pyemma/msm/__init__.py
+++ b/pyemma/msm/__init__.py
@@ -72,16 +72,9 @@ If you are not an expert user, use the API functions above.
 
 MSM functions (low-level API)
 =============================
-Low-level functions for estimation and analysis of transition matrices and io.
+Low-level functions for estimation and analysis of transition matrices and io have been moved to `MSMTools
+<https://msmtools.readthedocs.io/>`_.
 
-.. toctree::
-   :maxdepth: 1
-
-   msm.dtraj
-   msm.generation
-   msm.estimation
-   msm.analysis
-   msm.flux
 
 """
 from __future__ import absolute_import as _


### PR DESCRIPTION
We've deprecated the usage of low-level msm functions for a long time. In fact these function have not been importable any more for 2 releases. Only the docs are still there, which is also confusing. Now we just provide a link to the readthedocs page of msmtools.