### PR TITLE
[LaggedCovariance] added property cov_tau_tau

### DIFF
--- a/pyemma/coordinates/estimation/covariance.py
+++ b/pyemma/coordinates/estimation/covariance.py
@@ -249,6 +249,11 @@ class LaggedCovariance(StreamingEstimator, ProgressReporter):
         return self._rc.cov_XY(bessel=self.bessel)
 
     @property
+    def cov_tau_tau(self):
+        self._check_estimated()
+        return self._rc.cov_YY(bessel=self.bessel)
+
+    @property
     def nsave(self):
         if self.c00:
             return self._rc.storage_XX.nsave
@@ -264,3 +269,6 @@ class LaggedCovariance(StreamingEstimator, ProgressReporter):
         if self.c0t:
             if self._rc.storage_XY.nsave <= ns:
                 self._rc.storage_XY.nsave = ns
+        if self.ctt:
+            if self._rc.storage_YY.nsave <= ns:
+                self._rc.storage_YY.nsave = ns

--- a/pyemma/coordinates/estimation/covariance.py
+++ b/pyemma/coordinates/estimation/covariance.py
@@ -40,10 +40,13 @@ class LaggedCovariance(StreamingEstimator, ProgressReporter):
      ----------
      c00 : bool, optional, default=True
          compute instantaneous correlations over the first part of the data. If lag==0, use all of the data.
+         Makes the C00_ attribute available.
      c0t : bool, optional, default=False
          compute lagged correlations. Does not work with lag==0.
+         Makes the C0t_ attribute available.
      ctt : bool, optional, default=False
-         compute instantaneous correlations over the second part of the data. Does not work with lag==0.
+         compute instantaneous correlations over the time-shifted chunks of the data. Does not work with lag==0.
+         Makes the Ctt_ attribute available.
      remove_constant_mean : ndarray(N,), optional, default=None
          substract a constant vector of mean values from time series.
      remove_data_mean : bool, optional, default=False

--- a/pyemma/coordinates/estimation/covariance.py
+++ b/pyemma/coordinates/estimation/covariance.py
@@ -20,6 +20,8 @@ from __future__ import absolute_import
 import numpy as np
 import numbers
 from math import log
+
+from pyemma.util.annotators import deprecated
 from pyemma.util.types import is_float_vector, ensure_float_vector
 from pyemma.coordinates.data._base.streaming_estimator import StreamingEstimator
 from pyemma._base.progress import ProgressReporter
@@ -239,17 +241,32 @@ class LaggedCovariance(StreamingEstimator, ProgressReporter):
         return self._rc.mean_Y()
 
     @property
+    @deprecated('Please use the attribute "C00_".')
     def cov(self):
         self._check_estimated()
         return self._rc.cov_XX(bessel=self.bessel)
 
     @property
+    def C00_(self):
+        """ Instantaneous covariance matrix """
+        self._check_estimated()
+        return self._rc.cov_XX(bessel=self.bessel)
+
+    @property
+    @deprecated('Please use the attribute "C0t_".')
     def cov_tau(self):
         self._check_estimated()
         return self._rc.cov_XY(bessel=self.bessel)
 
     @property
-    def cov_tau_tau(self):
+    def C0t_(self):
+        """ Time-lagged covariance matrix """
+        self._check_estimated()
+        return self._rc.cov_XY(bessel=self.bessel)
+
+    @property
+    def Ctt_(self):
+        """ Covariance matrix of the time shifted data"""
         self._check_estimated()
         return self._rc.cov_YY(bessel=self.bessel)
 

--- a/pyemma/coordinates/estimation/koopman.py
+++ b/pyemma/coordinates/estimation/koopman.py
@@ -83,10 +83,10 @@ class _KoopmanEstimator(StreamingEstimator):
         return self
 
     def _finish_estimation(self):
-        R = spd_inv_split(self._covar.cov, epsilon=self.epsilon, canonical_signs=True)
+        R = spd_inv_split(self._covar.C00_, epsilon=self.epsilon, canonical_signs=True)
         # Set the new correlation matrix:
         M = R.shape[1]
