### PR TITLE
[ML-MSM] towards removing dtrajs attribute (deprecated first)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,27 +1,15 @@
 import pytest
+import sys
+
+# this is import for measuring coverage
+assert 'pyemma' not in sys.modules
 
 
 @pytest.fixture(scope='session')
 def no_progress_bars():
     """ disables progress bars during testing """
-    import subprocess
-
-    def pg_enabled():
-        out = subprocess.check_output(['python', '-c', 'from __future__ import print_function; import pyemma; print(pyemma.config.show_progress_bars)'])
-        return out.find('True') != -1
-
-    def cache_enabled():
-        out = subprocess.check_output(['python', '-c', 'from __future__ import print_function; import pyemma; print(pyemma.config.use_trajectory_lengths_cache)'])
-        return out.find('True') != -1
-
-    cfg_script = "import pyemma; pyemma.config.show_progress_bars = {pg}; pyemma.config.use_trajectory_lengths_cache = {cache};pyemma.config.save()"
-
-    pg_old_state = pg_enabled()
-    cache_old_state = cache_enabled()
-
-    enable = cfg_script.format(pg=pg_old_state, cache=cache_old_state)
-    disable = cfg_script.format(pg=False, cache=False)
-
-    subprocess.call(['python', '-c', disable])
-    yield  # run session, after generator returned, session is cleaned up.
-    subprocess.call(['python', '-c', enable])
+    if 'pyemma' in sys.modules:
+        pyemma = sys.modules['pyemma']
+        pyemma.config.show_progress_bars = False
+        pyemma.config.use_trajectory_lengths_cache = False
+    yield

--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -433,12 +433,6 @@ class _MSMEstimator(_Estimator, _MSM):
         A list of integer arrays with the discrete trajectories mapped to the connectivity mode used.
         For example, for connectivity='largest', the indexes will be given within the connected set.
         Frames that are not in the connected set will be -1.
-
-        Parameters
-        ----------
-        dtrajs : list containing ndarrays(dtype=int) or ndarray(n, dtype=int)
-            discrete trajectories, stored as integer ndarrays (arbitrary size)
-            or a single ndarray for only one trajectory.
         """
         self._check_is_estimated()
         # compute connected dtrajs

--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -22,8 +22,7 @@ import numpy as _np
 import warnings
 from msmtools import estimation as msmest
 
-
-from pyemma.util.annotators import alias, aliased, fix_docs
+from pyemma.util.annotators import alias, aliased, fix_docs, deprecated
 from pyemma.util.types import ensure_dtraj_list
 from pyemma._base.estimator import Estimator as _Estimator
 from pyemma.msm.estimators._dtraj_stats import DiscreteTrajectoryStats as _DiscreteTrajectoryStats
@@ -417,6 +416,7 @@ class _MSMEstimator(_Estimator, _MSM):
 
     @property
     @alias('dtrajs_full')
+    @deprecated("This attribute will be removed in the future!")
     def discrete_trajectories_full(self):
         """
         A list of integer arrays with the original (unmapped) discrete trajectories:
@@ -427,20 +427,52 @@ class _MSMEstimator(_Estimator, _MSM):
 
     @property
     @alias('dtrajs_active')
+    @deprecated("This attribute will be removed in the future!")
     def discrete_trajectories_active(self):
         """
         A list of integer arrays with the discrete trajectories mapped to the connectivity mode used.
         For example, for connectivity='largest', the indexes will be given within the connected set.
         Frames that are not in the connected set will be -1.
 
+        Parameters
+        ----------
+        dtrajs : list containing ndarrays(dtype=int) or ndarray(n, dtype=int)
+            discrete trajectories, stored as integer ndarrays (arbitrary size)
+            or a single ndarray for only one trajectory.
         """
         self._check_is_estimated()
         # compute connected dtrajs
-        self._dtrajs_active = []
-        for dtraj in self._dtrajs_full:
-            self._dtrajs_active.append(self._full2active[dtraj])
+        dtrajs_active = [self._full2active[dtraj] for dtraj in self._dtrajs_full]
+        return dtrajs_active
 
