### PR TITLE
Remove parametrize calls

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -38,6 +38,9 @@ requirements:
     - thermotools >=0.2.5
 
 test:
+  commands:
+  # enable the reporting of Python warning
+    - pip install pytest-warnings
   source_files:
     - conftest.py
     - setup.cfg

--- a/pyemma/coordinates/data/_base/transformer.py
+++ b/pyemma/coordinates/data/_base/transformer.py
@@ -186,15 +186,6 @@ class StreamingTransformer(Transformer, DataSource, NotifyOnChangesMixIn):
 
         return super(StreamingTransformer, self).get_output(dimensions, stride, skip, chunk)
 
-    @deprecated('use fit or estimate')
-    def parametrize(self, stride=1):
-        """ DEPRECATED: please use fit() or estimate()."""
-        if self._data_producer is None:
-            raise RuntimeError(
-                "This estimator has no data source given, giving up.")
-
-        return self.estimate(self.data_producer, stride=stride)
-
     @property
     def chunksize(self):
         """chunksize defines how much data is being processed at once."""

--- a/pyemma/coordinates/tests/test_assign.py
+++ b/pyemma/coordinates/tests/test_assign.py
@@ -154,11 +154,6 @@ class TestClusterAssign(unittest.TestCase):
         c = self.ass
         assert c.output_type() == np.int32
 
-    def test_parametrize(self):
-        c = self.ass
-        # nothing should happen
-        c.parametrize()
-
     def test_save_dtrajs(self):
         c = self.ass
         prefix = "test"

--- a/pyemma/coordinates/tests/test_featurereader_and_tica.py
+++ b/pyemma/coordinates/tests/test_featurereader_and_tica.py
@@ -87,7 +87,6 @@ class TestFeatureReaderAndTICA(unittest.TestCase):
             trans = api.tica(data=reader, dim=self.dim, lag=lag)
             log.info('number of trajectories reported by tica %d' % trans.number_of_trajectories())
             log.info('tau = %d corresponds to a number of %f cycles' % (lag, self.w*lag/(2.0*np.pi)))
-            trans.parametrize()
 
             # analytical solution for C_ij(lag) is 0.5*A[i]*A[j]*cos(phi[i]-phi[j])*cos(w*lag)
             ana_cov = 0.5*self.A[:, np.newaxis]*self.A*np.cos(self.phi[:, np.newaxis]-self.phi)

--- a/pyemma/coordinates/tests/test_featurereader_and_tica_projection.py
+++ b/pyemma/coordinates/tests/test_featurereader_and_tica_projection.py
@@ -100,7 +100,6 @@ class TestFeatureReaderAndTICAProjection(unittest.TestCase):
         for tau in [1, 10, 100, 1000, 2000]:
             trans = tica(lag=tau, dim=self.dim, kinetic_map=False)
 
-            log.info('number of trajectories reported by tica %d' % trans.number_of_trajectories())
             trans.estimate(reader)
             data = trans.get_output()
 

--- a/pyemma/coordinates/tests/test_featurereader_and_tica_projection.py
+++ b/pyemma/coordinates/tests/test_featurereader_and_tica_projection.py
@@ -99,10 +99,9 @@ class TestFeatureReaderAndTICAProjection(unittest.TestCase):
         reader = FeatureReader(self.trajnames, self.temppdb)
         for tau in [1, 10, 100, 1000, 2000]:
             trans = tica(lag=tau, dim=self.dim, kinetic_map=False)
-            trans.data_producer = reader
 
             log.info('number of trajectories reported by tica %d' % trans.number_of_trajectories())
-            trans.parametrize()
+            trans.estimate(reader)
             data = trans.get_output()
 
             log.info('max. eigenvalue: %f' % np.max(trans.eigenvalues))

--- a/pyemma/coordinates/tests/test_regspace.py
+++ b/pyemma/coordinates/tests/test_regspace.py
@@ -53,10 +53,10 @@ class TestRegSpaceClustering(unittest.TestCase):
     def setUp(self):
         self.dmin = 0.3
         self.clustering = RegularSpaceClustering(dmin=self.dmin)
-        self.clustering.data_producer = RandomDataSource()
+        self.src = RandomDataSource()
 
     def test_algorithm(self):
-        self.clustering.parametrize()
+        self.clustering.estimate(self.src)
 
         # correct type of dtrajs
         assert types.is_int_vector(self.clustering.dtrajs[0])
@@ -74,7 +74,7 @@ class TestRegSpaceClustering(unittest.TestCase):
                                     % (c[0], c[1], self.dmin, dist))
 
     def test_assignment(self):
