### PR TITLE
Fix pybind11 include

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "ipython"]
 	path = pyemma-ipython
 	url = https://github.com/markovmodel/PyEMMA_IPython.git
+[submodule "pybind11"]
+	path = pybind11
+	url = https://github.com/pybind/pybind11

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -40,3 +40,6 @@ recursive-include pyemma *.pyx *.h *.c
 
 # do not include eventually present eggs (installed during setup runtime)
 prune .eggs
+
+# include pybind11 headers in source archive
+recursive-include pybind11 *.h

--- a/setup.py
+++ b/setup.py
@@ -258,7 +258,6 @@ else:
     metadata['setup_requires'] = ['numpy>=1.7.0',
                                   'scipy',
                                   'mdtraj>=1.7.0',
-                                  'pybind11>=2.1.0',
                                   ]
 
     metadata['package_data'] = {

--- a/setup.py
+++ b/setup.py
@@ -274,6 +274,13 @@ else:
         warnings.warn('using git, require cython')
         metadata['setup_requires'] += ['cython>=0.22']
 
+        # init submodules
+        import subprocess
+        modules = ['pybind11', ]
+        cmd = "git submodule update --init {mod}"
+        for m in modules:
+            subprocess.check_call(cmd.format(mod=m).split(' '))
+
     # only require numpy and extensions in case of building/installing
     metadata['ext_modules'] = lazy_cythonize(callback=extensions)
 

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,8 @@ def extensions():
     from numpy import get_include as _np_inc
     np_inc = _np_inc()
 
-    import pybind11
+    pybind_inc = os.path.join(os.path.dirname(__file__), 'pybind11', 'include')
+    assert os.path.exists(pybind_inc)
 
     exts = []
 
@@ -105,7 +106,7 @@ def extensions():
                   include_dirs=[
                       mdtraj.capi()['include_dir'],
                       np_inc,
-                      pybind11.get_include(),
+                      pybind_inc,
                       'pyemma/coordinates/clustering/include',
                   ],
                   language='c++',
@@ -118,6 +119,7 @@ def extensions():
                   sources=['pyemma/_ext/variational/estimators/covar_c/covartools.cpp'],
                   include_dirs=['pyemma/_ext/variational/estimators/covar_c/',
                                 np_inc,
+                                pybind_inc,
                                 ],
                   extra_compile_args=['-std=c++11', '-O3', '-fvisibility=hidden'])
 


### PR DESCRIPTION
Discussed this solution with @clonker. We agreed upon, that it is the easiest and most fail-safe solution to include pybind11. It does not require on the python package anymore, but includes the headers of pybind as a submodule (which is automatically cloned, when setup.py is invoked from a git working copy). The headers are also bundled with pyemma's source tarball.

Fixes #1148 