### PR TITLE
[msm] improve user-friendliness by adding n_metastable to MSM class

### DIFF
--- a/pyemma/msm/models/msm.py
+++ b/pyemma/msm/models/msm.py
@@ -916,12 +916,21 @@ class MSM(_Model):
 
         # set metastable properties
         self._metastable_computed = True
+        self._n_metastable = copy.deepcopy(self._pcca.n_metastable)
         self._metastable_memberships = copy.deepcopy(self._pcca.memberships)
         self._metastable_distributions = copy.deepcopy(self._pcca.output_probabilities)
         self._metastable_sets = copy.deepcopy(self._pcca.metastable_sets)
         self._metastable_assignments = copy.deepcopy(self._pcca.metastable_assignment)
 
         return self._pcca
+
+    @property
+    def n_metastable(self):
+        """ Number of states chosen for PCCA++ computation.
+        """
+        # are we ready?
+        self._assert_metastable()
+        return self._n_metastable
 
     @property
     def metastable_memberships(self):

--- a/pyemma/msm/models/msm.py
+++ b/pyemma/msm/models/msm.py
@@ -916,7 +916,7 @@ class MSM(_Model):
 
         # set metastable properties
         self._metastable_computed = True
-        self._n_metastable = copy.deepcopy(self._pcca.n_metastable)
+        self._n_metastable = self._pcca.n_metastable
         self._metastable_memberships = copy.deepcopy(self._pcca.memberships)
         self._metastable_distributions = copy.deepcopy(self._pcca.output_probabilities)
         self._metastable_sets = copy.deepcopy(self._pcca.metastable_sets)

--- a/pyemma/msm/tests/test_msm.py
+++ b/pyemma/msm/tests/test_msm.py
@@ -641,6 +641,7 @@ class TestMSMDoubleWell(unittest.TestCase):
             ass = msm.metastable_assignments
             # test: number of states
             assert (len(ass) == msm.nstates)
+            assert msm.n_metastable == 2
             # test: should be 0 or 1
             assert (np.all(ass >= 0))
             assert (np.all(ass <= 1))


### PR DESCRIPTION
Since the PCCA metastable distributions are already available from the MSM object, it makes sense to also have the number of metastable states ready to hand. It'd be very convenient for long-term users... 