### PR TITLE
[NJobsMixin] do not query OMP_NUM_THREADS but PYEMMA_NJOBS to avoid trouble

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -29,6 +29,9 @@ your Python installation to at least version 3.5.
 - coordinates: Added the covariance property of time-lagged to CovarianceLagged. #1125
 - coordinates: clustering code modernized in C++ with pybind11 interface. #1142
 - variational: covartools code modernized in C++ with pybind11 interface. #1147
+- estimators: n_jobs setting does not look for OMP_NUM_THREADS, but for PYEMMA_NJOBS and SLURM_CPUS_ON_NODE to avoid
+  multiplying OpenMP threads with PyEMMA processes. On SLURM the number of allocated cores is used.
+  If nothing is set, the physical cpu count is considered.
 
 
 2.4 (05-19-2017)

--- a/pyemma/_base/parallel.py
+++ b/pyemma/_base/parallel.py
@@ -30,6 +30,7 @@ def get_n_jobs(logger=None):
     val = slurm_njobs or pyemma_njobs
     if not val:
         val = _from_hardware()
+    return val
 
 
 class NJobsMixIn(object):

--- a/pyemma/_base/parallel.py
+++ b/pyemma/_base/parallel.py
@@ -21,35 +21,53 @@ class NJobsMixIn(object):
 
     @n_jobs.setter
     def n_jobs(self, val):
-        """ set number of jobs/threads to use via assignment of data.
+        """ set number of jobs (processes/threads) to use.
+
+        Note that NumPy also uses concurrency (set number of threads of NumPy by setting OMP_NUM_THREADS)
+        and this will then multiply with number of jobs set here.
 
         Parameters
         ----------
         val: int or None
             a positive int for the number of jobs. Or None to usage all available resources.
 
-        If set to None, this will use all available CPUs or respect the environment variable "OMP_NUM_THREADS"
+        If set to None, this will use all available physical CPUs or respect the environment variable "PYEMMA_NJOBS"
         to obtain a job number.
 
         """
+        import psutil
+
         if val is None:
-            import os
-            import psutil
-            # TODO: aint it better to use a distinct variable for this use case eg. PYEMMA_NJOBS in order to avoid multiplying OMP threads with njobs?
-            omp_threads_from_env = os.getenv('OMP_NUM_THREADS', None)
-            if omp_threads_from_env:
-                try:
-                    val = int(omp_threads_from_env)
-                    if hasattr(self, 'logger'):
-                        self.logger.info("number of threads obtained from env variable"
-                                         " 'OMP_NUM_THREADS'=%s" % omp_threads_from_env)
-                except ValueError as ve:
-                    if hasattr(self, 'logger'):
-                        self.logger.warning("could not parse env variable 'OMP_NUM_THREADS'."
-                                            " Value='{}'. Error={}. Will use {} jobs."
-                                            .format(omp_threads_from_env, ve, val))
-                    val = psutil.cpu_count()
-            else:
-                val = psutil.cpu_count()
+
+            def _from_hardware():
+                return psutil.cpu_count(logical=False)
+
+            def _from_env(var):
+                import os
+                e = os.getenv(var, None)
+                if e:
+                    try:
+                        return int(e)
+                    except ValueError as ve:
+                        if hasattr(self, 'logger'):
+                            self.logger.warning("could not parse env variable '{var}'."
+                                                " Value='{val}'. Error={err}. Will use {val} jobs."
+                                                .format(err=ve, val=val, var=var))
+                return None
+
+            slurm_njobs = _from_env('SLURM_CPUS_ON_NODE')  # Number of CPUS on the allocated SLURM node.
+            pyemma_njobs = _from_env('PYEMMA_NJOBS')
+
+            if slurm_njobs and pyemma_njobs:
+                import warning
+                warning.warn('two settings for n_jobs from environment: PYEMMA_NJOBS and SLURM_CPUS_ON_NODE. '
+                             'Respecting the SLURM setting to avoid overprovisioning')
+
+            # slurm njobs will be used preferably.
+            val = slurm_njobs or pyemma_njobs
+            if not val:
+                val = _from_hardware()
 
         self._n_jobs = int(val)
+        # possible optimization: set affinity to first cpus to avoid switching cores and trashing the cache.
+        #psutil.Process().cpu_affinity(range(self._n_jobs))

--- a/pyemma/_base/parallel.py
+++ b/pyemma/_base/parallel.py
@@ -1,4 +1,36 @@
 
+def get_n_jobs(logger=None):
+    import psutil
+
+    def _from_hardware():
+        return psutil.cpu_count(logical=False)
+
+    def _from_env(var):
+        import os
+        e = os.getenv(var, None)
+        if e:
+            try:
+                return int(e)
+            except ValueError as ve:
+                if logger is not None:
+                    logger.warning("could not parse env variable '{var}'."
+                                   " Value='{val}'. Error={err}. Will use {val} jobs."
+                                   .format(err=ve, val=val, var=var))
+        return None
+
+    slurm_njobs = _from_env('SLURM_CPUS_ON_NODE')  # Number of CPUS on the allocated SLURM node.
+    pyemma_njobs = _from_env('PYEMMA_NJOBS')
+
+    if slurm_njobs and pyemma_njobs:
+        import warning
+        warning.warn('two settings for n_jobs from environment: PYEMMA_NJOBS and SLURM_CPUS_ON_NODE. '
+                     'Respecting the SLURM setting to avoid overprovisioning')
+
+    # slurm njobs will be used preferably.
+    val = slurm_njobs or pyemma_njobs
+    if not val:
+        val = _from_hardware()
+
 
 class NJobsMixIn(object):
     # mixin for sklearn-like estimators (estimation/ctor parameter has to contain n_jobs).
@@ -16,7 +48,6 @@ class NJobsMixIn(object):
         By setting the environment variable 'OMP_NUM_THREADS' to an integer,
         one will override the default argument of n_jobs (currently None).
         """
