### PR TITLE
[config] Refactored module hack to a normal class/instance pattern. Fixed docs

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -30,10 +30,13 @@ Changelog
   - Removed deprecated method parametrize. Use estimate or fit for now. #1088
   - Readers: nice error messages for file handling errors (which file caused the error). #1085
   - TICA: raise ZeroRankError, if the input data contained only constant features. #1055
-  - Added progress bar for collecting the data in kmenas pre-clustering phase. #1084
+  - KMeans: Added progress bar for collecting the data in pre-clustering phase. #1084
 
 - msm:
   - ImpliedTimescales estimation can be interrupted (strg+c, stop button in Jupyter notebooks). #1079
+
+- general:
+  - config: better documentation of the configuration parameters. #1095
 
 
 2.3.2 (2-19-2017)

--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -14,6 +14,8 @@ Changelog
   similar as suggested in [4] is implemented in the `score_cv` method, however this is currently
   inefficient and will be improved in future versions. #1093
 
+- config: Added a lot of documentation and added `mute` option to silence PyEMMA (almost completely).
+
 - References:
     [1] Noe, F. and F. Nueske: A variational approach to modeling slow processes
         in stochastic dynamical systems. SIAM Multiscale Model. Simul. 11, 635-655 (2013).

--- a/doc/source/Configuration.rst
+++ b/doc/source/Configuration.rst
@@ -91,4 +91,15 @@ Configuration values
 --------------------
 
 .. autoclass:: pyemma.util._config.Config
-   :members:
+    :members:
+    :undoc-members:
+
+    .. rubric:: Methods
+
+    .. autoautosummary:: pyemma.util._config.Config
+       :methods:
+
+    .. rubric:: Attributes
+
+    .. autoautosummary:: pyemma.util._config.Config
+        :attributes:

--- a/doc/source/Configuration.rst
+++ b/doc/source/Configuration.rst
@@ -1,3 +1,94 @@
-.. automodule:: pyemma.util.config
+
+Runtime Configuration
+=====================
+
+You can change some runtime behaviour of PyEMMA by setting a configuration
+value in PyEMMAs config module. These can be persisted to hard disk to be
+permanent on every import of the package.
+
+Examples
+--------
+
+Change values
+^^^^^^^^^^^^^
+To access the config at runtime eg. if progress bars should be shown:
+
+>>> from pyemma import config # doctest: +SKIP
+>>> print(config.show_progress_bars) # doctest: +SKIP
+True
+>>> config.show_progress_bars = False # doctest: +SKIP
+>>> print(config.show_progress_bars) # doctest: +SKIP
+False
+
+
+Store your changes / Create a configuration directory
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To create an editable configuration file, use the :py:func:`pyemma.config.save` method:
+
+>>> from pyemma import config # doctest: +SKIP
+>>> config.save('/tmp/pyemma_current.cfg') # doctest: +SKIP
+
+This will store the current runtime configuration values in the given file.
+Note that these settings will not be used on the next start of PyEMMA, because
+you first need to tell us, where you have stored this file. To do so, please
+set the environment variable **"PYEMMA_CFG_DIR"** to the directory, where you have
+stored the config file.
+
+* For Linux/OSX this thread `thread
+  <https://unix.stackexchange.com/questions/117467/how-to-permanently-set-environmental-variables>`_
+  may be helpful.
+* For Windows have a look at
+  `this <https://stackoverflow.com/questions/17312348/how-do-i-set-windows-environment-variables-permanently>`_.
+
+
+For details have a look at the brief documentation:
+https://docs.python.org/2/howto/logging.html
+
+Default configuration file
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Default settings are stored in a provided pyemma.cfg file, which is included in
+the Python package:
+
+.. literalinclude:: ../../pyemma/pyemma.cfg
+    :language: ini
+
+Configuration files
+^^^^^^^^^^^^^^^^^^^
+
+To configure the runtime behavior such as the logging system or other parameters,
+the configuration module reads several config files to build
+its final set of settings. It searches for the file 'pyemma.cfg' in several
+locations with different priorities:
+
+#. $CWD/pyemma.cfg
+#. $HOME/.pyemma/pyemma.cfg
+#. ~/pyemma.cfg
+#. $PYTHONPATH/pyemma/pyemma.cfg (always taken as default configuration file)
+
+Note that you can also override the location of the configuration directory by
+setting an environment variable named **"PYEMMA_CFG_DIR"** to a writeable path to
+override the location of the config files.
+
+The default values are stored in latter file to ensure these values are always
+defined.
+
+If no configuration file could be found, the defaults from the shipped package
+will apply.
+
+
+Load a configuration file
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In order to load a pre-saved configuration file, use the :py:func:`load` method:
+
+>>> from pyemma import config # doctest: +SKIP
+>>> config.load('pyemma_silent.cfg') # doctest: +SKIP
+
+
+Configuration values
+--------------------
+
+.. autoclass:: pyemma.util._config.Config
    :members:
-   :exclude-members: AttribStore

--- a/doc/source/legal.rst
+++ b/doc/source/legal.rst
@@ -1,3 +1,5 @@
+.. _legal-notes-label:
+
 =============
 Legal Notices
 =============