-        return self._dtrajs_active
+    @alias('compute_dtrajs_active')
+    def compute_discrete_trajectories_active(self, dtrajs):
+        """
+        A list of integer arrays with the discrete trajectories mapped to the connectivity mode used.
+        For example, for connectivity='largest', the indexes will be given within the connected set.
+        Frames that are not in the connected set will be -1.
+
+        Parameters
+        ----------
+        dtrajs : list containing ndarrays(dtype=int) or ndarray(n, dtype=int)
+            discrete trajectories, stored as integer ndarrays (arbitrary size)
+            or a single ndarray for only one trajectory.
+
+        """
+        self._check_is_estimated()
+        # compute connected dtrajs
+        dtrajs_active = [self._full2active[dtraj] for dtraj in dtrajs]
+        return dtrajs_active
+
+    def _check_dtrajs_arg(self, dtrajs):
+        # ensure dtrajs is given, otherwise warn the user.
+        if dtrajs is None:
+            import inspect
+            s = inspect.stack(context=1)
+            method = s[1][1][3]
+            warnings.warn("The dtrajs argument will be mandatory in the future for method {method}".format(method=method))
+            dtrajs = self._dtrajs_full
+        return dtrajs
 
     @property
     def count_matrix_active(self):
@@ -490,6 +522,7 @@ class _MSMEstimator(_Estimator, _MSM):
         return float(self._nstates) / float(self._nstates_full)
 
     @property
+    @deprecated('use compute_active_count_fraction')
     def active_count_fraction(self):
         """The fraction of counts in the largest connected set.
 
@@ -498,6 +531,16 @@ class _MSMEstimator(_Estimator, _MSM):
         from pyemma.util.discrete_trajectories import count_states
 
         hist = count_states(self._dtrajs_full)
+        hist_active = hist[self.active_set]
+        return float(_np.sum(hist_active)) / float(_np.sum(hist))
+
+    def compute_active_count_fraction(self, dtrajs):
+        """The fraction of counts in the largest connected set.
+        """
+        self._check_is_estimated()
+        from pyemma.util.discrete_trajectories import count_states
+
+        hist = count_states(dtrajs)
         hist_active = hist[self.active_set]
         return float(_np.sum(hist_active)) / float(_np.sum(hist))
 
@@ -511,13 +554,7 @@ class _MSMEstimator(_Estimator, _MSM):
         Ensures that the connected states are indexed and returns the indices
         """
         self._check_is_estimated()
-        try:  # if we have this attribute, return it
-            return self._active_state_indexes
-        except:  # didn't exist? then create it.
-            import pyemma.util.discrete_trajectories as dt
-
-            self._active_state_indexes = dt.index_states(self.discrete_trajectories_full, subset=self.active_set)
-            return self._active_state_indexes
+        return self._active_state_indexes
 
     def generate_traj(self, N, start=None, stop=None, stride=1):
         """Generates a synthetic discrete trajectory of length N and simulation time stride * lag time * N
@@ -637,8 +674,8 @@ class _MSMEstimator(_Estimator, _MSM):
     ################################################################################
     # For general statistics
     ################################################################################
-
-    def trajectory_weights(self):
+    @deprecated('Note that this method will require a dtrajs argument in the future.')
+    def trajectory_weights(self, dtrajs=None):
         r"""Uses the MSM to assign a probability weight to each trajectory frame.
 
         This is a powerful function for the calculation of arbitrary observables in the trajectories one has
@@ -685,16 +722,18 @@ class _MSMEstimator(_Estimator, _MSM):
 
         """
         self._check_is_estimated()
+        dtrajs = self._check_dtrajs_arg(dtrajs)
+
         # compute stationary distribution, expanded to full set
         statdist_full = _np.zeros([self._nstates_full])
         statdist_full[self.active_set] = self.stationary_distribution
         # histogram observed states
         import msmtools.dtraj as msmtraj
-        hist = 1.0 * msmtraj.count_states(self.discrete_trajectories_full)
+        hist = 1.0 * msmtraj.count_states(dtrajs)
         # simply read off stationary distribution and accumulate total weight
         W = []
         wtot = 0.0
-        for dtraj in self.discrete_trajectories_full:
+        for dtraj in dtrajs:
             w = statdist_full[dtraj] / hist[dtraj]
             W.append(w)
             wtot += _np.sum(w)
@@ -708,13 +747,18 @@ class _MSMEstimator(_Estimator, _MSM):
     # HMM-based coarse graining
     ################################################################################
 
-    def hmm(self, nhidden):
+    @deprecated('Note that this method will require a dtrajs argument in the future.')
+    def hmm(self, nhidden, dtrajs=None):
         """Estimates a hidden Markov state model as described in [1]_
 
         Parameters
         ----------
         nhidden : int
             number of hidden (metastable) states