-        assert isinstance(self._n_jobs, int)
         return self._n_jobs
 
     @n_jobs.setter
@@ -35,39 +66,6 @@ class NJobsMixIn(object):
         to obtain a job number.
 
         """
-        import psutil
-
         if val is None:
-
-            def _from_hardware():
-                return psutil.cpu_count(logical=False)
-
-            def _from_env(var):
-                import os
-                e = os.getenv(var, None)
-                if e:
-                    try:
-                        return int(e)
-                    except ValueError as ve:
-                        if hasattr(self, 'logger'):
-                            self.logger.warning("could not parse env variable '{var}'."
-                                                " Value='{val}'. Error={err}. Will use {val} jobs."
-                                                .format(err=ve, val=val, var=var))
-                return None
-
-            slurm_njobs = _from_env('SLURM_CPUS_ON_NODE')  # Number of CPUS on the allocated SLURM node.
-            pyemma_njobs = _from_env('PYEMMA_NJOBS')
-
-            if slurm_njobs and pyemma_njobs:
-                import warning
-                warning.warn('two settings for n_jobs from environment: PYEMMA_NJOBS and SLURM_CPUS_ON_NODE. '
-                             'Respecting the SLURM setting to avoid overprovisioning')
-
-            # slurm njobs will be used preferably.
-            val = slurm_njobs or pyemma_njobs
-            if not val:
-                val = _from_hardware()
-
+            val = get_n_jobs(logger=getattr(self, 'logger'))
         self._n_jobs = int(val)
-        # possible optimization: set affinity to first cpus to avoid switching cores and trashing the cache.
-        #psutil.Process().cpu_affinity(range(self._n_jobs))

--- a/pyemma/coordinates/clustering/tests/test_assign.py
+++ b/pyemma/coordinates/clustering/tests/test_assign.py
@@ -189,7 +189,7 @@ class TestClusterAssign(unittest.TestCase):
 
     def test_wrong_centers_argument2(self):
         dim = 3
-        data = np.empty((100,dim))
+        data = np.empty((100, dim))
         centers = np.empty(1)
 
         with self.assertRaises(ValueError):
@@ -197,16 +197,16 @@ class TestClusterAssign(unittest.TestCase):
 
     def test_threads_env_num_threads_fixed(self):
         desired_n_jobs = 2
-        with temporary_env('OMP_NUM_THREADS', 0):
-            assert os.environ['OMP_NUM_THREADS'] == '0'
+        with temporary_env('PYEMMA_NJOBS', 0):
+            assert os.environ['PYEMMA_NJOBS'] == '0'
             res = coor.assign_to_centers(self.X, self.centers_big, n_jobs=desired_n_jobs, return_dtrajs=False)
             self.assertEqual(res.n_jobs, desired_n_jobs)
 
     def test_threads_env_num_threads_fixed_def_arg(self):
         """ tests that if no njobs arg is given (None) we fall back to OMP_NUM_THREADS """
         desired_n_jobs = 3
-        with temporary_env('OMP_NUM_THREADS', desired_n_jobs):
-            assert os.environ['OMP_NUM_THREADS'] == str(desired_n_jobs)
+        with temporary_env('PYEMMA_NJOBS', desired_n_jobs):
+            assert os.environ['PYEMMA_NJOBS'] == str(desired_n_jobs)
             # note: we want another job number here, but it will be ignored!
             res = coor.assign_to_centers(self.X, self.centers_big, n_jobs=None, return_dtrajs=False)
             self.assertEqual(res.n_jobs, desired_n_jobs)
@@ -214,13 +214,17 @@ class TestClusterAssign(unittest.TestCase):
     def test_threads_omp_env_arg_borked(self):
         """ if the env var can not be interpreted as int, fall back to one thread. """
         expected = 3
-        with patch('psutil.cpu_count', lambda: expected), temporary_env('OMP_NUM_THREADS', 'this is not right'):
+        def fake_cpu_count(*args, **kw):
+            return expected
+        with patch('psutil.cpu_count', fake_cpu_count), temporary_env('OMP_NUM_THREADS', 'this is not right'):
             res = coor.assign_to_centers(self.X, self.centers_big, n_jobs=None, return_dtrajs=False)
             self.assertEqual(res.n_jobs, expected)
 
     def test_threads_cpu_count_def_arg(self):
         expected = int(os.getenv('OMP_NUM_THREADS', 3))
-        with patch('psutil.cpu_count', lambda: expected):
+        def fake_cpu_count(*args, **kw):
+            return expected
+        with patch('psutil.cpu_count', fake_cpu_count):
             res = coor.assign_to_centers(self.X, self.centers_big, return_dtrajs=False)
         self.assertEqual(res.n_jobs, expected)
 


### PR DESCRIPTION
Prior this change the setting of njobs multiplied with OMP_NUM_THREADS.

In addition SLURM_CPUS_ON_NODE is queried to avoid creating more threads
than allocated cpus (which hurts performance).