-        K = np.dot(R.T, np.dot((self._covar.cov_tau), R))
+        K = np.dot(R.T, np.dot((self._covar.C0t_), R))
         K = np.vstack((K, np.dot((self._covar.mean_tau - self._covar.mean), R)))
         ex1 = np.zeros((M + 1, 1))
         ex1[M, 0] = 1.0

--- a/pyemma/coordinates/tests/test_covar_estimator.py
+++ b/pyemma/coordinates/tests/test_covar_estimator.py
@@ -157,27 +157,27 @@ class TestCovarEstimator(unittest.TestCase):
         # many passes
         cc = covariance_lagged(data=self.data, c0t=False, remove_data_mean=False, bessel=False, chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.mx_lag0)
-        np.testing.assert_allclose(cc.cov, self.Mxx_lag0)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_lag0)
 
     def test_XX_meanfree(self):
         # many passes
         cc = covariance_lagged(data=self.data, c0t=False, remove_data_mean=True, bessel=False, chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.mx_lag0)
-        np.testing.assert_allclose(cc.cov, self.Mxx0_lag0)
+        np.testing.assert_allclose(cc.C00_, self.Mxx0_lag0)
 
     def test_XX_weightobj_withmean(self):
         # many passes
         cc = covariance_lagged(data=self.data, c0t=False, remove_data_mean=False, weights=self.wobj, bessel=False,
                                chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.mx_wobj_lag0)
-        np.testing.assert_allclose(cc.cov, self.Mxx_wobj_lag0)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_wobj_lag0)
 
     def test_XX_weightobj_meanfree(self):
         # many passes
         cc = covariance_lagged(data=self.data, c0t=False, remove_data_mean=True, weights=self.wobj, bessel=False,
                                chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.mx_wobj_lag0)
-        np.testing.assert_allclose(cc.cov, self.Mxx0_wobj_lag0)
+        np.testing.assert_allclose(cc.C00_, self.Mxx0_wobj_lag0)
 
     def test_XXXY_withmean(self):
         # many passes
@@ -185,8 +185,8 @@ class TestCovarEstimator(unittest.TestCase):
                                chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.mx)
         np.testing.assert_allclose(cc.mean_tau, self.my)
-        np.testing.assert_allclose(cc.cov, self.Mxx)
-        np.testing.assert_allclose(cc.cov_tau, self.Mxy)
+        np.testing.assert_allclose(cc.C00_, self.Mxx)
+        np.testing.assert_allclose(cc.C0t_, self.Mxy)
 
     def test_XXXY_meanfree(self):
         # many passes
@@ -194,8 +194,8 @@ class TestCovarEstimator(unittest.TestCase):
                                chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.mx)
         np.testing.assert_allclose(cc.mean_tau, self.my)
-        np.testing.assert_allclose(cc.cov, self.Mxx0)
-        np.testing.assert_allclose(cc.cov_tau, self.Mxy0)
+        np.testing.assert_allclose(cc.C00_, self.Mxx0)
+        np.testing.assert_allclose(cc.C0t_, self.Mxy0)
 
     def test_XXXY_weightobj_withmean(self):
         # many passes
@@ -203,8 +203,8 @@ class TestCovarEstimator(unittest.TestCase):
                                bessel=False, chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.mx_wobj)
         np.testing.assert_allclose(cc.mean_tau, self.my_wobj)
-        np.testing.assert_allclose(cc.cov, self.Mxx_wobj)
-        np.testing.assert_allclose(cc.cov_tau, self.Mxy_wobj)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_wobj)
+        np.testing.assert_allclose(cc.C0t_, self.Mxy_wobj)
 
     def test_XXXY_weightobj_meanfree(self):
         # many passes
@@ -214,82 +214,82 @@ class TestCovarEstimator(unittest.TestCase):
 
         np.testing.assert_allclose(cc.mean, self.mx_wobj)
         np.testing.assert_allclose(cc.mean_tau, self.my_wobj)