+            
+        dtrajs : list containing ndarrays(dtype=int) or ndarray(n, dtype=int)
+            discrete trajectories, stored as integer ndarrays (arbitrary size)
+            or a single ndarray for only one trajectory.
 
         Returns
         -------
@@ -728,21 +772,27 @@ class _MSMEstimator(_Estimator, _MSM):
 
         """
         self._check_is_estimated()
+        dtrajs = self._check_dtrajs_arg(dtrajs)
         # check if the time-scale separation is OK
         # if hmm.nstates = msm.nstates there is no problem. Otherwise, check spectral gap
         if self.nstates > nhidden:
             timescale_ratios = self.timescales()[:-1] / self.timescales()[1:]
-            if timescale_ratios[nhidden-2] < 1.5:
-                self.logger.warning('Requested coarse-grained model with ' + str(nhidden) + ' metastable states at ' +
-                                    'lag=' + str(self.lag) + '.' + 'The ratio of relaxation timescales between ' +
-                                    str(nhidden) + ' and ' + str(nhidden+1) + ' states is only ' +
-                                    str(timescale_ratios[nhidden-2]) + ' while we recommend at least 1.5. ' +
-                                    'It is possible that the resulting HMM is inaccurate. Handle with caution.')
+            if timescale_ratios[nhidden - 2] < 1.5:
+                self.logger.warning('Requested coarse-grained model with {nhidden} metastable states at lag={lag}.'
+                                    ' The ratio of relaxation timescales between'
+                                    ' {nhidden} and {nhidden_1} states is only {ratio}'
+                                    ' while we recommend at least 1.5.'
+                                    ' It is possible that the resulting HMM is inaccurate. Handle with caution.'.format(
+                    lag=self.lag,
+                    nhidden=nhidden,
+                    nhidden_1=nhidden + 1,
+                    ratio = timescale_ratios[nhidden - 2],
+                ))
         # run HMM estimate
         from pyemma.msm.estimators.maximum_likelihood_hmsm import MaximumLikelihoodHMSM
         estimator = MaximumLikelihoodHMSM(lag=self.lagtime, nstates=nhidden, msm_init=self,
                                           reversible=self.is_reversible, dt_traj=self.dt_traj)
-        estimator.estimate(self.discrete_trajectories_full)
+        estimator.estimate(dtrajs)
         return estimator.model
 
     def coarse_grain(self, ncoarse, method='hmm'):
@@ -778,7 +828,7 @@ class _MSMEstimator(_Estimator, _MSM):
     ################################################################################
 
     def cktest(self, nsets, memberships=None, mlags=10, conf=0.95, err_est=False,
-               n_jobs=1, show_progress=True):
+               n_jobs=1, show_progress=True, dtrajs=None):
         """ Conducts a Chapman-Kolmogorow test.
 
         Parameters
@@ -803,7 +853,9 @@ class _MSMEstimator(_Estimator, _MSM):
             how many jobs to use during calculation
         show_progress : bool, optional
             Show progress bars for calculation?
-
+        dtrajs : list containing ndarrays(dtype=int) or ndarray(n, dtype=int)
+            discrete trajectories, stored as integer ndarrays (arbitrary size)
+            or a single ndarray for only one trajectory.
         Returns
         -------
         cktest : :class:`ChapmanKolmogorovValidator <pyemma.msm.ChapmanKolmogorovValidator>`
