### PR TITLE
[kmeans] allow to pass the seed into kmeans

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -26,7 +26,7 @@ Changelog
 
 - coordinates:
    - kmeans: allow the random seed used for initializing the centers to be passed. The prior behaviour
-     was to init the generator by time, if fixed_seed=False. Now bool and int can be passed. #
+     was to init the generator by time, if fixed_seed=False. Now bool and int can be passed. #1091
 
 **Fixes**:
 

--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -24,6 +24,10 @@ Changelog
     [3] McGibbon, R and V. S. Pande: Variational cross-validation of slow
         dynamical modes in molecular kinetics, J. Chem. Phys. 142, 124105 (2015).
 
+- coordinates:
+   - kmeans: allow the random seed used for initializing the centers to be passed. The prior behaviour
+     was to init the generator by time, if fixed_seed=False. Now bool and int can be passed. #
+
 **Fixes**:
 
 - coordinates:

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -1398,8 +1398,9 @@ def cluster_kmeans(data=None, k=None, max_iter=10, tolerance=1e-5, stride=1,
         determines if the initial cluster centers are chosen according to the kmeans++-algorithm
         or drawn uniformly distributed from the provided data set
 
-    fixed_seed : bool
-        if set to true, the random seed gets fixed resulting in deterministic behavior; default is false
+    fixed_seed : bool or (positive) integer 
+        if set to true, the random seed gets fixed resulting in deterministic behavior; default is false.
+        If an integer >= 0 is given, use this to initialize the random generator.
 
     n_jobs : int or None, default None
         Number of threads to use during assignment of the data.

--- a/pyemma/coordinates/clustering/kmeans.py
+++ b/pyemma/coordinates/clustering/kmeans.py
@@ -111,12 +111,13 @@ class KmeansClustering(AbstractClustering, ProgressReporter):
 
     @fixed_seed.setter
     def fixed_seed(self, val):
-        if isinstance(val, bool):
+        from pyemma.util import types
+        if isinstance(val, bool) or val is None:
             if val:
                 self._fixed_seed = 42
             else:
                 self._fixed_seed = random.randint(0, 2**32-1)
-        elif isinstance(val, int):
+        elif types.is_int(val):
             if val < 0 or val > 2**32-1:
                 self.logger.warn("seed has to be positive (or smaller than 2**32-1)."
                                  " Seed will be chosen randomly.")

--- a/pyemma/coordinates/clustering/kmeans.py
+++ b/pyemma/coordinates/clustering/kmeans.py
@@ -119,7 +119,7 @@ class KmeansClustering(AbstractClustering, ProgressReporter):
         elif isinstance(val, int):
             if val < 0 or val > 2**32-1:
                 self.logger.warn("seed has to be positive (or smaller than 2**32-1)."
-                                 " Seed has been set to a time dependant value.")
+                                 " Seed will be chosen randomly.")
                 self.fixed_seed = False
             else:
                 self._fixed_seed = val

--- a/pyemma/coordinates/clustering/kmeans.py
+++ b/pyemma/coordinates/clustering/kmeans.py
@@ -117,7 +117,7 @@ class KmeansClustering(AbstractClustering, ProgressReporter):
             else:
                 self._fixed_seed = random.randint(0, 2**32-1)
         elif isinstance(val, int):
-            if not (0 < val > 2**32-1):
+            if val < 0 or val > 2**32-1:
                 self.logger.warn("seed has to be positive (or smaller than 2**32-1)."
                                  " Seed will be chosen randomly.")
                 self.fixed_seed = False

--- a/pyemma/coordinates/clustering/kmeans.py
+++ b/pyemma/coordinates/clustering/kmeans.py
@@ -117,7 +117,7 @@ class KmeansClustering(AbstractClustering, ProgressReporter):
             else:
                 self._fixed_seed = random.randint(0, 2**32-1)
         elif isinstance(val, int):
-            if val < 0 or val > 2**32-1:
+            if not (0 < val > 2**32-1):
                 self.logger.warn("seed has to be positive (or smaller than 2**32-1)."
                                  " Seed will be chosen randomly.")
                 self.fixed_seed = False