-        np.testing.assert_allclose(cc.cov, self.Mxx0_wobj)
-        np.testing.assert_allclose(cc.cov_tau, self.Mxy0_wobj)
+        np.testing.assert_allclose(cc.C00_, self.Mxx0_wobj)
+        np.testing.assert_allclose(cc.C0t_, self.Mxy0_wobj)
 
     def test_XXXY_sym_withmean(self):
         # many passes
         cc = covariance_lagged(data=self.data, remove_data_mean=False, c0t=True, lag=self.lag, reversible=True,
                                bessel=False, chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.m_sym)
-        np.testing.assert_allclose(cc.cov, self.Mxx_sym)
-        np.testing.assert_allclose(cc.cov_tau, self.Mxy_sym)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_sym)
+        np.testing.assert_allclose(cc.C0t_, self.Mxy_sym)
 
     def test_XXXY_sym_meanfree(self):
         # many passes
         cc = covariance_lagged(data=self.data, remove_data_mean=True, c0t=True, lag=self.lag, reversible=True,
                                bessel=False, chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.m_sym)
-        np.testing.assert_allclose(cc.cov, self.Mxx0_sym)
-        np.testing.assert_allclose(cc.cov_tau, self.Mxy0_sym)
+        np.testing.assert_allclose(cc.C00_, self.Mxx0_sym)
+        np.testing.assert_allclose(cc.C0t_, self.Mxy0_sym)
 
     def test_XXXY_weightobj_sym_withmean(self):
         # many passes
         cc = covariance_lagged(data=self.data, remove_data_mean=False, c0t=True, lag=self.lag, reversible=True,
                                bessel=False, weights=self.wobj, chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.m_sym_wobj)
-        np.testing.assert_allclose(cc.cov, self.Mxx_sym_wobj)
-        np.testing.assert_allclose(cc.cov_tau, self.Mxy_sym_wobj)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_sym_wobj)
+        np.testing.assert_allclose(cc.C0t_, self.Mxy_sym_wobj)
 
     def test_XXXY_weightobj_sym_meanfree(self):
         # many passes
         cc = covariance_lagged(data=self.data, remove_data_mean=True, c0t=True, lag=self.lag, reversible=True,
                                bessel=False, weights=self.wobj, chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.m_sym_wobj)
-        np.testing.assert_allclose(cc.cov, self.Mxx0_sym_wobj)
-        np.testing.assert_allclose(cc.cov_tau, self.Mxy0_sym_wobj)
+        np.testing.assert_allclose(cc.C00_, self.Mxx0_sym_wobj)
+        np.testing.assert_allclose(cc.C0t_, self.Mxy0_sym_wobj)
 
     def test_XX_meanconst(self):
         cc = covariance_lagged(data=self.data, c0t=False, remove_constant_mean=self.mean_const, bessel=False,
                                chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.mx_c_lag0)
-        np.testing.assert_allclose(cc.cov, self.Mxx_c_lag0)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_c_lag0)
 
     def test_XX_weighted_meanconst(self):
         cc = covariance_lagged(data=self.data, c0t=False, remove_constant_mean=self.mean_const, weights=self.wobj, bessel=False,
                                chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.mx_c_wobj_lag0)
-        np.testing.assert_allclose(cc.cov, self.Mxx_c_wobj_lag0)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_c_wobj_lag0)
 
     def test_XY_meanconst(self):
         cc = covariance_lagged(data=self.data, remove_constant_mean=self.mean_const, c0t=True, lag=self.lag, bessel=False,
                                chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.mx_c)
         np.testing.assert_allclose(cc.mean_tau, self.my_c)
-        np.testing.assert_allclose(cc.cov, self.Mxx_c)
-        np.testing.assert_allclose(cc.cov_tau, self.Mxy_c)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_c)
+        np.testing.assert_allclose(cc.C0t_, self.Mxy_c)
 
     def test_XY_weighted_meanconst(self):
         cc = covariance_lagged(data=self.data, remove_constant_mean=self.mean_const, c0t=True, weights=self.wobj, lag=self.lag,
                                bessel=False, chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.mx_c_wobj)
         np.testing.assert_allclose(cc.mean_tau, self.my_c_wobj)
