### PR TITLE
Fix transformer in memory

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -7,16 +7,17 @@ Changelog
 **New features**:
 
 - msm: Added Augmented Markov Models. A way to include averaged experimental
-  data into estimation of Markov models from molecular simulations. The method is described in [1].
+  data into estimation of Markov models from molecular simulations. The method is described in [1]. #1111
 
 - References:
 
-  [1] Olsson S, Wu H, Paul F, Clementi C, Noe F: Combining Experimental and Simulation Data 
+  [1] Olsson S, Wu H, Paul F, Clementi C, Noe F: Combining Experimental and Simulation Data
       via Augmented Markov Models" In revision.
 
 **Fixes**:
 
 - datasets: fixed get_multi_temperature_data and get_umbrella_sampling_data for Python 3. #1102
+- coordinates: fixed StreamingTransformers (TICA, Kmeans, etc.) not respecting the in_memory flag. #1112
 
 
 2.4 (05-19-2017)

--- a/pyemma/coordinates/data/_base/transformer.py
+++ b/pyemma/coordinates/data/_base/transformer.py
@@ -23,7 +23,6 @@ from abc import ABCMeta, abstractmethod
 import numpy as np
 import six
 
-from pyemma._base.logging import Loggable
 from pyemma._ext.sklearn.base import TransformerMixin
 from pyemma.coordinates.data._base.datasource import DataSource, DataSourceIterator
 from pyemma.coordinates.data._base.iterable import Iterable
@@ -31,7 +30,6 @@ from pyemma.coordinates.data._base.random_accessible import RandomAccessStrategy
 from pyemma.coordinates.data._base.streaming_estimator import StreamingEstimator
 from pyemma.coordinates.util.change_notification import (inform_children_upon_change,
                                                          NotifyOnChangesMixIn)
-from pyemma.util.annotators import deprecated
 from six.moves import range
 
 

--- a/pyemma/coordinates/data/_base/transformer.py
+++ b/pyemma/coordinates/data/_base/transformer.py
@@ -22,6 +22,8 @@ from abc import ABCMeta, abstractmethod
 
 import numpy as np
 import six
+
+from pyemma._base.logging import Loggable
 from pyemma._ext.sklearn.base import TransformerMixin
 from pyemma.coordinates.data._base.datasource import DataSource, DataSourceIterator
 from pyemma.coordinates.data._base.iterable import Iterable
@@ -229,7 +231,7 @@ class StreamingTransformerIterator(DataSourceIterator):
     def __init__(self, data_source, skip=0, chunk=0, stride=1, return_trajindex=False, cols=None):
         super(StreamingTransformerIterator, self).__init__(
             data_source, return_trajindex=return_trajindex)
-        self._it = self._data_source.data_producer._create_iterator(
+        self._it = self._data_source.data_producer.iterator(
             skip=skip, chunk=chunk, stride=stride, return_trajindex=return_trajindex, cols=cols
         )
         self.state = self._it.state

--- a/pyemma/coordinates/data/fragmented_trajectory_reader.py
+++ b/pyemma/coordinates/data/fragmented_trajectory_reader.py
@@ -194,7 +194,7 @@ class _FragmentedTrajectoryIterator(object):
                 # if stride doesn't divide length, one has to offset the next trajectory
                 overlap = self._calculate_new_overlap(self._stride, self._reader_lengths[idx], overlap)
                 chunksize = min(length, r.trajectory_length(0, self._stride, skip=_skip))
-                it = r._create_iterator(stride=self._stride, skip=_skip, chunk=chunksize, return_trajindex=True)
+                it = r.iterator(stride=self._stride, skip=_skip, chunk=chunksize, return_trajindex=True)
                 with it:
                     for itraj, data in it:
                         L = len(data)


### PR DESCRIPTION
There was a bug in StreamingTransformers and FragmentedReader, which led to ignoring the in_memory flag.