### PR TITLE
[Iterable] Do not update the `in_memory` property, if exception during mapping

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -27,6 +27,8 @@ Changelog
 **Fixes**:
 
 - coordinates:
+  - StreamingEstimators: If an exception occurred during flipping the `in_memory` property,
+    the state is not updated. #1096
   - Removed deprecated method parametrize. Use estimate or fit for now. #1088
   - Readers: nice error messages for file handling errors (which file caused the error). #1085
   - TICA: raise ZeroRankError, if the input data contained only constant features. #1055

--- a/pyemma/coordinates/data/_base/iterable.py
+++ b/pyemma/coordinates/data/_base/iterable.py
@@ -34,6 +34,9 @@ class Iterable(six.with_metaclass(ABCMeta, ProgressReporter, Loggable)):
         if self.default_chunksize < 0:
             raise ValueError("Chunksize of %s was provided, but has to be >= 0" % self.default_chunksize)
         self._in_memory = False
+        self._mapping_to_mem_active = False
+        self._Y = []
+        self._Y_source = None
         # should be set in subclass
         self._ndim = 0
 
@@ -79,20 +82,21 @@ class Iterable(six.with_metaclass(ABCMeta, ProgressReporter, Loggable)):
     def _clear_in_memory(self):
         if self._logger_is_active(self._loglevel_DEBUG):
             self._logger.debug("clear memory")
-        assert self.in_memory, "tried to delete in memory results which are not set"
-        self._Y = None
+        self._Y = []
         self._Y_source = None
 
     def _map_to_memory(self, stride=1):
         r"""Maps results to memory. Will be stored in attribute :attr:`_Y`."""
         if self._logger_is_active(self._loglevel_DEBUG):
             self._logger.debug("mapping to mem")
-        assert self._in_memory
+
         self._mapping_to_mem_active = True
-        self._Y = self.get_output(stride=stride)
-        from pyemma.coordinates.data import DataInMemory
-        self._Y_source = DataInMemory(self._Y)
-        self._mapping_to_mem_active = False
+        try:
+            self._Y = self.get_output(stride=stride)
+            from pyemma.coordinates.data import DataInMemory
+            self._Y_source = DataInMemory(self._Y)
+        finally:
+            self._mapping_to_mem_active = False
 
     def iterator(self, stride=1, lag=0, chunk=None, return_trajindex=True, cols=None, skip=0):
         """ creates an iterator to stream over the (transformed) data.
@@ -307,8 +311,6 @@ class Iterable(six.with_metaclass(ABCMeta, ProgressReporter, Loggable)):
                 elif e.errno == errno.ENOENT:
                     continue
                 raise
-            else:
-                continue
         f = None
         with self.iterator(stride, chunk=chunksize, return_trajindex=False) as it:
             self._progress_register(it.n_chunks, "saving to csv")

--- a/pyemma/coordinates/data/_base/iterable.py
+++ b/pyemma/coordinates/data/_base/iterable.py
@@ -69,12 +69,12 @@ class Iterable(six.with_metaclass(ABCMeta, ProgressReporter, Loggable)):
         """
         old_state = self._in_memory
         if not old_state and op_in_mem:
-            self._in_memory = op_in_mem
             self._Y = []
             self._map_to_memory()
         elif not op_in_mem and old_state:
             self._clear_in_memory()
-            self._in_memory = op_in_mem
+
+        self._in_memory = op_in_mem
 
     def _clear_in_memory(self):
         if self._logger_is_active(self._loglevel_DEBUG):

--- a/pyemma/coordinates/data/_base/iterable.py
+++ b/pyemma/coordinates/data/_base/iterable.py
@@ -35,7 +35,7 @@ class Iterable(six.with_metaclass(ABCMeta, ProgressReporter, Loggable)):
             raise ValueError("Chunksize of %s was provided, but has to be >= 0" % self.default_chunksize)
         self._in_memory = False
         self._mapping_to_mem_active = False
-        self._Y = []
+        self._Y = None
         self._Y_source = None
         # should be set in subclass
         self._ndim = 0