-        self.clustering.parametrize()
+        self.clustering.estimate(self.src)
 
         assert len(self.clustering.clustercenters) > 1
 
@@ -88,26 +88,26 @@ class TestRegSpaceClustering(unittest.TestCase):
         self.clustering.assign(data_to_cluster, stride=1)
 
     def test_spread_data(self):
-        self.clustering.data_producer = RandomDataSource(a=-2, b=2)
+        src =  RandomDataSource(a=-2, b=2)
         self.clustering.dmin = 2
-        self.clustering.parametrize()
+        self.clustering.estimate(src)
 
     def test1d_data(self):
         data = np.random.random(100)
         cluster_regspace(data, dmin=0.3)
 
     def test_non_existent_metric(self):
-        self.clustering.data_producer = RandomDataSource(a=-2, b=2)
+        src = RandomDataSource(a=-2, b=2)
         self.clustering.dmin = 2
         self.clustering.metric = "non_existent_metric"
         with self.assertRaises(ValueError):
-            self.clustering.parametrize()
+            self.clustering.estimate(src)
 
     def test_minRMSD_metric(self):
-        self.clustering.data_producer = RandomDataSource(a=-2, b=2)
+        src = RandomDataSource(a=-2, b=2)
         self.clustering.dmin = 2
         self.clustering.metric = "minRMSD"
-        self.clustering.parametrize()
+        self.clustering.estimate(src)
 
         data_to_cluster = np.random.random((1000, 3))
 
@@ -122,7 +122,7 @@ class TestRegSpaceClustering(unittest.TestCase):
             # Cause all warnings to always be triggered.
             warnings.simplefilter("always")
             # Trigger a warning.
-            self.clustering.estimate(self.clustering.data_producer)
+            self.clustering.estimate(self.src)
             assert w
             assert len(w) == 1
 

--- a/pyemma/coordinates/tests/test_stride.py
+++ b/pyemma/coordinates/tests/test_stride.py
@@ -62,8 +62,6 @@ class TestStride(unittest.TestCase):
         for stride in range(1, 100, 23):
             r = coor.source(self.trajnames, top=self.temppdb)
             t = coor.tica(data=r, lag=2, dim=2)
-            # t.data_producer = r
-            t.parametrize()
 
             # subsample data
             out_tica = t.get_output(stride=stride)
@@ -110,7 +108,6 @@ class TestStride(unittest.TestCase):
             try:
                 t = coor.tica(r, lag=tau, stride=stride, dim=2)
                 # force_eigenvalues_le_one=True enables an internal consistency check in TICA
-                t.parametrize(stride=stride)
                 self.assertTrue(np.all(t.eigenvalues <= 1.0+1.E-12))
             except RuntimeError:
                 assert tau % stride != 0

--- a/pyemma/coordinates/tests/test_tica.py
+++ b/pyemma/coordinates/tests/test_tica.py
@@ -164,8 +164,8 @@ class TestTICA_Basic(unittest.TestCase):
 
     def test_in_memory(self):
         data = np.random.random((100, 10))
-        tica_obj = api.tica(lag=10, dim=1)
         reader = api.source(data)
+        tica_obj = api.tica(reader, lag=10, dim=1)
 
         tica_obj.in_memory = True
         tica_obj.get_output()

--- a/pyemma/coordinates/tests/test_tica.py
+++ b/pyemma/coordinates/tests/test_tica.py
@@ -88,7 +88,6 @@ class TestTICA_Basic(unittest.TestCase):
         with numpy_random_seed(0):
             data = np.random.randn(100, 10)
         tica_obj = api.tica(data=data, lag=10, dim=1)
-        tica_obj.parametrize()
         Y = tica_obj._transform_array(data)
         # right shape
         assert types.is_float_matrix(Y)
@@ -167,10 +166,8 @@ class TestTICA_Basic(unittest.TestCase):
         data = np.random.random((100, 10))
         tica_obj = api.tica(lag=10, dim=1)
         reader = api.source(data)
-        tica_obj.data_producer = reader
 
         tica_obj.in_memory = True
-        tica_obj.parametrize()
         tica_obj.get_output()
 
     def test_too_short_trajs(self):
@@ -365,10 +362,6 @@ class TestTICAExtensive(unittest.TestCase):
 
     def test_output_type(self):
         assert self.tica_obj.output_type() == np.float32
-
-    def test_parametrize(self):
-        # nothing should happen
-        self.tica_obj.parametrize()
 
     def test_trajectory_length(self):
         assert self.tica_obj.trajectory_length(0) == self.T

