### PR TITLE
[estimate-param-scan] allow for interrupting parameter scans for fail…

### DIFF
--- a/pyemma/_base/estimator.py
+++ b/pyemma/_base/estimator.py
@@ -137,6 +137,9 @@ def _estimate_param_scan_worker(estimator, params, X, evaluate, evaluate_args,
     try:  # catch any exception
         estimator.estimate(X, **params)
         model = estimator.model
+    except KeyboardInterrupt:
+        # we want to be able to interactively interrupt the worker, no matter of failfast=False.
+        raise
     except:
         e = sys.exc_info()[1]
         if isinstance(estimator, Loggable):


### PR DESCRIPTION
Eg. for calculating implied timescales, one could not interrupt the process
of estimating, because KeyboardInterrupt exceptions are being handled as
estimation errors.