### PR TITLE
HDF5 reader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ sudo: false
 env:
   global:
     - PATH=$HOME/miniconda/bin:$PATH
-    - common_py_deps="conda-build=2.1.4"
+    - common_py_deps="conda-build=2"
     - PACKAGENAME=pyemma
     - ORGNAME=omnia
     - PYTHONHASHSEED=0

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - scipy
     - setuptools
     - six >=1.10
-    - thermotools >=0.2.5
+    - thermotools >=0.2.6
 
 test:
   commands:
@@ -49,7 +49,8 @@ test:
   files:
     - matplotlibrc
   requires:
-    - pytest 
+    - h5py
+    - pytest
     - pytest-cov
     - pytest-faulthandler
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -12,6 +12,7 @@ build:
   preserve_egg_dir: True
   script_env:
    - CIRCLE_TEST_REPORTS
+   - OMP_NUM_THREADS
 
 requirements:
   build:

--- a/pyemma/coordinates/data/_base/datasource.py
+++ b/pyemma/coordinates/data/_base/datasource.py
@@ -116,9 +116,19 @@ class DataSource(Iterable, TrajectoryRandomAccessible):
                     info = TrajectoryInfoCache.instance()[filename, self]
                 else:
                     info = self._get_traj_info(filename)
-                lengths.append(info.length)
-                offsets.append(info.offsets)
-                ndims.append(info.ndim)
+                # nested data set support.
+                if hasattr(info, 'children'):
+                    lengths.append(info.length)
+                    offsets.append(info.offsets)
+                    ndims.append(info.ndim)
+                    for c in info.children:
+                        lengths.append(c.length)
+                        offsets.append(c.offsets)
+                        ndims.append(c.ndim)
+                else:
+                    lengths.append(info.length)
+                    offsets.append(info.offsets)
+                    ndims.append(info.ndim)
                 if len(filename_list) > 3:
                     self._progress_update(1)
 
@@ -247,8 +257,9 @@ class DataSource(Iterable, TrajectoryRandomAccessible):
                                 for itraj in range(n)),
                                dtype=int, count=n)
         else:
