### PR TITLE
[datasets/double_well_thermo] fix function for py3 and made tests dir a pkg

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+2.4.1 (tba)
+-----------
+
+**New features**:
+
+-
+
+**Fixes**:
+
+- datasets: fixed get_multi_temperature_data and get_umbrella_sampling_data for Python 3. #1102
+
+
 2.4 (05-19-2017)
 ----------------
 

--- a/pyemma/datasets/tests/test_datasets.py
+++ b/pyemma/datasets/tests/test_datasets.py
@@ -34,7 +34,7 @@ def test_umbrella_sampling_data():
     for key in us_data.keys():
         assert key in req_keys
     for key in req_keys:
-        assert us_data.has_key(key)
+        assert key in us_data
     memm = estimate_umbrella_sampling(
         us_data['us_trajs'],
         us_data['us_dtrajs'],
@@ -62,7 +62,7 @@ def test_multi_temperature_data():
     for key in mt_data.keys():
         assert key in req_keys
     for key in req_keys:
-        assert mt_data.has_key(key)
+        assert key in mt_data
     memm = estimate_multi_temperature(
         mt_data['energy_trajs'],
         mt_data['temp_trajs'],
@@ -78,3 +78,4 @@ def test_multi_temperature_data():
     memm.msm.pcca(2)
     pi = [memm.msm.pi[s].sum() for s in memm.msm.metastable_sets]
     assert_allclose(pi, [0.3, 0.7], rtol=0.25, atol=0.1)
+


### PR DESCRIPTION
This passed CI, because I didn't spot that tests in datasets was never executed. This is due to the missing
init.py in tests (conda-build requires us to make the tests importable).