### PR TITLE
[MLMSM] use pi from msmtools tmatrix estimation

### DIFF
--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -1117,15 +1117,6 @@ class MaximumLikelihoodMSM(_MSMEstimator):
         if isinstance(P, tuple):
             P, statdist_active = P
 
-        # continue sparse or dense?
-        if not self.sparse:
-            # converting count matrices to arrays. As a result the
-            # transition matrix and all subsequent properties will be
-            # computed using dense arrays and dense matrix algebra.
-            self._C_full = self._C_full.toarray()
-            self._C_active = self._C_active.toarray()
-            P = P.toarray()
-
         # Done. We set our own model parameters, so this estimator is
         # equal to the estimated model.
         self._dtrajs_full = dtrajs

--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -1087,11 +1087,16 @@ class MaximumLikelihoodMSM(_MSMEstimator):
             statdist_active = self.statdist_constraint[self.active_set]
             statdist_active /= statdist_active.sum()  # renormalize
 
+        opt_args = {}
+        # TODO: non-rev estimate of msmtools does not comply with its own api...
+        if statdist_active is None and self.reversible:
+            opt_args['return_statdist'] = True
+
         # Estimate transition matrix
         if self.connectivity == 'largest':
             P = msmest.transition_matrix(self._C_active, reversible=self.reversible,
                                          mu=statdist_active, maxiter=self.maxiter,
-                                         maxerr=self.maxerr)
+                                         maxerr=self.maxerr, **opt_args)
         elif self.connectivity == 'none':
             # reversible mode only possible if active set is connected
             # - in this case all visited states are connected and thus
@@ -1101,7 +1106,26 @@ class MaximumLikelihoodMSM(_MSMEstimator):
                                  'because the set of all visited states is not reversibly connected')
             P = msmest.transition_matrix(self._C_active, reversible=self.reversible,
                                          mu=statdist_active,
-                                         maxiter=self.maxiter, maxerr=self.maxerr)
+                                         maxiter=self.maxiter, maxerr=self.maxerr,
+                                         **opt_args
+                                         )
+        else:
+            raise NotImplementedError(
+                'MSM estimation with connectivity=%s is currently not implemented.' % self.connectivity)
+
+        # msmtools returns a tuple for statdist_active = None.
+        if isinstance(P, tuple):
+            P, statdist_active = P
+
+        # continue sparse or dense?
+        if not self.sparse:
+            # converting count matrices to arrays. As a result the
+            # transition matrix and all subsequent properties will be
+            # computed using dense arrays and dense matrix algebra.
+            self._C_full = self._C_full.toarray()
+            self._C_active = self._C_active.toarray()
+            P = P.toarray()
+
         # Done. We set our own model parameters, so this estimator is
         # equal to the estimated model.
         self._dtrajs_full = dtrajs

--- a/pyemma/msm/tests/test_msm.py
+++ b/pyemma/msm/tests/test_msm.py
@@ -147,17 +147,18 @@ class TestMSMDoubleWell(unittest.TestCase):
         cls.statdist = nu/nu.sum()
 
         cls.tau = 10
-        cls.msmrev = estimate_markov_model(cls.dtraj, cls.tau)
-        cls.msmrevpi = estimate_markov_model(cls.dtraj, cls.tau,
+        maxerr = 1e-12
+        cls.msmrev = estimate_markov_model(cls.dtraj, cls.tau ,maxerr=maxerr)
+        cls.msmrevpi = estimate_markov_model(cls.dtraj, cls.tau,maxerr=maxerr,
                                              statdist=cls.statdist)
-        cls.msm = estimate_markov_model(cls.dtraj, cls.tau, reversible=False)
+        cls.msm = estimate_markov_model(cls.dtraj, cls.tau, reversible=False, maxerr=maxerr)
 
         """Sparse"""
-        cls.msmrev_sparse = estimate_markov_model(cls.dtraj, cls.tau, sparse=True)
-        cls.msmrevpi_sparse = estimate_markov_model(cls.dtraj, cls.tau,
+        cls.msmrev_sparse = estimate_markov_model(cls.dtraj, cls.tau, sparse=True, maxerr=maxerr)
+        cls.msmrevpi_sparse = estimate_markov_model(cls.dtraj, cls.tau,maxerr=maxerr,
                                                     statdist=cls.statdist,
                                                     sparse=True)
-        cls.msm_sparse = estimate_markov_model(cls.dtraj, cls.tau, reversible=False, sparse=True)
+        cls.msm_sparse = estimate_markov_model(cls.dtraj, cls.tau, reversible=False, sparse=True, maxerr=maxerr)
 
     # ---------------------------------
     # SCORE


### PR DESCRIPTION
For reversible estimates we get pi directly from msmtools.estimation.tmatrix. So we use it for the cases where it applies. The tests were checking eigenvalues within a numerical tolerance of 1e-12, so we set max_err accordingly.

Done with the aid of @fabian-paul 