@@ -823,13 +875,14 @@ class _MSMEstimator(_Estimator, _MSM):
             134: 174105
 
         """
+        dtrajs = self._check_dtrajs_arg(dtrajs)
         from pyemma.msm.estimators import ChapmanKolmogorovValidator
         if memberships is None:
             self.pcca(nsets)
             memberships = self.metastable_memberships
         ck = ChapmanKolmogorovValidator(self, self, memberships, mlags=mlags, conf=conf,
                                         n_jobs=n_jobs, err_est=err_est, show_progress=show_progress)
-        ck.estimate(self._dtrajs_full)
+        ck.estimate(dtrajs)
         return ck
 
 
@@ -1061,15 +1114,20 @@ class MaximumLikelihoodMSM(_MSMEstimator):
 
         # Done. We set our own model parameters, so this estimator is
         # equal to the estimated model.
+        # TODO: remove in a future version.
         self._dtrajs_full = dtrajs
         self._connected_sets = msmest.connected_sets(self._C_full)
         self.set_model_params(P=P, pi=statdist_active, reversible=self.reversible,
                               dt_model=self.timestep_traj.get_scaled(self.lag))
 
+        from pyemma.util.discrete_trajectories import index_states
+        self._active_state_indexes = index_states(dtrajs, subset=self.active_set)
+
         return self
 
     # TODO: change to statistically effective count matrix!
     @property
+    @deprecated('please use compute_effective_count_matrix in the future.')
     def effective_count_matrix(self):
         """Statistically uncorrelated transition counts within the active set of states
 
@@ -1082,11 +1140,38 @@ class MaximumLikelihoodMSM(_MSMEstimator):
 
         """
         self._check_is_estimated()
+        import msmtools.estimation as msmest
         Ceff_full = msmest.effective_count_matrix(self._dtrajs_full, self.lag)
         from pyemma.util.linalg import submatrix
         Ceff = submatrix(Ceff_full, self.active_set)
         return Ceff
         # return self._C_active / float(self.lag)
+
+    # TODO: change to statistically effective count matrix!
+    def compute_effective_count_matrix(self, dtrajs):
+        """Statistically uncorrelated transition counts within the active set of states
+
+        You can use this count matrix for Bayesian estimation or error perturbation.
+
+        Parameters
+        ----------
+        dtrajs : list containing ndarrays(dtype=int) or ndarray(n, dtype=int)
+            discrete trajectories, stored as integer ndarrays (arbitrary size)
+            or a single ndarray for only one trajectory.
+
+        References
+        ----------
+        [1] Noe, F. (2015) Statistical inefficiency of Markov model count matrices
+            http://publications.mi.fu-berlin.de/1699/1/autocorrelation_counts.pdf
+
+        """
+        self._check_is_estimated()
+        import msmtools.estimation as msmest
+        Ceff_full = msmest.effective_count_matrix(dtrajs, self.lag)
+        from pyemma.util.linalg import submatrix
+        Ceff = submatrix(Ceff_full, self.active_set)
+        return Ceff
+        # return self._C_active / float(self.l
 
 
 @fix_docs
@@ -1282,7 +1367,7 @@ class OOMReweightedMSM(_MSMEstimator):
 
         # Done. We set our own model parameters, so this estimator is
         # equal to the estimated model.
-        self._dtrajs_full = dtrajs
+        self._dtrajs_full = dtrajs  # TODO: remove this in a future version.
         self._connected_sets = msmest.connected_sets(self._C_full)
         self._Xi = Xi
         self._omega = omega

--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -460,6 +460,7 @@ class _MSMEstimator(_Estimator, _MSM):
 
         """
         self._check_is_estimated()
+        dtrajs = ensure_dtraj_list(dtrajs)
         # compute connected dtrajs
         dtrajs_active = [self._full2active[dtraj] for dtraj in dtrajs]
         return dtrajs_active
@@ -468,9 +469,10 @@ class _MSMEstimator(_Estimator, _MSM):
         # ensure dtrajs is given, otherwise warn the user.
         if dtrajs is None:
             import inspect
-            s = inspect.stack(context=1)
-            method = s[1][1][3]
-            warnings.warn("The dtrajs argument will be mandatory in the future for method {method}".format(method=method))
+            s = inspect.stack(context=3)
+            method = s[1][3]
+            warnings.warn("The dtrajs argument will be mandatory in the future for method {method}."
+                          .format(method=method), stacklevel=3)
             dtrajs = self._dtrajs_full
         return dtrajs
 
@@ -538,6 +540,7 @@ class _MSMEstimator(_Estimator, _MSM):
         """The fraction of counts in the largest connected set.
         """
         self._check_is_estimated()
