### PR TITLE
Vamp sparse svd

### DIFF
--- a/devtools/conda-recipe/run_test.py
+++ b/devtools/conda-recipe/run_test.py
@@ -14,6 +14,7 @@ pytest_args = ("-v --pyargs {test_pkg} "
                "--cov-report=xml:{dest_report} "
                "--doctest-modules "
                #"-n 2 "# -p no:xdist" # disable xdist in favour of coverage plugin
+               "--durations=20 "
                "--junit-xml={junit_xml} "
                "-c {pytest_cfg}"
                .format(test_pkg=test_pkg, cover_pkg=cover_pkg,

--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -262,12 +262,10 @@ class _MSMEstimator(_Estimator, _MSM):
             self.score_k = score_k
 
         # determine actual scoring rank
-        if self.score_k is None:
-            self.score_k = self.nstates
-        if self.score_k > self.nstates:
+        if self.score_k is not None and self.score_k > self.nstates - 1:
             self.logger.warning('Requested scoring rank ' + str(self.score_k) +
                                 'exceeds number of MSM states. Reduced to score_k = ' + str(self.nstates))
-            self.score_k = self.nstates  # limit to nstates
+            self.score_k = self.nstates - 1  # limit to nstates
 
         # training data
         K = self.transition_matrix  # model


### PR DESCRIPTION
This is an optimization, which uses scipy.linalg.sparse.svds, if k is an integer. This should reduce the runtime for large systems, if only the k slowest processes are requested.

Runtime comparison for test_msm.TestDoubleWell.test_score and test_score_cv. Note that only test_score uses k != None.

```
sparse
------------------------------------------------------------------------------------ benchmark: 2 tests -----------------------------------------------------------------------------------
Name (time in ms)             Min                    Max                   Mean                StdDev                 Median                 IQR            Outliers(*)  Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_score                41.1294 (1.0)          42.5916 (1.0)          41.6456 (1.0)          0.4692 (1.0)          41.3623 (1.0)        0.8409 (1.0)              7;0      21           1
test_score_cv         50,944.8712 (>1000.0)  53,527.9801 (>1000.0)  51,525.9339 (>1000.0)  1,123.0513 (>1000.0)  51,021.4687 (>1000.0)  812.3603 (966.02)           1;1       5           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------



dense 
------------------------------------------------------------------------------------ benchmark: 2 tests -----------------------------------------------------------------------------------
Name (time in ms)             Min                    Max                   Mean              StdDev                 Median                   IQR            Outliers(*)  Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_score                48.8161 (1.0)          50.8415 (1.0)          49.3896 (1.0)        0.5492 (1.0)          49.2008 (1.0)          0.7691 (1.0)              3;0      15           1
test_score_cv         49,625.0162 (>1000.0)  51,794.3575 (>1000.0)  50,513.7014 (>1000.0)  935.3322 (>1000.0)  50,068.3540 (>1000.0)  1,531.5309 (>1000.0)          1;0       5           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```