--- a/pyemma/coordinates/tests/test_uniform_time.py
+++ b/pyemma/coordinates/tests/test_uniform_time.py
@@ -39,20 +39,16 @@ class TestUniformTimeClustering(unittest.TestCase):
         reader = DataInMemory(x)
 
         k = 2
-        c = api.cluster_uniform_time(k=k)
-
-        c.data_producer = reader
-        c.parametrize()
+        c = api.cluster_uniform_time(reader, k=k)
 
     def test_2d(self):
         x = np.random.random((300, 3))
         reader = DataInMemory(x)
 
         k = 2
-        c = api.cluster_uniform_time(k=k)
+        c = api.cluster_uniform_time( k=k)
 
-        c.data_producer = reader
-        c.parametrize()
+        c.estimate(reader)
 
     def test_2d_skip(self):
         x = np.random.random((300, 3))
@@ -61,8 +57,7 @@ class TestUniformTimeClustering(unittest.TestCase):
         k = 2
         c = api.cluster_uniform_time(k=k, skip=100)
 
-        c.data_producer = reader
-        c.parametrize()
+        c.estimate(reader)
 
     def test_big_k(self):
         x = np.random.random((300, 3))
@@ -70,8 +65,7 @@ class TestUniformTimeClustering(unittest.TestCase):
         k=151
         c = api.cluster_uniform_time(k=k)
 
-        c.data_producer = reader
-        c.parametrize()
+        c.estimate(reader)
 
 
 if __name__ == "__main__":

--- a/pyemma/msm/tests/test_msm.py
+++ b/pyemma/msm/tests/test_msm.py
@@ -127,9 +127,7 @@ class TestMSMRevPi(unittest.TestCase):
         self.assertTrue(np.all(msm.active_set==np.array([0, 2])))
         with self.assertRaises(ValueError):
             msm = estimate_markov_model(dtraj_invalid, 1, statdist=pi)
-        
-        
-        
+
 
 class TestMSMDoubleWell(unittest.TestCase):
 

--- a/pyemma/plots/tests/test_its.py
+++ b/pyemma/plots/tests/test_its.py
@@ -26,7 +26,7 @@ from __future__ import absolute_import
 import unittest
 import numpy as np
 
-from pyemma.msm import its
+from pyemma.msm import its, MaximumLikelihoodMSM, ImpliedTimescales
 from pyemma.plots import plot_implied_timescales
 from msmtools.generation import generate_traj
 
@@ -40,21 +40,23 @@ class TestItsPlot(unittest.TestCase):
                       [.25, .25, .25, .25],
                       ])
         # bogus its object
-        lags = [1,2,3,5,10]
-        cls.its = its(generate_traj(P, 100), lags=lags, errors='bayes'
-                      )
+        lags = [1, 2, 3, 5, 10]
+        dtraj = generate_traj(P, 100)
+        estimator = MaximumLikelihoodMSM(dt_traj='10 ps')
+        cls.its = ImpliedTimescales(estimator=estimator)
+        cls.its.estimate(dtraj, lags=lags)
+
         cls.refs = cls.its.timescales[-1]
         return cls
 
     def test_plot(self):
         plot_implied_timescales(self.its,
-                                refs=self.refs)
+                                refs=self.refs, outfile='/tmp/1.pdf')
     def test_nits(self):
         plot_implied_timescales(self.its,
                                 refs=self.refs, nits=2)
     def test_process(self):
-        plot_implied_timescales(self.its,
-                                refs=self.refs, process=[1,2])
+        plot_implied_timescales(self.its, refs=self.refs, process=[1,2], dt=0.01, units='ns', outfile='/tmp/2.pdf')
 
 
 if __name__ == "__main__":

--- a/pyemma/plots/tests/test_its.py
+++ b/pyemma/plots/tests/test_its.py
@@ -51,12 +51,13 @@ class TestItsPlot(unittest.TestCase):
 
     def test_plot(self):
         plot_implied_timescales(self.its,
-                                refs=self.refs, outfile='/tmp/1.pdf')
+                                refs=self.refs)
+
     def test_nits(self):
         plot_implied_timescales(self.its,
                                 refs=self.refs, nits=2)
     def test_process(self):
-        plot_implied_timescales(self.its, refs=self.refs, process=[1,2], dt=0.01, units='ns', outfile='/tmp/2.pdf')
+        plot_implied_timescales(self.its, refs=self.refs, process=[1,2], dt=0.01, units='ns')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We could also remove the parametrize method, since it has now been deprecated for a long time.

This fixes #1086 