### PR TITLE
[TrajInfoCache] handle exceptions from bogus files.

### DIFF
--- a/pyemma/coordinates/data/util/traj_info_cache.py
+++ b/pyemma/coordinates/data/util/traj_info_cache.py
@@ -195,7 +195,11 @@ class TrajectoryInfoCache(object):
         # handle cache misses and not interpretable results by re-computation.
         # Note: this also handles UnknownDBFormatExceptions!
         except KeyError:
-            info = reader._get_traj_info(filename)
+            try:
+                info = reader._get_traj_info(filename)
+            except BaseException as e:
+                raise IOError('Could not obtain info for file {f}. '
+                              'Original error was {e}'.format(f=filename, e=e))
             info.hash_value = key
             info.abs_path = abs_path
             # store info in db

--- a/pyemma/coordinates/tests/test_api_source.py
+++ b/pyemma/coordinates/tests/test_api_source.py
@@ -108,7 +108,7 @@ class TestApiSourceFileReader(unittest.TestCase):
 
     def test_bullshit_csv(self):
         # this file is not parseable as tabulated float file
-        self.assertRaises(ValueError, api.source, self.bs)
+        self.assertRaises(IOError, api.source, self.bs)
 
 import pkg_resources
 class TestApiSourceFeatureReader(unittest.TestCase):

--- a/pyemma/coordinates/tests/test_traj_info_cache.py
+++ b/pyemma/coordinates/tests/test_traj_info_cache.py
@@ -113,6 +113,15 @@ class TestTrajectoryInfoCache(unittest.TestCase):
                 api.source(f.name)
                 assert f.name in cm.exception.message
 
+        # bogus files
+        with NamedTemporaryFile(suffix='.npy', delete=False) as f:
+            x = np.array([1, 2, 3])
+            np.save(f, x)
+            with open(f.name, 'wb') as f2:
+                f2.write(b'asdf')
+            with self.assertRaises(IOError) as cm:
+                api.source(f.name)
+
     def test_featurereader_xtc(self):
         # cause cache failures
         with settings(use_trajectory_lengths_cache=False):


### PR DESCRIPTION
The filename which caused the error along with the original exception message
is being raised as IOError to inform the user the file is corrupt.

Thanks to Esam for bringing this up.