### PR TITLE
[StreamingTransformer] added missing argument to overloaded method.

### DIFF
--- a/pyemma/coordinates/data/_base/transformer.py
+++ b/pyemma/coordinates/data/_base/transformer.py
@@ -199,8 +199,8 @@ class StreamingTransformer(Transformer, DataSource, NotifyOnChangesMixIn):
 
         self.data_producer.chunksize = int(size)
 
-    def number_of_trajectories(self):
-        return self.data_producer.number_of_trajectories()
+    def number_of_trajectories(self, stride=1):
+        return self.data_producer.number_of_trajectories(stride)
 
     def trajectory_length(self, itraj, stride=1, skip=None):
         return self.data_producer.trajectory_length(itraj, stride=stride, skip=skip)


### PR DESCRIPTION
In Iterable, this method takes a stride argument, while the overload missed this one. Only popped up in AbstractClustering objects...