### PR TITLE
add Python 3.6 to travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - CONDA_PY=2.7 CONDA_NPY=1.11
     - CONDA_PY=3.4 CONDA_NPY=1.10
     - CONDA_PY=3.5 CONDA_NPY=1.11
+    - CONDA_PY=3.6 CONDA_NPY=1.11
 
 before_install:
 - devtools/ci/travis/install_miniconda.sh


### PR DESCRIPTION
Adds Python 3.6 to the travis test matrix (3.6 now default in Anaconda release)