-        np.testing.assert_allclose(cc.cov, self.Mxx_c_wobj)
-        np.testing.assert_allclose(cc.cov_tau, self.Mxy_c_wobj)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_c_wobj)
+        np.testing.assert_allclose(cc.C0t_, self.Mxy_c_wobj)
 
     def test_XY_sym_meanconst(self):
         cc = covariance_lagged(data=self.data, remove_constant_mean=self.mean_const, c0t=True, reversible=True, lag=self.lag,
                                bessel=False, chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.m_c_sym)
-        np.testing.assert_allclose(cc.cov, self.Mxx_c_sym)
-        np.testing.assert_allclose(cc.cov_tau, self.Mxy_c_sym)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_c_sym)
+        np.testing.assert_allclose(cc.C0t_, self.Mxy_c_sym)
 
     def test_XY_sym_weighted_meanconst(self):
         cc = covariance_lagged(data=self.data, remove_constant_mean=self.mean_const, c0t=True, reversible=True, weights=self.wobj,
                                lag=self.lag, bessel=False, chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.m_c_sym_wobj)
-        np.testing.assert_allclose(cc.cov, self.Mxx_c_sym_wobj)
-        np.testing.assert_allclose(cc.cov_tau, self.Mxy_c_sym_wobj)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_c_sym_wobj)
+        np.testing.assert_allclose(cc.C0t_, self.Mxy_c_sym_wobj)
 
 
 class TestCovarianceEstimatorGivenWeights(TestCovarEstimator):
@@ -440,7 +440,7 @@ class TestCovarEstimatorWeightsList(unittest.TestCase):
         weights[0][:] = 1E-44
 
         cov = covariance_lagged(data, lag=3, weights=weights, chunksize=10)
-        assert np.all(cov.cov < 1)
+        assert np.all(cov.C00_ < 1)
 
     @unittest.skip("zero weights known to be broken #1117")
     def test_weights_equal_to_zero(self):
@@ -457,12 +457,12 @@ class TestCovarEstimatorWeightsList(unittest.TestCase):
 
         cov = covariance_lagged(data, lag=3, weights=weights, chunksize=5)
         zeros = sum((sum (w==0) for w in weights))
-        assert np.all(cov.cov < 1), cov.cov
-        assert np.all(cov.cov > 0), cov.cov
+        assert np.all(cov.C00_ < 1), cov.C00_
+        assert np.all(cov.C00_ > 0), cov.C00_
 
         #from statsmodels.stats.weightstats import DescrStatsW
         #ds = DescrStatsW(data, weights=weights)
-        #np.testing.assert_allclose(cov.cov, ds.cov)
+        #np.testing.assert_allclose(cov.C00_, ds.cov)
 
     def test_non_matching_length(self):
         n = 100

--- a/pyemma/coordinates/tests/test_eq_covar_estimator.py
+++ b/pyemma/coordinates/tests/test_eq_covar_estimator.py
@@ -111,9 +111,9 @@ class TestEqCovar(unittest.TestCase):
         cc = covariance_lagged(data=self.data, c0t=False, lag=self.tau, bessel=False, weights="koopman")
         cc1 = covariance_lagged(data=self.data, c0t=False, lag=self.tau, bessel=False, weights=self.weight_object)
         assert np.allclose(cc.mean, self.mx)
-        assert np.allclose(cc.cov, self.Mxx)
+        assert np.allclose(cc.C00_, self.Mxx)
         assert np.allclose(cc1.mean, self.mx)
