### PR TITLE
Fix hmsm msm init param clone

### DIFF
--- a/pyemma/_ext/sklearn/base.py
+++ b/pyemma/_ext/sklearn/base.py
@@ -70,6 +70,13 @@ def clone(estimator, safe=True):
     new_object = klass(**new_object_params)
     params_set = new_object.get_params(deep=False)
 
+    # TODO: this is a brute force method to make things work for parameter studies. #1135
+    # But this can potentially use a lot of memory in case of large input data, which is also copied then.
+    # we need a way to distinguish input parameters from derived model parameters, which is currently only ensured for
+    # estimators in the coordinates package.
+    if hasattr(estimator, '_estimated') and estimator._estimated:
+        return copy.deepcopy(estimator)
+
     # quick sanity check of the parameters of the clone
     for name in new_object_params:
         param1 = new_object_params[name]

--- a/pyemma/_ext/sklearn/base.py
+++ b/pyemma/_ext/sklearn/base.py
@@ -63,19 +63,19 @@ def clone(estimator, safe=True):
                             "it does not seem to be a scikit-learn estimator "
                             "as it does not implement a 'get_params' methods."
                             % (repr(estimator), type(estimator)))
-    klass = estimator.__class__
-    new_object_params = estimator.get_params(deep=False)
-    for name, param in six.iteritems(new_object_params):
-        new_object_params[name] = clone(param, safe=False)
-    new_object = klass(**new_object_params)
-    params_set = new_object.get_params(deep=False)
-
     # TODO: this is a brute force method to make things work for parameter studies. #1135
     # But this can potentially use a lot of memory in case of large input data, which is also copied then.
     # we need a way to distinguish input parameters from derived model parameters, which is currently only ensured for
     # estimators in the coordinates package.
     if hasattr(estimator, '_estimated') and estimator._estimated:
         return copy.deepcopy(estimator)
+
+    klass = estimator.__class__
+    new_object_params = estimator.get_params(deep=False)
+    for name, param in six.iteritems(new_object_params):
+        new_object_params[name] = clone(param, safe=False)
+    new_object = klass(**new_object_params)
+    params_set = new_object.get_params(deep=False)
 
     # quick sanity check of the parameters of the clone
     for name in new_object_params:

--- a/pyemma/msm/estimators/maximum_likelihood_hmsm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_hmsm.py
@@ -184,8 +184,7 @@ class MaximumLikelihoodHMSM(_Estimator, _HMSM):
 
         # INIT HMM
         from bhmm import init_discrete_hmm
-        from pyemma.msm.estimators import MaximumLikelihoodMSM
-        from pyemma.msm.estimators import OOMReweightedMSM
+        from pyemma.msm.estimators import MaximumLikelihoodMSM, OOMReweightedMSM
         if self.msm_init=='largest-strong':
             hmm_init = init_discrete_hmm(dtrajs_lagged_strided, self.nstates, lag=1,
                                          reversible=self.reversible, stationary=True, regularize=True,
@@ -194,8 +193,7 @@ class MaximumLikelihoodHMSM(_Estimator, _HMSM):
             hmm_init = init_discrete_hmm(dtrajs_lagged_strided, self.nstates, lag=1,
                                          reversible=self.reversible, stationary=True, regularize=True,
                                          method='spectral', separate=self.separate)
-        elif issubclass(self.msm_init.__class__, MaximumLikelihoodMSM) or \
-                issubclass(self.msm_init.__class__, OOMReweightedMSM):  # initial MSM given.
+        elif isinstance(self.msm_init, (MaximumLikelihoodMSM, OOMReweightedMSM)):  # initial MSM given.
             from bhmm.init.discrete import init_discrete_hmm_spectral
             p0, P0, pobs0 = init_discrete_hmm_spectral(self.msm_init.count_matrix_full, self.nstates,
                                                        reversible=self.reversible, stationary=True,
@@ -256,6 +254,16 @@ class MaximumLikelihoodHMSM(_Estimator, _HMSM):
         # return submodel (will return self if all None)
         return self.submodel(states=states_subset, obs=observe_subset, mincount_connectivity=self.mincount_connectivity)
 
+    @property
+    def msm_init(self):
+        return self._msm_init
+
+    @msm_init.setter
+    def msm_init(self, value):
+        from pyemma.msm.estimators import MaximumLikelihoodMSM, OOMReweightedMSM
+        if (isinstance(value, (MaximumLikelihoodMSM, OOMReweightedMSM)) and not value._estimated):
+            raise ValueError('Given initial msm has not been estimated. Input was {}'.format(value))
+        self._msm_init = value
 
     @property
     def lagtime(self):

--- a/pyemma/msm/tests/test_hmsm.py
+++ b/pyemma/msm/tests/test_hmsm.py
@@ -425,6 +425,13 @@ class TestMLHMM(unittest.TestCase):
         k2 = 1.0 / t2
         assert np.abs(k2 - ksum) < 1e-4
 
+    def test_cktest_simple(self):
+        import pyemma
+        dtraj = np.random.randint(0, 10, 100)
+        oom = pyemma.msm.estimate_markov_model(dtraj, 1)
+        hmm = oom.coarse_grain(2)
+        hmm.cktest()
+
 
 class TestHMMSpecialCases(unittest.TestCase):
 


### PR DESCRIPTION
    [sklearn] if an already estimated Estimator is passed, deep copy it
    
    This is mandatory for parameter studies, which clones estimators to
    provide a "fresh" and independent blue print.
    
    Eg. there was a bug in HMM.cktest(), which does a parameter study over a
    series of lag times and cloning led to forgetting derived attributes
    like the count matrix of the initial model.
    
    This is a ugly workaround for this situation and should be properly
    fixed in the future, because deep copying the object multiplies the
    memory footprint by every copy taken.

Fixes #1135 

Another potential fix for the future is the usage of the declared serialize fields in the estimator (which then of course has to be serializable, but this is mission crucial any ways). So it depends on #867 and that developers are aware that they have to declare derived/computed fields. When we use this feature, we can simply serialize the estimator and have directly everything we want (parameters and estimated quantities).