### PR TITLE
Fix streaming estimation transformer data producer

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -1,6 +1,22 @@
 Changelog
 =========
 
+2.3.1 (tba)
+-----------
+
+**New features**:
+
+- msm:
+  - ImpliedTimescales: enable insertion/removal of lag times.
+    Avoid recomputing existing models. #1030
+
+**Fixes**:
+
+- coordinates:
+   - If Estimators supporting streaming are used directly, restore previous behaviour. #1034
+     Note that estimators used directly from the API are not affected.
+
+
 2.3 (6-1-2017)
 --------------
 

--- a/pyemma/coordinates/clustering/assign.py
+++ b/pyemma/coordinates/clustering/assign.py
@@ -87,11 +87,12 @@ class AssignCenters(AbstractClustering):
 
     @AbstractClustering.data_producer.setter
     def data_producer(self, dp):
-        # check dimensions
-        dim = self.clustercenters.shape[1]
-        if not dim == dp.dimension():
-            raise ValueError('cluster centers have wrong dimension. Have dim=%i'
-                             ', but input has %i' % (dim, dp.dimension()))
+        if dp is not None:
+            # check dimensions
+            dim = self.clustercenters.shape[1]
+            if not dim == dp.dimension():
+                raise ValueError('cluster centers have wrong dimension. Have dim=%i'
+                                 ', but input has %i' % (dim, dp.dimension()))
         AbstractClustering.data_producer.fset(self, dp)
 
     def _estimate(self, iterable, **kw):

--- a/pyemma/coordinates/data/_base/streaming_estimator.py
+++ b/pyemma/coordinates/data/_base/streaming_estimator.py
@@ -37,13 +37,15 @@ class StreamingEstimator(Estimator):
         self._chunksize = chunksize
 
     def estimate(self, X, **kwargs):
+        # ensure the input is able to provide a stream
         if not isinstance(X, Iterable):
             if isinstance(X, np.ndarray) or \
-                    (isinstance(X, (list, tuple)) and len(X) > 0 and all([isinstance(x, np.ndarray) for x in X])):
+                    (isinstance(X, (list, tuple)) and len(X) > 0 and all((isinstance(x, np.ndarray) for x in X))):
                 X = DataInMemory(X, self.chunksize)
             else:
                 raise ValueError("no np.ndarray or non-empty list of np.ndarrays given")
-
+        # Because we want to use pipelining methods like get_output, we have to set a data producer.
+        self.data_producer = X
         # run estimation
         try:
             super(StreamingEstimator, self).estimate(X, **kwargs)

--- a/pyemma/coordinates/tests/test_pca.py
+++ b/pyemma/coordinates/tests/test_pca.py
@@ -222,5 +222,13 @@ class TestPCAExtensive(unittest.TestCase):
         true_corr = np.corrcoef(feature_traj.T, pca_traj.T)[:nfeat,-npcs:]
         np.testing.assert_allclose(test_corr, true_corr, atol=1.E-8)
 
+    def test_pipelining_sklearn_compat(self):
+        from pyemma.coordinates.transform import PCA
+        t = PCA(dim=2)
+        x = np.random.random((20, 3))
+        y = t.fit_transform(x)
+        y2 = t.get_output()
+        np.testing.assert_allclose(y2[0], y)
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/tests/test_tica.py
+++ b/pyemma/coordinates/tests/test_tica.py
@@ -178,7 +178,15 @@ class TestTICA_Basic(unittest.TestCase):
 
     def test_with_skip(self):
         data = np.random.random((100, 10))
-        tica_obj = api.tica(lag=10, dim=1, skip=1)
+        tica_obj = api.tica(data, lag=10, dim=1, skip=1)
+
+    def test_pipelining_sklearn_compat(self):
+        from pyemma.coordinates.transform import TICA
+        t = TICA(1)
+        x = np.random.random((20, 3))
+        y = t.fit_transform(x)
+        y2 = t.get_output()
+        np.testing.assert_allclose(y2[0], y)
 
 
 class TestTICAExtensive(unittest.TestCase):


### PR DESCRIPTION
[streaming-estimator] set data_producer in estimate()

This import attribute was missing, breaking streamed access.
Also invoke setter of data_producer to ensure random_access is initialized properly.

Fixes #1034