--- a/pyemma/coordinates/clustering/kmeans.py
+++ b/pyemma/coordinates/clustering/kmeans.py
@@ -115,12 +115,11 @@ class KmeansClustering(AbstractClustering, ProgressReporter):
             if val:
                 self._fixed_seed = 42
             else:
-                import time
-                # make sure we do not overflow unsigned int
-                self._fixed_seed = min(int(time.time()), 2**32 - 1)
+                self._fixed_seed = random.randint(0, 2**32-1)
         elif isinstance(val, int):
-            if val < 0:
-                self.logger.warn("seed has to be positive. Seed has been set to a time dependant value.")
+            if val < 0 or val > 2**32-1:
+                self.logger.warn("seed has to be positive (or smaller than 2**32-1)."
+                                 " Seed has been set to a time dependant value.")
                 self.fixed_seed = False
             else:
                 self._fixed_seed = val

--- a/pyemma/coordinates/clustering/src/kmeans.c
+++ b/pyemma/coordinates/clustering/src/kmeans.c
@@ -261,7 +261,8 @@ error:
 }
 
 static PyObject* initCentersKMpp(PyObject *self, PyObject *args) {
-    int k, centers_found, first_center_index, i, j, n_trials, random_seed;
+    int k, centers_found, first_center_index, i, j, n_trials;
+    unsigned random_seed;
     int some_not_done;
     float d;
     float dist_sum;
@@ -296,7 +297,7 @@ static PyObject* initCentersKMpp(PyObject *self, PyObject *args) {
     dist_sum = 0.0;
 
     /* parse python input (np_data, metric, k) */
-    if (!PyArg_ParseTuple(args, "O!sii", &PyArray_Type, &np_data, &metric, &k, &random_seed)) {
+    if (!PyArg_ParseTuple(args, "O!siI", &PyArray_Type, &np_data, &metric, &k, &random_seed)) {
         goto error;
     }
 

--- a/pyemma/coordinates/clustering/src/kmeans.c
+++ b/pyemma/coordinates/clustering/src/kmeans.c
@@ -261,7 +261,7 @@ error:
 }
 
 static PyObject* initCentersKMpp(PyObject *self, PyObject *args) {
-    int k, centers_found, first_center_index, i, j, n_trials, use_random_seed;
+    int k, centers_found, first_center_index, i, j, n_trials, random_seed;
     int some_not_done;
     float d;
     float dist_sum;
@@ -294,26 +294,14 @@ static PyObject* initCentersKMpp(PyObject *self, PyObject *args) {
     next_center_candidates_rand = NULL;
     next_center_candidates_potential = NULL;
     dist_sum = 0.0;
-    use_random_seed = 1;
-
 
     /* parse python input (np_data, metric, k) */
-    if (!PyArg_ParseTuple(args, "O!sii", &PyArray_Type, &np_data, &metric, &k, &use_random_seed)) {
+    if (!PyArg_ParseTuple(args, "O!sii", &PyArray_Type, &np_data, &metric, &k, &random_seed)) {
         goto error;
     }
 
-    if(use_random_seed) {
-        #ifndef _KMEANS_INIT_RANDOM_SEED
-        #define _KMEANS_INIT_RANDOM_SEED
-        /* set random seed */
-        srand(time(NULL));
-        #endif
-    } else {
-        #ifdef _KMEANS_INIT_RANDOM_SEED
-        #undef _KMEANS_INIT_RANDOM_SEED
-        #endif
-        srand(42);
-    }
+    /* set random seed */
+    srand(random_seed);
 
     n_frames = np_data->dimensions[0];
     dim = np_data->dimensions[1];
@@ -492,10 +480,8 @@ static PyObject* initCentersKMpp(PyObject *self, PyObject *args) {
     memcpy(arr_data, init_centers, PyArray_ITEMSIZE((PyArrayObject*) ret_init_centers) * k * dim);
     Py_INCREF(ret_init_centers);  /* The returned list should still exist after calling the C extension */
 error:
-    // reset the seed to something else than 42
-    if(!use_random_seed) {
-        srand(time(NULL));
-    }
+    // reset the seed
+    srand(time(NULL));
     free(buffer_a);
     free(buffer_b);
     free(taken_points);
@@ -545,8 +531,8 @@ static char INIT_CENTERS_USAGE[] = "init_centers(data, metric, k)\n"\
 "    (input) One of \"euclidean\" or \"minRMSD\" (case sensitive).\n"\
 "k : int\n"\
 "    (input) the number of cluster centers to be assigned for initialization."\
-"use_random_seed : bool\n"\
-"    (input) determines if a fixed seed should be used or a random one\n"\
+"random_seed : unsigned int\n"\
+"    (input) fixed seed for choosing kmeans++ center candidates.\n"\
 "\n"\
 "Returns\n"\
 "-------\n"\

--- a/pyemma/coordinates/clustering/src/kmeans.c
+++ b/pyemma/coordinates/clustering/src/kmeans.c
@@ -262,7 +262,7 @@ error:
 
 static PyObject* initCentersKMpp(PyObject *self, PyObject *args) {
     int k, centers_found, first_center_index, i, j, n_trials;
-    unsigned random_seed;
+    unsigned int random_seed;
     int some_not_done;
     float d;
     float dist_sum;

--- a/pyemma/coordinates/tests/test_kmeans.py
+++ b/pyemma/coordinates/tests/test_kmeans.py
@@ -23,6 +23,7 @@ Created on 28.01.2015
 from __future__ import absolute_import
 
 import os
+import random
 import unittest
 
 from pyemma.coordinates.api import cluster_kmeans
@@ -77,17 +78,22 @@ class TestKmeans(unittest.TestCase):
             np.testing.assert_array_equal(km1.clustercenters, km2.clustercenters,
                                           "should yield same centers with fixed seed")
 
+            # check a user defined seed
+            seed = random.randint(0, 2**32-1)
+            km1 = cluster_kmeans(X, k=10, init_strategy=init_strategy, fixed_seed=seed)
+            km2 = cluster_kmeans(X, k=10, init_strategy=init_strategy, fixed_seed=seed)
+            self.assertEqual(km1.fixed_seed, km2.fixed_seed)
+            np.testing.assert_array_equal(km1.clustercenters, km2.clustercenters,
+                                          "should yield same centers with fixed seed")
+
             # test that not-fixed seed yields different results
-            retry, done = 0, False
-            while not done and retry < 4:
-                try:
-                    km3 = cluster_kmeans(X, k=10, init_strategy=init_strategy, fixed_seed=False)
-                    self.assertRaises(AssertionError, np.testing.assert_array_equal,
-                                      km1.clustercenters, km3.clustercenters)
-                    done = True
-                except AssertionError:
-                    retry += 1
-            self.assertTrue(done, 'using a fixed seed compared to a not fixed one made no difference!')
+            km3 = cluster_kmeans(X, k=10, init_strategy=init_strategy, fixed_seed=False)
+            self.assertNotEqual(km3.fixed_seed, 42)
+
+    def test_negative_seed(self):
+        """ ensure negative seeds converted to something positive"""
+        km = cluster_kmeans(np.random.random((10, 3)), k=2, fixed_seed=-1)
+        self.assertGreaterEqual(km.fixed_seed, 0)
 
     def test_3gaussian_2d_multitraj(self):
         # generate 1D data from three gaussians

--- a/pyemma/coordinates/tests/test_kmeans.py
+++ b/pyemma/coordinates/tests/test_kmeans.py
@@ -95,6 +95,9 @@ class TestKmeans(unittest.TestCase):
         km = cluster_kmeans(np.random.random((10, 3)), k=2, fixed_seed=-1)
         self.assertGreaterEqual(km.fixed_seed, 0)
 
+    def test_seed_too_large(self):
+        km = cluster_kmeans(np.random.random((10, 3)), k=2, fixed_seed=2**32)
+
     def test_3gaussian_2d_multitraj(self):
         # generate 1D data from three gaussians
         X1 = np.zeros((100, 2))


### PR DESCRIPTION
Now bool and int can be passed to kmeans "fixed_seed" parameter. If fixed_seed is False, then a time based seed is used. If it is True, seed is 42 (like the previous behaviour). In seed is an integer, just ensure it fits into unsigned int (C) and pass it to the extension.

@franknoe This will circumvent your problems with "fast" kmeans