-            return np.fromiter(((l - skip - 1) // stride + 1 for l in self._lengths),
+            x= np.fromiter(((l - skip - 1) // stride + 1 for l in self._lengths),
                                dtype=int, count=n)
+            return x
 
     def n_frames_total(self, stride=1, skip=0):
         r"""Returns total number of frames.

--- a/pyemma/coordinates/data/_base/datasource.py
+++ b/pyemma/coordinates/data/_base/datasource.py
@@ -257,9 +257,8 @@ class DataSource(Iterable, TrajectoryRandomAccessible):
                                 for itraj in range(n)),
                                dtype=int, count=n)
         else:
-            x= np.fromiter(((l - skip - 1) // stride + 1 for l in self._lengths),
+            return np.fromiter(((l - skip - 1) // stride + 1 for l in self._lengths),
                                dtype=int, count=n)
-            return x
 
     def n_frames_total(self, stride=1, skip=0):
         r"""Returns total number of frames.

--- a/pyemma/coordinates/data/h5_reader.py
+++ b/pyemma/coordinates/data/h5_reader.py
@@ -26,11 +26,11 @@ class H5Reader(DataSource):
         The default selection will match all groups and all data sets.
         All selections have to begin with the root node '/'.
 
-    chunksize: int
+    chunk_size: int
     """
 
-    def __init__(self, filenames, selection='/*', chunksize=5000, **kw):
-        super(H5Reader, self).__init__(chunksize=chunksize)
+    def __init__(self, filenames, selection='/*', chunk_size=5000, **kw):
+        super(H5Reader, self).__init__(chunksize=chunk_size)
 
         self._is_reader = True
         self._is_random_accessible = True

--- a/pyemma/coordinates/data/h5_reader.py
+++ b/pyemma/coordinates/data/h5_reader.py
@@ -185,14 +185,3 @@ class H5Iterator(DataInMemoryIterator):
 
     def _next_chunk(self):
         return self._next_chunk_impl(self.data)
-
-
-if __name__ == '__main__':
-    files = ['/group/ag_cmb/marscher/feature_sel/A3D-1-protein-048.dcd_dist_ca.h5',
-             '/group/ag_cmb/marscher/feature_sel/A3D-1-protein-050.dcd_dist_ca.h5']
-    reader = H5Reader(files, selection='/dist_ca')
-
-    out = reader.get_output()
-    print(len(out))
-    for o in out:
-        print(o.shape)

--- a/pyemma/coordinates/data/h5_reader.py
+++ b/pyemma/coordinates/data/h5_reader.py
@@ -1,0 +1,201 @@
+from pyemma.coordinates.data._base.datasource import DataSource
+from pyemma.coordinates.data.data_in_memory import DataInMemoryIterator
+from pyemma.coordinates.data.util.traj_info_cache import TrajInfo
+
+__author__ = 'marscher'
+
+
+class H5Reader(DataSource):
+    r""" Reader for HDF5 files.
+
+    The reader needs h5py and pytables installed. The first package is used for the actual file handling, while
+    the latter is only used to import compression filters (eg. BLOSC).
+
+    Parameters
+    ----------
+    filenames: list of str
+
+    selection: str or mapping, default='/*'
+        HDF5-path selection (group0/group_x/dataset_name) given as a regular expression. Eg.
+             /group1/.*/my_dataset
+        will selection all 'my_dataset' in group1 no matter which kind of sub-groups these may belong to.
+
+        If a mapping is provided, it shall contain one selection per input file name.
+
+        Note, that selections may contain wildcards to select multiple groups (trees) and data sets.
+        The default selection will match all groups and all data sets.
+        All selections have to begin with the root node '/'.
+
+    chunksize: int
+    """
+
+    def __init__(self, filenames, selection='/*', chunksize=5000):
+        super(H5Reader, self).__init__(chunksize=chunksize)
+
+        self._is_reader = True
+        self._is_random_accessible = True
+
+        from pyemma.coordinates.data.data_in_memory import (DataInMemoryCuboidRandomAccessStrategy,
+                                                            DataInMemoryJaggedRandomAccessStrategy,
+                                                            DataInMemoryLinearRandomAccessStrategy,
+                                                            DataInMemoryLinearItrajRandomAccessStrategy)
+        self._ra_cuboid = DataInMemoryCuboidRandomAccessStrategy(self, 3)
+        self._ra_jagged = DataInMemoryJaggedRandomAccessStrategy(self, 3)
+        self._ra_linear_strategy = DataInMemoryLinearRandomAccessStrategy(self, 2)
+        self._ra_linear_itraj_strategy = DataInMemoryLinearItrajRandomAccessStrategy(self, 3)
+
+        # set selection first, so we can use it the filename setter.
+        self.selection = selection
+        # we count data sets as itrajs, because a hdf5 file can contain multiple data sets.
+        from collections import defaultdict
+        self._itraj_dataset_mapping = defaultdict(int)
+
+        # we explicitly do not want to cache anything for H5, because the user can provide different selections
+        # and the interface of the cache does not allow for such a mapping (1:1 relation filename:(dimension, len)).
+        from pyemma.util.contexts import settings
+        with settings(use_trajectory_lengths_cache=False):
+            self.filenames = filenames
+
+        # we need to override the ntraj attribute to be equal with the itraj_counter to respect all data sets.
+        self._ntraj = self._itraj_counter
+
+        # sanity
+        if self._itraj_counter == 0:
+            raise ValueError('Your provided selection did not match anything in your provided files. '
+                             'Check the log output')
+
+    @property
+    def selection(self):
+        return self._selection
+
+    @selection.setter
+    def selection(self, value):
+        # 1. open all files, and check that selection matches for each file
+        # 2. check that dimension are all the same for each file
+        from typing import Mapping
+        if isinstance(value, Mapping):
+            # check if we have a wildcard
+            if any(('*' in e for e in value)):
+                # TODO: expand this to match the len of filenames
+                pass
+            else:
+                pass
+        elif isinstance(value, str):
+            if not value.startswith('/'):
+                raise ValueError('selection has to start with the root node "/". '
+                                 'Followed by an explicit group name or wildcard specifier.')
+
+        self._selection = value
+        # since we have update the selection, reset the counter for itrajs.
+        self._itraj_counter = 0
+        # we re-assign the file names here to reflect the updated selection (if filenames was set before).
+        if self._filenames is not None:
+            self.filenames = self.filenames
+
+    @property
+    def n_datasets(self):
+        return self._itraj_counter
+
+    def _get_traj_info(self, filename):
+        # noinspection PyUnresolvedReferences
+        import tables
+        import h5py
+
+        with h5py.File(filename, mode='r') as f:
+            try:
+                sel = self.selection[filename]
+            except (KeyError, TypeError):
+                sel = self.selection
+            import re
+
+            # unfortunately keys do not start with a root, so insert it now to simplify matching.
+            keys = list(f.keys())
+            for i, k in enumerate(keys):
+                if not k.startswith('/'):
+                    keys[i] = '/' + k
+
+            matches = []
+            children = []
+            def name_matches_selection(name, obj):
+                nonlocal matches
+                if not isinstance(obj, h5py.Dataset):
+                    return
+
+                m = re.match(sel, obj.name)
+                if m is not None:
+                    matches.append(m)
+            f.visititems(name_matches_selection)
+
+            if not matches:
+                self.logger.warning('selection "%s" did not match any group/dataset in file "%s"', sel, filename)
+
+            for m in matches:
+                path = m.string
+                h5_item = f[path]
+                assert h5_item.ndim == 2, 'only 2-dimension datasets supported'
+                ndim = h5_item.shape[1]
+                lengths = h5_item.shape[0]
+                self._itraj_dataset_mapping[self._itraj_counter] = (filename, path)
+                self._itraj_counter += 1
+                children.append(TrajInfo(ndim, lengths))
+
+        if children:
+            t = children[0]
+            t.children = children[1:]
+        else:
+            t = TrajInfo(-1, 0)
+        return t
+
+    def _load_file(self, itraj):
+        # noinspection PyUnresolvedReferences
+        import tables
+        import h5py
+        filename, path = self._itraj_dataset_mapping[itraj]
+        self.logger.debug('load file %s with path %s', filename, path)
+        file = h5py.File(filename, 'r')
+        ds = file[path]
+        return ds
+
+    def _create_iterator(self, skip=0, chunk=0, stride=1, return_trajindex=True, cols=None):
+        return H5Iterator(self, skip=skip, chunk=chunk, stride=stride, return_trajindex=return_trajindex, cols=cols)
+
+
+class H5Iterator(DataInMemoryIterator):
+    def __init__(self, data_source, skip=0, chunk=0, stride=1, return_trajindex=False, cols=False):
+        super(H5Iterator, self).__init__(data_source=data_source, skip=skip,
+                                         chunk=chunk, stride=stride,
+                                         return_trajindex=return_trajindex,
+                                         cols=cols)
+
+    #def data(self, itraj):
+    #    return self._data_source._load_file(itraj)
+
+    def close(self):
+        if hasattr(self, '_fh'):
+            self._fh.close()
+            del self._fh
+
+    def _select_file(self, itraj):
+        if self._selected_itraj != itraj:
+            self._first_file_opened = True
+            self.close()
+            self._t = 0
+            self._itraj = itraj
+            self._selected_itraj = self._itraj
+            if itraj < self.number_of_trajectories():
+                self.data = self._data_source._load_file(itraj)
+                self._fh = self.data.file
+
+    def _next_chunk(self):
+        return self._next_chunk_impl(self.data)
+
+
+if __name__ == '__main__':
+    files = ['/group/ag_cmb/marscher/feature_sel/A3D-1-protein-048.dcd_dist_ca.h5',
+             '/group/ag_cmb/marscher/feature_sel/A3D-1-protein-050.dcd_dist_ca.h5']
+    reader = H5Reader(files, selection='/dist_ca')
+
+    out = reader.get_output()
+    print(len(out))
+    for o in out:
+        print(o.shape)

--- a/pyemma/coordinates/data/h5_reader.py
+++ b/pyemma/coordinates/data/h5_reader.py
@@ -29,7 +29,7 @@ class H5Reader(DataSource):
     chunksize: int
     """
 
-    def __init__(self, filenames, selection='/*', chunksize=5000):
+    def __init__(self, filenames, selection='/*', chunksize=5000, **kw):
         super(H5Reader, self).__init__(chunksize=chunksize)
 
         self._is_reader = True

--- a/pyemma/coordinates/data/h5_reader.py
+++ b/pyemma/coordinates/data/h5_reader.py
@@ -167,9 +167,6 @@ class H5Iterator(DataInMemoryIterator):
                                          return_trajindex=return_trajindex,
                                          cols=cols)
 
-    #def data(self, itraj):
-    #    return self._data_source._load_file(itraj)
-
     def close(self):
         if hasattr(self, '_fh'):
             self._fh.close()

--- a/pyemma/coordinates/data/util/reader_utils.py
+++ b/pyemma/coordinates/data/util/reader_utils.py
@@ -89,9 +89,12 @@ def create_file_reader(input_files, topology, featurizer, chunk_size=1000, **kw)
 
             if all_exist:
                 from mdtraj.formats.registry import FormatRegistry
-
+                # we need to check for h5 first, because of mdtraj custom HDF5 traj format (which is deprecated).
+                if suffix in ['.h5', '.hdf5']:
+                    from pyemma.coordinates.data.h5_reader import H5Reader
+                    reader = H5Reader(filenames=input_files, chunksize=chunk_size, **kw)
                 # CASE 1.1: file types are MD files
-                if suffix in list(FormatRegistry.loaders.keys()):
+                elif suffix in list(FormatRegistry.loaders.keys()):
                     # check: do we either have a featurizer or a topology file name? If not: raise ValueError.
                     # create a MD reader with file names and topology
                     if not featurizer and not topology:

--- a/pyemma/coordinates/data/util/reader_utils.py
+++ b/pyemma/coordinates/data/util/reader_utils.py
@@ -91,8 +91,15 @@ def create_file_reader(input_files, topology, featurizer, chunk_size=1000, **kw)
                 from mdtraj.formats.registry import FormatRegistry
                 # we need to check for h5 first, because of mdtraj custom HDF5 traj format (which is deprecated).
                 if suffix in ['.h5', '.hdf5']:
-                    from pyemma.coordinates.data.h5_reader import H5Reader
-                    reader = H5Reader(filenames=input_files, chunksize=chunk_size, **kw)
+                    # TODO: inspect if it is a mdtraj h5 file, eg. has the given attributes
+                    try:
+                        from mdtraj.formats import HDF5TrajectoryFile
+                        HDF5TrajectoryFile(input_list[0])
+                        reader = FeatureReader(input_list, featurizer=featurizer, topologyfile=topology,
+                                               chunksize=chunk_size)
+                    except:
+                        from pyemma.coordinates.data.h5_reader import H5Reader
+                        reader = H5Reader(filenames=input_files, chunk_size=chunk_size, **kw)
                 # CASE 1.1: file types are MD files
                 elif suffix in list(FormatRegistry.loaders.keys()):
                     # check: do we either have a featurizer or a topology file name? If not: raise ValueError.

--- a/pyemma/coordinates/tests/test_h5reader.py
+++ b/pyemma/coordinates/tests/test_h5reader.py
@@ -65,3 +65,8 @@ class TestH5Reader(unittest.TestCase):
         out = self.reader.get_output()
         np.testing.assert_equal(out, [self.data]*2)
 
+    def test_source(self):
+        from pyemma.coordinates import source
+        reader = source(self.f1, selection='/.*/test_ds')
+        self.assertIsInstance(reader, H5Reader)
+        self.assertEqual(reader.ntraj, 2)

--- a/pyemma/coordinates/tests/test_h5reader.py
+++ b/pyemma/coordinates/tests/test_h5reader.py
@@ -1,0 +1,61 @@
+import unittest
+import numpy as np
+
+from pyemma.coordinates.data.h5_reader import H5Reader
+from pyemma.util.testing_tools import MockLoggingHandler
+
+try:
+    import h5py, tables
+    have_hdf5 = True
+except ImportError:
+    have_hdf5 = False
+
+
+@unittest.skipIf(not have_hdf5, 'no hdf5 support. Install h5py and pytables')
+class TestH5Reader(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        import tempfile
+        # create test data sets
+        cls.directory = tempfile.mkdtemp('test_h5reader')
+
+        cls.f1 = tempfile.mktemp(suffix='.h5', dir=cls.directory)
+        cls.shape = (10, 3)
+        cls.data = np.arange(cls.shape[0]*cls.shape[1]).reshape(cls.shape)
+        with h5py.File(cls.f1, mode='w') as f:
+            ds = f.create_group('test').create_group('another_group').create_dataset('test_ds', shape=cls.shape)
+            ds[:] = cls.data
+            ds = f.create_group('test2').create_dataset('test_ds', shape=cls.shape)
+            ds[:] = cls.data
+            f.create_dataset('another_ds', shape=(10, 23))
+        cls.total_frames = cls.shape[0] * 2
+
+        cls.reader = H5Reader(cls.f1, selection='/.*/test_ds')
+
+    def test_ndim(self):
+        assert self.reader.ndim == self.shape[1]
+        assert self.reader.filenames == [self.f1]
+        self.assertEqual(self.reader.n_frames_total(), self.total_frames)
+        self.assertEqual(self.reader.n_datasets, 2)
+
+    def test_udpate_selection(self):
+        self.reader.selection = '/test2/*'
+        assert self.reader.ndim == self.shape[1]
+        assert self.reader.n_frames_total() == self.shape[0]
+        assert self.reader.n_datasets == 1
+
+    def test_non_matching_selection(self):
+        with self.assertRaises(ValueError):
+            h = MockLoggingHandler()
+            import logging
+            logging.getLogger('pyemma.coordinates').addHandler(h)
+            r = H5Reader(self.f1, selection='/non_existent')
+
+            self.assertIn('did not match', h.messages['warning'])
+            assert r.ndim == -1
+            assert r.n_frames_total() == 0
+
+    def test_output(self):
+        out = self.reader.get_output()
+        np.testing.assert_equal(out, [self.data]*2)
+

--- a/pyemma/coordinates/tests/test_h5reader.py
+++ b/pyemma/coordinates/tests/test_h5reader.py
@@ -32,6 +32,11 @@ class TestH5Reader(unittest.TestCase):
 
         cls.reader = H5Reader(cls.f1, selection='/.*/test_ds')
 
+    @classmethod
+    def tearDownClass(cls):
+        import shutil
+        shutil.rmtree(cls.directory)
+
     def test_ndim(self):
         assert self.reader.ndim == self.shape[1]
         assert self.reader.filenames == [self.f1]
@@ -54,6 +59,7 @@ class TestH5Reader(unittest.TestCase):
             self.assertIn('did not match', h.messages['warning'])
             assert r.ndim == -1
             assert r.n_frames_total() == 0
+            assert r.ntraj == 0
 
     def test_output(self):
         out = self.reader.get_output()


### PR DESCRIPTION
Because a HDF5 file can contain multiple distinct data sets,
we provide a selection functionality with regular expression
support. All the matching data sets (their absolute path) will be
considered as unique trajectories. By default all data sets are
selected.

At the moment the selection can only be a single string, but we
should add a mapping for {filenames: selection} in the future
in order to be more flexible.

Note that this is currently not available for the coordinates.source method.