@@ -53,6 +55,8 @@ The text of this disclaimer is based on the services of www.disclaimer.de
 
 Data privacy statement
 ======================
+
+.. _legal-notes-priv-label:
 
 Server-Log-Files
 ----------------

--- a/pyemma/coordinates/tests/test_traj_info_cache.py
+++ b/pyemma/coordinates/tests/test_traj_info_cache.py
@@ -85,7 +85,8 @@ class TestTrajectoryInfoCache(unittest.TestCase):
 
     def test_store_load_traj_info(self):
         x = np.random.random((10, 3))
-        my_conf = config()
+        from pyemma.util._config import Config
+        my_conf = Config()
         my_conf.cfg_dir = self.work_dir
         with mock.patch('pyemma.coordinates.data.util.traj_info_cache.config', my_conf):
             with NamedTemporaryFile(delete=False) as fh:

--- a/pyemma/pyemma.cfg
+++ b/pyemma/pyemma.cfg
@@ -31,3 +31,6 @@ coordinates_check_output = False
 
 # latest version check
 check_version = True
+
+# mute progressbars and logging events (only critical)
+mute = False

--- a/pyemma/util/__init__.py
+++ b/pyemma/util/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import absolute_import
+from ._config import Config as _Config
+
+# default config instance
+config = _Config()

--- a/pyemma/util/_config.py
+++ b/pyemma/util/_config.py
@@ -48,8 +48,10 @@ class Config(object):
     DEFAULT_LOGGING_FILE_NAME = 'logging.yml'
 
     def __init__(self):
-        # this is a SafeConfigParser instance
+        # this is a ConfigParser instance
         self._conf_values = None
+
+        self._old_level = None
 
         # note we do not invoke the cfg_dir setter here, because we do not want anything to be created/copied yet.
         # first check if there is a config dir set via environment
@@ -220,6 +222,28 @@ class Config(object):
     #    from pyemma.util.log import setup_logging
     #   #config['incremental'] = True
     #    setup_logging(self, config)
+
+    @property
+    def mute(self):
+        """ Switch this to True, to tell PyEMMA not to use progress bars and logging to console. """
+        return self._conf_values.getboolean('pyemma', 'mute')
+
+    @mute.setter
+    def mute(self, value):
+        value = bool(value)
+        import logging
+        if value:
+            self.show_progress_bars = False
+            self._old_level = logging.getLogger('pyemma').level
+            logging.getLogger('pyemma').setLevel('CRITICAL')
+        else:
+            self.show_progress_bars = True
+
+            if self._old_level is not None:
+                logging.getLogger('pyemma').setLevel(self._old_level)
+                self._old_level = None
+
+        self._conf_values.set('pyemma', 'mute', str(value))
 
     @property
     def traj_info_max_entries(self):

--- a/pyemma/util/_config.py
+++ b/pyemma/util/_config.py
@@ -39,6 +39,7 @@ if six.PY2:
 class ReadConfigException(Exception):
     pass
 
+__all__ = ('Config', )
 
 class Config(object):
 
@@ -98,13 +99,18 @@ class Config(object):
             print(Config._format_msg("no configuration directory set or usable."
                                       " Falling back to defaults."))
 
+    def __call__(self):
+        # return a new instance, this is used for testing purposes only.
+        return Config()
+
     def save(self, filename=None):
         """ Saves the runtime configuration to disk.
 
         Parameters
         ----------
-        filename ; str or None, default=None
-            writeable path to configuration filename. If None, use default location and filename.
+        filename: str or None, default=None
+            writeable path to configuration filename.
+            If None, use default location and filename.
         """
         if not filename:
             filename = self.DEFAULT_CONFIG_FILE_NAME
@@ -281,11 +287,14 @@ class Config(object):
         """ Check for the latest release online.
         
         Disable this if you have privacy concerns.
-        We collect:
+        We currently collect:
+
          * Python version
          * PyEMMA version
          * operating system
          * MAC address
+
+        See :doc:`legal` for further information.
         """
         return self._conf_values.getboolean('pyemma', 'check_version')
 

--- a/pyemma/util/tests/test_config.py
+++ b/pyemma/util/tests/test_config.py
@@ -152,6 +152,30 @@ class TestConfig(unittest.TestCase):
         self.config_inst.traj_info_max_entries = 1
         self.assertEqual(self.config_inst.traj_info_max_entries, 1)
 
+    def test_mute_logging(self):
+        self.config_inst.mute = False
+
+        import logging
+        logger = logging.getLogger('pyemma')
+        old_level = logger.level
+
+        self.config_inst.mute = True
+        assert logger.level >= 50
+
+        # unmute again and check level got restored
+        self.config_inst.mute = False
+        self.assertEqual(logger.level, old_level)
+
+    def test_mute_progress(self):
+        """ switch mute on shall turn off progress bars"""
+        from pyemma._base.progress import ProgressReporter
+        import mock
+        rp = ProgressReporter()
+
+        self.config_inst.mute = True
+        with mock.patch('pyemma.config', self.config_inst):
+            assert not rp.show_progress
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
    Now each property of the Config class has a documentation. Moved the examples
    to doc/source/Configuration.rst (because numpydoc does not allow for extra
    sections).
    Removed all dirty hacks of a class instance pretending to be a module.
    
    Fixes #1089