+        dtrajs = ensure_dtraj_list(dtrajs)
         from pyemma.util.discrete_trajectories import count_states
 
         hist = count_states(dtrajs)
@@ -674,7 +677,6 @@ class _MSMEstimator(_Estimator, _MSM):
     ################################################################################
     # For general statistics
     ################################################################################
-    @deprecated('Note that this method will require a dtrajs argument in the future.')
     def trajectory_weights(self, dtrajs=None):
         r"""Uses the MSM to assign a probability weight to each trajectory frame.
 
@@ -1127,7 +1129,7 @@ class MaximumLikelihoodMSM(_MSMEstimator):
 
     # TODO: change to statistically effective count matrix!
     @property
-    @deprecated('please use compute_effective_count_matrix in the future.')
+    @deprecated('Please use compute_effective_count_matrix in the future.')
     def effective_count_matrix(self):
         """Statistically uncorrelated transition counts within the active set of states
 
@@ -1166,6 +1168,7 @@ class MaximumLikelihoodMSM(_MSMEstimator):
 
         """
         self._check_is_estimated()
+        dtrajs = ensure_dtraj_list(dtrajs)
         import msmtools.estimation as msmest
         Ceff_full = msmest.effective_count_matrix(dtrajs, self.lag)
         from pyemma.util.linalg import submatrix

--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -31,6 +31,8 @@ from pyemma.util.units import TimeUnit as _TimeUnit
 from pyemma.util import types as _types
 from pyemma.msm.estimators._OOM_MSM import *
 from pyemma.util.statistics import confidence_interval as _ci
+
+
 @fix_docs
 @aliased
 class _MSMEstimator(_Estimator, _MSM):
@@ -1135,7 +1137,6 @@ class MaximumLikelihoodMSM(_MSMEstimator):
 
         """
         self._check_is_estimated()
-        import msmtools.estimation as msmest
         Ceff_full = msmest.effective_count_matrix(self._dtrajs_full, self.lag)
         from pyemma.util.linalg import submatrix
         Ceff = submatrix(Ceff_full, self.active_set)

--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -1370,6 +1370,8 @@ class OOMReweightedMSM(_MSMEstimator):
         # Done. We set our own model parameters, so this estimator is
         # equal to the estimated model.
         self._dtrajs_full = dtrajs  # TODO: remove this in a future version.
+        from pyemma.util.discrete_trajectories import index_states
+        self._active_state_indexes = index_states(dtrajs, subset=self.active_set)
         self._connected_sets = msmest.connected_sets(self._C_full)
         self._Xi = Xi
         self._omega = omega

--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -1745,6 +1745,9 @@ class AugmentedMarkovModel(MaximumLikelihoodMSM):
         if _np.size(self.active_set) == 0:
             raise RuntimeError('Active set is empty. Cannot estimate AMM.')
 
+        from pyemma.util.discrete_trajectories import index_states
+        self._active_state_indexes = index_states(dtrajs, subset=self.active_set)
+
         # active count matrix and number of states
         self._C_active = dtrajstats.count_matrix(subset=self.active_set)
         self._nstates = self._C_active.shape[0]

--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -749,7 +749,6 @@ class _MSMEstimator(_Estimator, _MSM):
     # HMM-based coarse graining
     ################################################################################
 
