### PR TITLE
Ducktype weights in Covariance API

### DIFF
--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -1178,8 +1178,8 @@ def tica(data=None, lag=10, dim=-1, var_cutoff=0.95, kinetic_map=True, commute_m
     """
     from pyemma.coordinates.transform.tica import TICA
     from pyemma.coordinates.estimation.koopman import _KoopmanEstimator
-    from pyemma.coordinates.estimation.koopman import _Weights
     import six
+    import types
     if isinstance(weights, six.string_types):
         if weights == "koopman":
             if data is None:
@@ -1190,11 +1190,11 @@ def tica(data=None, lag=10, dim=-1, var_cutoff=0.95, kinetic_map=True, commute_m
         elif weights == "empirical":
             weights = None
         else:
-            raise ValueError("reweighting must be either 'empirical', 'koopman' or an instance of _Weights.")
-    elif isinstance(weights, _Weights):
+            raise ValueError("reweighting must be either 'empirical', 'koopman' or an object with a weights(data) method.")
+    elif hasattr(weights, 'weights') and type(getattr(weights, 'weights')) == types.MethodType:
         weights = weights
     else:
-        raise ValueError("reweighting must be either 'empirical', 'koopman' or an instance of _Weights.")
+        raise ValueError("reweighting must be either 'empirical', 'koopman' or an object with a weights(data) method.")
 
     if not remove_mean:
         import warnings
@@ -1271,7 +1271,7 @@ def covariance_lagged(data=None, c00=True, c0t=True, ctt=False, remove_constant_
 
     from pyemma.coordinates.estimation.covariance import LaggedCovariance
     from pyemma.coordinates.estimation.koopman import _KoopmanEstimator
-    from pyemma.coordinates.estimation.koopman import _Weights
+    import types
     import six
     if isinstance(weights, six.string_types):
         if weights== "koopman":
@@ -1280,14 +1280,14 @@ def covariance_lagged(data=None, c00=True, c0t=True, ctt=False, remove_constant_
             koop = _KoopmanEstimator(lag=lag, stride=stride, skip=skip)
             _param_stage(data, koop, stride=stride)
             weights = koop.weights
-        elif weights== "empirical":
+        elif weights == "empirical":
             weights = None
         else:
-            raise ValueError("reweighting must be either 'empirical', 'koopman' or an instance of _Weights.")
-    elif isinstance(weights, _Weights):
+            raise ValueError("reweighting must be either 'empirical', 'koopman' or an object with a weights(data) method.")
+    elif hasattr(weights, 'weights') and type(getattr(weights, 'weights')) == types.MethodType:
         weights = weights
     else:
-        raise ValueError("reweighting must be either 'empirical', 'koopman' or an instance of _Weights.")
+        raise ValueError("reweighting must be either 'empirical', 'koopman' or an object with a weights(data) method.")
 
     lc = LaggedCovariance(c00=c00, c0t=c0t, ctt=ctt, remove_constant_mean=remove_constant_mean,
                           remove_data_mean=remove_data_mean, reversible=reversible, bessel=bessel, lag=lag,

--- a/pyemma/coordinates/estimation/covariance.py
+++ b/pyemma/coordinates/estimation/covariance.py
@@ -96,7 +96,7 @@ class LaggedCovariance(StreamingEstimator, ProgressReporter):
         self._rc = None
         self._used_data = 0
 
-    def _compute_weight_series(self, X, it):
+    def _compute_weight_series(self, X):
         if self.weights is None:
             return None
         elif isinstance(self.weights, numbers.Real):
@@ -151,7 +151,7 @@ class LaggedCovariance(StreamingEstimator, ProgressReporter):
                 else:
                     X, Y = data, None
 
-                weight_series = self._compute_weight_series(X, it)
+                weight_series = self._compute_weight_series(X)
 
                 if self.remove_constant_mean is not None:
                     X = X - self.remove_constant_mean[np.newaxis, :]

--- a/pyemma/coordinates/estimation/koopman.py
+++ b/pyemma/coordinates/estimation/koopman.py
@@ -51,12 +51,7 @@ def _compute_u(K):
     return u
 
 
-class _Weights(object):
-
-    def weights(self, X):
-        raise NotImplementedError("weights function not implemented.")
-
-class _KoopmanWeights(_Weights):
+class _KoopmanWeights(object):
     def __init__(self, u, u_const):
         self._u = u
         self._u_const = u_const

--- a/pyemma/coordinates/tests/test_covar_estimator.py
+++ b/pyemma/coordinates/tests/test_covar_estimator.py
@@ -4,12 +4,12 @@ import numpy as np
 
 from pyemma.coordinates import covariance_lagged
 from pyemma.coordinates import source
-from pyemma.coordinates.estimation.koopman import _Weights
+#from pyemma.coordinates.estimation.koopman import _Weights
 
 
 __author__ = 'noe'
 
-class weight_object(_Weights):
+class weight_object(object):
     def __init__(self):
         self.A = np.random.rand(2)
     def weights(self, X):


### PR DESCRIPTION
This change makes it obsolete to inherit a custom weight class from the hidden _Weights class in the koopman implementation. The prior solution is java-style and not user friendly.