### PR TITLE
Fix abstract methods

### DIFF
--- a/pyemma/coordinates/data/_base/datasource.py
+++ b/pyemma/coordinates/data/_base/datasource.py
@@ -421,7 +421,7 @@ class DataSourceIterator(metaclass=ABCMeta):
     @abstractmethod
     def close(self):
         """ closes the reader"""
-        pass
+        raise NotImplementedError()
 
     @abstractmethod
     def _select_file(self, itraj):
@@ -432,7 +432,7 @@ class DataSourceIterator(metaclass=ABCMeta):
         itraj : int
             index of trajectory to open.
         """
-        pass
+        raise NotImplementedError()
 
     def reset(self):
         """
@@ -657,7 +657,7 @@ class DataSourceIterator(metaclass=ABCMeta):
 
     @abstractmethod
     def _next_chunk(self):
-        pass
+        raise NotImplementedError()
 
     def __next__(self):
         return self.next()

--- a/pyemma/coordinates/data/_base/iterable.py
+++ b/pyemma/coordinates/data/_base/iterable.py
@@ -348,7 +348,7 @@ class Iterable(ProgressReporter, Loggable, metaclass=ABCMeta):
         :param return_trajindex: take the trajindex into account
         :return: a chunk of data if return_trajindex is False, otherwise a tuple of (trajindex, data).
         """
-        pass
+        raise NotImplementedError()
 
     def output_type(self):
         r""" By default transformers return single precision floats. """

--- a/pyemma/coordinates/data/_base/random_accessible.py
+++ b/pyemma/coordinates/data/_base/random_accessible.py
@@ -100,7 +100,7 @@ class RandomAccessStrategy(metaclass=ABCMeta):
 
     @abstractmethod
     def _handle_slice(self, idx):
-        pass
+        raise NotImplementedError()
 
     @property
     def max_slice_dimension(self):

--- a/pyemma/coordinates/data/_base/transformer.py
+++ b/pyemma/coordinates/data/_base/transformer.py
@@ -40,7 +40,7 @@ class Transformer(TransformerMixin, metaclass=ABCMeta):
     @abstractmethod
     def describe(self):
         r""" Get a descriptive string representation of this class."""
-        pass
+        raise NotImplementedError()
 
     def transform(self, X):
         r"""Maps the input data through the transformer to correspondingly
@@ -99,7 +99,7 @@ class Transformer(TransformerMixin, metaclass=ABCMeta):
             input data and d is the output dimension of this transformer.
 
         """
-        pass
+        raise NotImplementedError()
 
 
 class StreamingTransformer(Transformer, DataSource, NotifyOnChangesMixIn):
@@ -123,7 +123,7 @@ class StreamingTransformer(Transformer, DataSource, NotifyOnChangesMixIn):
 
     @abstractmethod
     def dimension(self):
-        pass
+        raise NotImplementedError()
 
     @property
     # overload of DataSource

--- a/pyemma/coordinates/tests/test_api_source.py
+++ b/pyemma/coordinates/tests/test_api_source.py
@@ -108,7 +108,12 @@ class TestApiSourceFileReader(unittest.TestCase):
 
     def test_bullshit_csv(self):
         # this file is not parseable as tabulated float file
-        self.assertRaises(IOError, api.source, self.bs)
+        with self.assertRaises(Exception) as r:
+            api.source(self.bs)
+        # depending on we have the traj info cache switched on, we get these types of exceptions.
+        self.assertIsInstance(r.exception, (IOError, ValueError))
+        self.assertIn('could not parse', str(r.exception))
+
 
 import pkg_resources
 class TestApiSourceFeatureReader(unittest.TestCase):


### PR DESCRIPTION
This could have led to problems, if child classes implemented an
abstract method just by calling super (which simply resulted in None
being returned).

