### PR TITLE
Fix coverage reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ before_install:
 script:
 - conda build -q devtools/conda-recipe
 
-after_success:
-- pwd; ls -alh
+after_script:
 - bash <(curl -s https://codecov.io/bash) -f $HOME/coverage.xml -e CONDA_PY,CONDA_NPY
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -36,6 +36,8 @@ requirements:
     - thermotools >=0.2.5
 
 test:
+  source_files:
+    - setup.cfg
   requires:
     - pytest 
     - pytest-cov

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -2,9 +2,11 @@ package:
   name: pyemma-dev
   # version number: [base tag]+[commits-upstream]_[git_hash]
   # eg. v2.0+0_g8824162
-  version: {{ GIT_DESCRIBE_TAG[1:] + '+' +GIT_BUILD_STR}}
+  version: {{ GIT_DESCRIBE_TAG[1:] + '+' + GIT_BUILD_STR}}
 source:
   path: ../..
+  # borked:
+  #git_url: ../../
 
 build:
   preserve_egg_dir: True
@@ -38,6 +40,7 @@ requirements:
 test:
   source_files:
     - setup.cfg
+    - versioneer.py
   requires:
     - pytest 
     - pytest-cov

--- a/devtools/conda-recipe/run_test.py
+++ b/devtools/conda-recipe/run_test.py
@@ -2,6 +2,7 @@ import os
 import sys
 import pytest
 import shutil
+import tempfile
 
 test_pkg = 'pyemma'
 cover_pkg = test_pkg
@@ -12,7 +13,8 @@ pytest_cfg = 'setup.cfg'
 
 print("Using pytest config file: %s" % pytest_cfg)
 assert os.path.exists(pytest_cfg), "pytest cfg not found"
-
+tmp = tempfile.mkdtemp()
+os.chdir(tmp)
 print("current cwd:", os.getcwd())
 
 # matplotlib headless backend
@@ -25,7 +27,7 @@ pytest_args = ("-v --pyargs {test_pkg} "
                "--doctest-modules "
                #"-n 2 "# -p no:xdist" # disable xdist in favour of coverage plugin
                "--junit-xml={junit_xml} "
-               "-c {pytest_cfg} "
+               "-c {pytest_cfg}"
                .format(test_pkg=test_pkg, cover_pkg=cover_pkg,
                        junit_xml=junit_xml, pytest_cfg=pytest_cfg)
                .split(' '))

--- a/devtools/conda-recipe/run_test.py
+++ b/devtools/conda-recipe/run_test.py
@@ -14,7 +14,8 @@ pytest_cfg = 'setup.cfg'
 print("Using pytest config file: %s" % pytest_cfg)
 assert os.path.exists(pytest_cfg), "pytest cfg not found"
 tmp = tempfile.mkdtemp()
-#os.chdir(tmp)
+shutil.copy(pytest_cfg, tmp)
+os.chdir(tmp)
 print("current cwd:", os.getcwd())
 
 # matplotlib headless backend

--- a/devtools/conda-recipe/run_test.py
+++ b/devtools/conda-recipe/run_test.py
@@ -14,7 +14,7 @@ pytest_cfg = 'setup.cfg'
 print("Using pytest config file: %s" % pytest_cfg)
 assert os.path.exists(pytest_cfg), "pytest cfg not found"
 tmp = tempfile.mkdtemp()
-os.chdir(tmp)
+#os.chdir(tmp)
 print("current cwd:", os.getcwd())
 
 # matplotlib headless backend

--- a/devtools/conda-recipe/run_test.py
+++ b/devtools/conda-recipe/run_test.py
@@ -1,26 +1,19 @@
-import tempfile
 import os
 import sys
 import pytest
 import shutil
-import pkg_resources
 
 test_pkg = 'pyemma'
 cover_pkg = test_pkg
 
 junit_xml = os.path.join(os.getenv('CIRCLE_TEST_REPORTS', '.'), 'junit.xml')
 
-if os.getenv('CONDA_BUILD', False):
-    pytest_cfg = pkg_resources.resource_filename(test_pkg, 'setup.cfg')
-else:
-    pytest_cfg = os.path.join(os.path.abspath(os.path.dirname(__file__)), '../../setup.cfg')
+pytest_cfg = 'setup.cfg'
 
 print("Using pytest config file: %s" % pytest_cfg)
 assert os.path.exists(pytest_cfg), "pytest cfg not found"
 
-# chdir to an path outside of conda-bld, which is known to persist the build phase
-run_dir = tempfile.mkdtemp()
-os.chdir(run_dir)
+print("current cwd:", os.getcwd())
 
 # matplotlib headless backend
 with open('matplotlibrc', 'w') as fh:

--- a/setup.py
+++ b/setup.py
@@ -276,7 +276,7 @@ else:
                                   ]
 
     metadata['package_data'] = {
-                                'pyemma': ['pyemma.cfg', 'logging.yml', 'setup.cfg'],
+                                'pyemma': ['pyemma.cfg', 'logging.yml'],
                                 'pyemma.coordinates.tests': ['data/*'],
                                 'pyemma.msm.tests': ['data/*'],
                                 'pyemma.datasets': ['*.npz'],


### PR DESCRIPTION
pyemma was import by the run_test script implicitly by invoking pkg_resources. This led to import statements and definitions not be shown as executed in the report.