-    @deprecated('Note that this method will require a dtrajs argument in the future.')
     def hmm(self, nhidden, dtrajs=None):
         """Estimates a hidden Markov state model as described in [1]_
 

--- a/pyemma/msm/tests/test_amm.py
+++ b/pyemma/msm/tests/test_amm.py
@@ -90,7 +90,7 @@ class TestAMMSimple(unittest.TestCase):
         self.assertTrue(np.allclose(self.AMM.pi, amm.pi))
         self.assertTrue(np.allclose(self.AMM.lagrange, amm.lagrange))
 
-class TestAMMDoubleWell(_tmsm):#unittest.TestCase):
+class TestAMMDoubleWell(_tmsm):
 
     @classmethod
     def setUpClass(cls):
@@ -147,9 +147,6 @@ class TestAMMDoubleWell(_tmsm):#unittest.TestCase):
 
     def test_count_matrix_full(self):
         self._count_matrix_full(self.amm)
-
-    def test_discrete_trajectories_full(self):
-        self._discrete_trajectories_full(self.amm)
 
     def test_discrete_trajectories_active(self):
         self._discrete_trajectories_active(self.amm)

--- a/pyemma/msm/tests/test_msm.py
+++ b/pyemma/msm/tests/test_msm.py
@@ -135,6 +135,7 @@ class TestMSMDoubleWell(unittest.TestCase):
     def setUpClass(cls):
         import pyemma.datasets
         cls.dtraj = pyemma.datasets.load_2well_discrete().dtraj_T100K_dt10
+        #assert isinstance(cls.dtraj, list)
         nu = 1.*np.bincount(cls.dtraj)        
         cls.statdist = nu/nu.sum()
         
@@ -314,21 +315,10 @@ class TestMSMDoubleWell(unittest.TestCase):
         self._count_matrix_full(self.msmrevpi_sparse)
         self._count_matrix_full(self.msm_sparse)
 
-    def _discrete_trajectories_full(self, msm):
-        assert (np.all(self.dtraj == msm.discrete_trajectories_full[0]))
-
-    def test_discrete_trajectories_full(self):
-        self._discrete_trajectories_full(self.msmrev)
-        self._discrete_trajectories_full(self.msmrevpi)
-        self._discrete_trajectories_full(self.msm)
-        self._discrete_trajectories_full(self.msmrev_sparse)
-        self._discrete_trajectories_full(self.msmrevpi_sparse)
-        self._discrete_trajectories_full(self.msm_sparse)
-
     def _discrete_trajectories_active(self, msm):
-        dta = msm.discrete_trajectories_active
+        dta = msm.compute_discrete_trajectories_active(self.dtraj)
         # HERE
-        assert (len(dta) == 1)
+        self.assertEqual(len(dta), 1)
         # HERE: states are shifted down from the beginning, because early states are missing
         assert (dta[0][0] < self.dtraj[0])
 
@@ -382,9 +372,9 @@ class TestMSMDoubleWell(unittest.TestCase):
 
     def _active_count_fraction(self, msm):
         # should always be a fraction
-        assert (0.0 <= msm.active_count_fraction <= 1.0)
+        assert (0.0 <= msm.compute_active_count_fraction(self.dtraj) <= 1.0)
         # special case for this data set:
-        assert (msm.active_count_fraction == 1.0)
+        assert (msm.compute_active_count_fraction(self.dtraj) == 1.0)
 
     def test_active_count_fraction(self):
         self._active_count_fraction(self.msmrev)
@@ -408,7 +398,7 @@ class TestMSMDoubleWell(unittest.TestCase):
         self._active_state_fraction(self.msm_sparse)
 
     def _effective_count_matrix(self, msm):
-        Ceff = msm.effective_count_matrix
+        Ceff = msm.compute_effective_count_matrix(self.dtraj)
         assert (np.all(Ceff.shape == (msm.nstates, msm.nstates)))
 
     def test_effective_count_matrix(self):
@@ -893,7 +883,7 @@ class TestMSMDoubleWell(unittest.TestCase):
         # compare to histogram
         import pyemma.util.discrete_trajectories as dt
 
-        hist = dt.count_states(msm.discrete_trajectories_full)
+        hist = dt.count_states(self.dtraj)
         # number of frames should match on active subset
         A = msm.active_set
         for i in range(A.shape[0]):
@@ -933,7 +923,7 @@ class TestMSMDoubleWell(unittest.TestCase):
         # must have the right size
         assert (len(ss) == msm.nstates)
         # must be correctly assigned
-        dtraj_active = msm.discrete_trajectories_active[0]
+        dtraj_active = msm.compute_discrete_trajectories_active(self.dtraj)[0]
         for i, samples in enumerate(ss):
             # right shape
             assert (np.all(samples.shape == (nsample, 2)))


### PR DESCRIPTION
As discussed yesterday, I started to remove the storage of discrete trajectories in the estimator. This makes the class more sklearn-like in term it separates data from the actual estimation.

The properties, which rely on _dtrajs_full now have an equivalent "compute_$attribute". These methods take a dtrajs argument.