--- a/pyemma/coordinates/data/_base/iterable.py
+++ b/pyemma/coordinates/data/_base/iterable.py
@@ -72,18 +72,16 @@ class Iterable(six.with_metaclass(ABCMeta, ProgressReporter, Loggable)):
         """
         old_state = self._in_memory
         if not old_state and op_in_mem:
-            self._Y = []
             self._map_to_memory()
         elif not op_in_mem and old_state:
             self._clear_in_memory()
 
-        self._in_memory = op_in_mem
-
     def _clear_in_memory(self):
         if self._logger_is_active(self._loglevel_DEBUG):
             self._logger.debug("clear memory")
-        self._Y = []
+        self._Y = None
         self._Y_source = None
+        self._in_memory = False
 
     def _map_to_memory(self, stride=1):
         r"""Maps results to memory. Will be stored in attribute :attr:`_Y`."""
@@ -97,6 +95,8 @@ class Iterable(six.with_metaclass(ABCMeta, ProgressReporter, Loggable)):
             self._Y_source = DataInMemory(self._Y)
         finally:
             self._mapping_to_mem_active = False
+
+        self._in_memory = True
 
     def iterator(self, stride=1, lag=0, chunk=None, return_trajindex=True, cols=None, skip=0):
         """ creates an iterator to stream over the (transformed) data.

--- a/pyemma/coordinates/tests/test_featurereader.py
+++ b/pyemma/coordinates/tests/test_featurereader.py
@@ -263,5 +263,15 @@ class TestFeatureReader(unittest.TestCase):
         self.assertNotIn(0, res)
         self.assertIn(1, res)
 
+    def test_flip_in_memory_exception(self):
+        """ ensure in_memory behaves well during exceptions. """
+        reader = api.source(self.trajfile, top=self.topfile)
+        def dummy(x): raise ValueError("no")
+        reader.featurizer.add_custom_func(dummy, 1)
+        try:
+            reader.in_memory = True
+        except ValueError:
+            assert not reader.in_memory
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/tests/test_random_access_stride.py
+++ b/pyemma/coordinates/tests/test_random_access_stride.py
@@ -61,27 +61,31 @@ def _test_ra_with_format(format, stride):
             except EnvironmentError:
                 pass
 
+
 class TestRandomAccessStride(TestCase):
-    def setUp(self):
-        self.tmpdir = tempfile.mkdtemp('test_random_access')
-        self.dim = 5
-        self.data = [np.random.random((100, self.dim)).astype(np.float32),
-                     np.random.random((20, self.dim)).astype(np.float32),
-                     np.random.random((20, self.dim)).astype(np.float32)]
-        self.stride = np.asarray([
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdir = tempfile.mkdtemp('test_random_access')
+        cls.dim = 5
+        cls.data = [np.random.random((100, cls.dim)).astype(np.float32),
+                     np.random.random((20, cls.dim)).astype(np.float32),
+                     np.random.random((20, cls.dim)).astype(np.float32)]
+        cls.stride = np.asarray([
             [0, 1], [0, 3], [0, 3], [0, 5], [0, 6], [0, 7],
             [2, 1], [2, 1]
         ])
-        self.stride2 = np.asarray([[2, 0]])
-        self.topfile = pkg_resources.resource_filename(__name__, 'data/test.pdb')
-        trajfile1, xyz1, n_frames1 = create_traj(self.topfile, dir=self.tmpdir, format=".binpos", length=100)
-        trajfile2, xyz2, n_frames2 = create_traj(self.topfile, dir=self.tmpdir, format=".binpos", length=20)
-        trajfile3, xyz3, n_frames3 = create_traj(self.topfile, dir=self.tmpdir, format=".binpos", length=20)
-        self.data_feature_reader = [trajfile1, trajfile2, trajfile3]
+        cls.stride2 = np.asarray([[2, 0]])
+        cls.topfile = pkg_resources.resource_filename(__name__, 'data/test.pdb')
+        trajfile1, xyz1, n_frames1 = create_traj(cls.topfile, dir=cls.tmpdir, format=".binpos", length=100)
+        trajfile2, xyz2, n_frames2 = create_traj(cls.topfile, dir=cls.tmpdir, format=".binpos", length=20)
+        trajfile3, xyz3, n_frames3 = create_traj(cls.topfile, dir=cls.tmpdir, format=".binpos", length=20)
+        cls.data_feature_reader = [trajfile1, trajfile2, trajfile3]
 
-    def tearDown(self):
+    @classmethod
+    def tearDownClass(cls):
         import shutil
-        shutil.rmtree(self.tmpdir, ignore_errors=True)
+        shutil.rmtree(cls.tmpdir, ignore_errors=True)
 
     def _get_reader_instance(self, instance_number):
         if instance_number == 0:


### PR DESCRIPTION
This bug is especially annoying in jupyter notebooks, when you map a reader etc. to memory and there is an error (eg. some custom function raised), the reader will think in_memory is True, because the flag is updated before the mapping is done.

Eg.:
```
reader.in_memory = True # raised
# so there is nothing memory, because of the exception, but anyway in_memory is True now..
assert not reader.in_memory # raises AssertionError
```