### PR TITLE
Use random access feature reader high stride

### DIFF
--- a/pyemma/coordinates/data/util/reader_utils.py
+++ b/pyemma/coordinates/data/util/reader_utils.py
@@ -69,6 +69,7 @@ def create_file_reader(input_files, topology, featurizer, chunk_size=1000, **kw)
                 raise ValueError("The passed list did not exclusively contain strings or was a list of lists "
                                  "(fragmented trajectory).")
 
+        # TODO: this does not handle suffixes like .xyz.gz (rare)
         _, suffix = os.path.splitext(input_list[0])
 
         # check: do all files have the same file type? If not: raise ValueError.

--- a/pyemma/coordinates/tests/test_random_access_stride.py
+++ b/pyemma/coordinates/tests/test_random_access_stride.py
@@ -468,5 +468,19 @@ class TestRandomAccessStride(TestCase):
             it = r.iterator(stride=1000, chunk=100000)
             assert it._mditer.is_ra_iter
 
+            out_ra = r.get_output(stride=1000, chunk=10000)
+        it = r.iterator(stride=1)
+        assert not it._mditer.is_ra_iter
+        out = r.get_output(stride=1000)
+        np.testing.assert_equal(out_ra, out)
+
+        # check max stride exceeding
+        from pyemma.coordinates.util.patches import iterload
+        it = r.iterator(stride=iterload.MAX_STRIDE_SWITCH_TO_RA+1)
+        assert it._mditer.is_ra_iter
+
+        it = r.iterator(stride=iterload.MAX_STRIDE_SWITCH_TO_RA)
+        assert not it._mditer.is_ra_iter
+
 if __name__ == '__main__':
     unittest.main()

--- a/pyemma/coordinates/util/patches.py
+++ b/pyemma/coordinates/util/patches.py
@@ -145,7 +145,6 @@ class iterload(object):
         else:
             n_atoms = self._topology.n_atoms
 
-        # if we have a random access iterator or conventional mdtraj chunked strided reading would exceed a memory limit:
         if (self.is_ra_iter or
                     self._stride > iterload.MAX_STRIDE_SWITCH_TO_RA or
                 (8 * self._chunksize * self._stride * n_atoms > iterload.MEMORY_CUTOFF)):
@@ -341,6 +340,9 @@ def _read_traj_data(atom_indices, f, n_frames, **kwargs):
         cell_lengths, cell_angles = res[1:]
     elif len(res) == 4 or isinstance(f, (HDF5TrajectoryFile, DTRTrajectoryFile, NetCDFTrajectoryFile)):
         cell_lengths, cell_angles = res[2:4]
+    elif len(res) == 3:
+        # this tng format.
+        box = res[2]
     else:
         assert len(res) == 1, "len:{l}, type={t}".format(l=len(res), t=f)
         #raise NotImplementedError("format read function not handled..." + str(f))

--- a/pyemma/coordinates/util/patches.py
+++ b/pyemma/coordinates/util/patches.py
@@ -71,6 +71,9 @@ load_topology_cached = _cache_mdtraj_topology(load_topology)
 
 
 class iterload(object):
+
+    MEMORY_CUTOFF = int(128 * 1024**2) # 128 MB
+
     def __init__(self, filename, chunk=1000, **kwargs):
         """An iterator over a trajectory from one or more files on disk, in fragments
 
@@ -135,12 +138,14 @@ class iterload(object):
             raise Exception("Not supported as trajectory format {ext}".format(ext=self._extension))
 
         self._mode = None
-        if isinstance(self._stride, np.ndarray):
+        if self.is_ra_iter:
             self._mode = 'random_access'
             self._f = (lambda x:
                        md_open(x, n_atoms=self._topology.n_atoms)
                        if self._extension in ('.crd', '.mdcrd')
                        else md_open(self._filename))(self._filename)
+            if not isinstance(self._stride, np.ndarray):
+                self._stride  = np.arange(self._skip, len(self._f), self._stride)
             self._ra_it = self._random_access_generator(self._f)
         else:
             self._mode = 'traj'
@@ -163,6 +168,15 @@ class iterload(object):
     def skip(self, value):
         assert self._mode == 'traj'
         self._skip = value
+
+    @property
+    def is_ra_iter(self):
+        if self._atom_indices is not None:
+            n_atoms = len(self._atom_indices)
+        else:
+            n_atoms = self._topology.n_atoms
+        return (isinstance(self._stride, np.ndarray) or
+               (8 * self._chunksize * self._stride * n_atoms > iterload.MEMORY_CUTOFF))
 
     def __iter__(self):
         return self
@@ -188,7 +202,7 @@ class iterload(object):
             except (IOError, IndexError):
                 raise StopIteration("too short trajectory")
 
-        if isinstance(self._stride, np.ndarray):
+        if self.is_ra_iter:
             return next(self._ra_it)
         else:
             if self._chunksize == 0:


### PR DESCRIPTION
see issue #480 for background.

The problem is circumvented by creating a RA stride array to collect the desired frames. If the stride is bigger than a cutoff, this strategy is used and avoids reading a lot of unwanted data. The other active option is that if stride*chunksize*n_atoms exceeds a certain memory limit.

The values are of course debatable, eg. the stride cutoff maybe to large for big systems, since it should be more io efficient to just seek to the frames, if the frame lengths exceeds a certain buffer size used by the operating system (or hard drive).