-        assert np.allclose(cc1.cov, self.Mxx)
+        assert np.allclose(cc1.C00_, self.Mxx)
 
     def test_XX_removeconstantmean(self):
         cc = covariance_lagged(data=self.data, c0t=False, lag=self.tau, remove_constant_mean=self.mean_constant,
@@ -121,9 +121,9 @@ class TestEqCovar(unittest.TestCase):
         cc1 = covariance_lagged(data=self.data, c0t=False, lag=self.tau, remove_constant_mean=self.mean_constant,
                                 bessel=False, weights=self.weight_object)
         assert np.allclose(cc.mean, self.mx_c)
-        assert np.allclose(cc.cov, self.Mxx_c)
+        assert np.allclose(cc.C00_, self.Mxx_c)
         assert np.allclose(cc1.mean, self.mx_c)
-        assert np.allclose(cc1.cov, self.Mxx_c)
+        assert np.allclose(cc1.C00_, self.Mxx_c)
 
     def test_XX_removedatamean(self):
         cc = covariance_lagged(data=self.data, c0t=False, lag=self.tau, remove_data_mean=True, bessel=False,
@@ -131,21 +131,21 @@ class TestEqCovar(unittest.TestCase):
         cc1 = covariance_lagged(data=self.data, c0t=False, lag=self.tau, remove_data_mean=True, bessel=False,
                                 weights=self.weight_object)
         assert np.allclose(cc.mean, self.mx)
-        assert np.allclose(cc.cov, self.Mxx0)
+        assert np.allclose(cc.C00_, self.Mxx0)
         assert np.allclose(cc1.mean, self.mx)
-        assert np.allclose(cc1.cov, self.Mxx0)
+        assert np.allclose(cc1.C00_, self.Mxx0)
 
     def test_XY(self):
         cc = covariance_lagged(data=self.data, lag=self.tau, c0t=True, bessel=False, weights="koopman")
         cc1 = covariance_lagged(data=self.data, lag=self.tau, c0t=True, bessel=False, weights=self.weight_object)
         assert np.allclose(cc.mean, self.mx)
         assert np.allclose(cc.mean_tau, self.my)
-        assert np.allclose(cc.cov, self.Mxx)
-        assert np.allclose(cc.cov_tau, self.Mxy)
+        assert np.allclose(cc.C00_, self.Mxx)
+        assert np.allclose(cc.C0t_, self.Mxy)
         assert np.allclose(cc1.mean, self.mx)
         assert np.allclose(cc1.mean_tau, self.my)
-        assert np.allclose(cc1.cov, self.Mxx)
-        assert np.allclose(cc1.cov_tau, self.Mxy)
+        assert np.allclose(cc1.C00_, self.Mxx)
+        assert np.allclose(cc1.C0t_, self.Mxy)
 
 
     def test_XY_removeconstantmean(self):
@@ -155,12 +155,12 @@ class TestEqCovar(unittest.TestCase):
                                 bessel=False, weights="koopman")
         assert np.allclose(cc.mean, self.mx_c)
         assert np.allclose(cc.mean_tau, self.my_c)
-        assert np.allclose(cc.cov, self.Mxx_c)
-        assert np.allclose(cc.cov_tau, self.Mxy_c)
+        assert np.allclose(cc.C00_, self.Mxx_c)
+        assert np.allclose(cc.C0t_, self.Mxy_c)
         assert np.allclose(cc1.mean, self.mx_c)
         assert np.allclose(cc1.mean_tau, self.my_c)
-        assert np.allclose(cc1.cov, self.Mxx_c)
-        assert np.allclose(cc1.cov_tau, self.Mxy_c)
+        assert np.allclose(cc1.C00_, self.Mxx_c)
+        assert np.allclose(cc1.C0t_, self.Mxy_c)
 
     def test_XY_removedatamean(self):
         cc = covariance_lagged(data=self.data, lag=self.tau, c0t=True, remove_data_mean=True, bessel=False,
@@ -169,12 +169,12 @@ class TestEqCovar(unittest.TestCase):
                                 weights=self.weight_object)
         assert np.allclose(cc.mean, self.mx)
         assert np.allclose(cc.mean_tau, self.my)
-        assert np.allclose(cc.cov, self.Mxx0)
-        assert np.allclose(cc.cov_tau, self.Mxy0)
+        assert np.allclose(cc.C00_, self.Mxx0)
+        assert np.allclose(cc.C0t_, self.Mxy0)
         assert np.allclose(cc1.mean, self.mx)
         assert np.allclose(cc1.mean_tau, self.my)
-        assert np.allclose(cc1.cov, self.Mxx0)
-        assert np.allclose(cc1.cov_tau, self.Mxy0)
+        assert np.allclose(cc1.C00_, self.Mxx0)
+        assert np.allclose(cc1.C0t_, self.Mxy0)
 
     def test_XY_sym(self):
         cc = covariance_lagged(data=self.data, lag=self.tau, c0t=True, reversible=True, bessel=False,
@@ -182,11 +182,11 @@ class TestEqCovar(unittest.TestCase):
         cc1 = covariance_lagged(data=self.data, lag=self.tau, c0t=True, reversible=True, bessel=False,
                                 weights=self.weight_object)
         assert np.allclose(cc.mean, self.msym)
-        assert np.allclose(cc.cov, self.Mxx_sym)
-        assert np.allclose(cc.cov_tau, self.Mxy_sym)
+        assert np.allclose(cc.C00_, self.Mxx_sym)
+        assert np.allclose(cc.C0t_, self.Mxy_sym)
         assert np.allclose(cc1.mean, self.msym)
-        assert np.allclose(cc1.cov, self.Mxx_sym)
-        assert np.allclose(cc1.cov_tau, self.Mxy_sym)
+        assert np.allclose(cc1.C00_, self.Mxx_sym)
+        assert np.allclose(cc1.C0t_, self.Mxy_sym)
 
     def test_XY_sym_removeconstantmean(self):
         cc = covariance_lagged(data=self.data, lag=self.tau, c0t=True, reversible=True,
@@ -194,11 +194,11 @@ class TestEqCovar(unittest.TestCase):
         cc1 = covariance_lagged(data=self.data, lag=self.tau, c0t=True, reversible=True,
                                 remove_constant_mean=self.mean_constant, bessel=False, weights=self.weight_object)
         assert np.allclose(cc.mean, self.msym_c)
-        assert np.allclose(cc.cov, self.Mxx_c_sym)
-        assert np.allclose(cc.cov_tau, self.Mxy_c_sym)
+        assert np.allclose(cc.C00_, self.Mxx_c_sym)
+        assert np.allclose(cc.C0t_, self.Mxy_c_sym)
         assert np.allclose(cc1.mean, self.msym_c)
-        assert np.allclose(cc1.cov, self.Mxx_c_sym)
-        assert np.allclose(cc1.cov_tau, self.Mxy_c_sym)
+        assert np.allclose(cc1.C00_, self.Mxx_c_sym)
+        assert np.allclose(cc1.C0t_, self.Mxy_c_sym)
 
     def test_XY_sym_removedatamean(self):
         cc = covariance_lagged(data=self.data, lag=self.tau, c0t=True, reversible=True, remove_data_mean=True,
@@ -206,13 +206,11 @@ class TestEqCovar(unittest.TestCase):
         cc1 = covariance_lagged(data=self.data, lag=self.tau, c0t=True, reversible=True, remove_data_mean=True,
                                 bessel=False, weights=self.weight_object)
         assert np.allclose(cc.mean, self.msym)
-        assert np.allclose(cc.cov, self.Mxx0_sym)
-        assert np.allclose(cc.cov_tau, self.Mxy0_sym)
+        assert np.allclose(cc.C00_, self.Mxx0_sym)
+        assert np.allclose(cc.C0t_, self.Mxy0_sym)
         assert np.allclose(cc1.mean, self.msym)
-        assert np.allclose(cc1.cov, self.Mxx0_sym)
-        assert np.allclose(cc1.cov_tau, self.Mxy0_sym)
-
-
+        assert np.allclose(cc1.C00_, self.Mxx0_sym)
+        assert np.allclose(cc1.C0t_, self.Mxy0_sym)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We can compute the instantaneous covariance on the lagged data by setting
ctt=True, but there was no property to access it.

@fabian-paul, @franknoe Do you agree, that this property name is not optimal and do you maybe have a better suggestion?