### PR TITLE
fix for Initialized bhmm

### DIFF
--- a/pyemma/msm/estimators/bayesian_hmsm.py
+++ b/pyemma/msm/estimators/bayesian_hmsm.py
@@ -166,22 +166,21 @@ class BayesianHMSM(_MaximumLikelihoodHMSM, _SampledHMSM, ProgressReporterMixin):
             self.observe_nonempty = default_observe_nonempty
         else:  # if given another initialization, must copy its attributes
             copy_attributes = ['_nstates', '_nstates_obs_full', '_nstates_obs',
-                               '_reversible', '_pi',
-                               '_dtrajs_full', '_dtrajs_lagged', '_dtrajs_obs',
+                               '_reversible', '_pi', '_dtrajs_full', '_dtrajs_lagged', '_dtrajs_obs',
                                '_observable_set', 'likelihoods', 'likelihood',
                                'hidden_state_probabilities', 'hidden_state_trajectories',
                                'count_matrix', 'initial_count', 'initial_distribution', '_active_set']
-            check_user_choises = ['lag', '_nstates']
+            check_user_choices = ['lag', '_nstates']
 
             # check if nstates and lag are compatible
-            for attr in check_user_choises:
+            for attr in check_user_choices:
                 if not self.__getattribute__(attr) == self.init_hmsm.__getattribute__(attr):
                     raise UserWarning('BayesianHMSM cannot be initialized with init_hmsm with '
-                    + 'incompatible lag or nstates.')
+                                      + 'incompatible lag or nstates.')
 
             # update self with estimates from init_hmsm
             self.__dict__.update(
-            {k: i for k, i in self.init_hmsm.__dict__.items() if k in copy_attributes})
+                {k: i for k, i in self.init_hmsm.__dict__.items() if k in copy_attributes})
 
             # as mentioned in the docstring, take init_hmsm observed set observation probabilities
             self.observe_nonempty = False

--- a/pyemma/msm/estimators/bayesian_hmsm.py
+++ b/pyemma/msm/estimators/bayesian_hmsm.py
@@ -109,8 +109,10 @@ class BayesianHMSM(_MaximumLikelihoodHMSM, _SampledHMSM, ProgressReporterMixin):
               sample, the sampler cannot recover and that transition will never
               be sampled again. This option is not recommended unless you have
               a small HMM and a lot of data.
-        init_hmsm : default=None
-            deprecated.
+        init_hmsm : :class:`HMSM <pyemma.msm.models.HMSM>`, default=None
+            Single-point estimate of HMSM object around which errors will be evaluated.
+            If None is give an initial estimate will be automatically generated using the
+            given parameters.
         store_hidden : bool, optional, default=False
             store hidden trajectories in sampled HMMs
         show_progress : bool, default=True
@@ -138,7 +140,7 @@ class BayesianHMSM(_MaximumLikelihoodHMSM, _SampledHMSM, ProgressReporterMixin):
         self.transition_matrix_prior = transition_matrix_prior
         self.nsamples = nsamples
         if init_hmsm is not None:
-            raise NotImplementedError('Currently unsupported')
+            assert issubclass(init_hmsm.__class__, _MaximumLikelihoodHMSM), 'hmsm must be of type MaximumLikelihoodHMSM'
         self.init_hmsm = init_hmsm
         self.conf = conf
         self.store_hidden = store_hidden
@@ -163,7 +165,27 @@ class BayesianHMSM(_MaximumLikelihoodHMSM, _SampledHMSM, ProgressReporterMixin):
             self.mincount_connectivity = default_mincount_connectivity
             self.observe_nonempty = default_observe_nonempty
         else:  # if given another initialization, must copy its attributes
-            raise NotImplementedError()
+            # TODO: this is too tedious - need to automatize parameter+result copying between estimators.
+            self.nstates = self.init_hmsm.nstates
+            self.reversible = self.init_hmsm.is_reversible
+            self.stationary = self.init_hmsm.stationary
+            # trajectories
+            self._dtrajs_full = self.init_hmsm._dtrajs_full
+            self._dtrajs_lagged = self.init_hmsm._dtrajs_lagged
+            self._observable_set = self.init_hmsm._observable_set
+            self._dtrajs_obs = self.init_hmsm._dtrajs_obs
+            # MLE estimation results
+            self.likelihoods = self.init_hmsm.likelihoods  # Likelihood history
+            self.likelihood = self.init_hmsm.likelihood
+            self.hidden_state_probabilities = self.init_hmsm.hidden_state_probabilities  # gamma variables
+            self.hidden_state_trajectories = self.init_hmsm.hidden_state_trajectories  # Viterbi path
+            self.count_matrix = self.init_hmsm.count_matrix  # hidden count matrix
+            self.initial_count = self.init_hmsm.initial_count  # hidden init count
+            self.initial_distribution = self.init_hmsm.initial_distribution
+            self._active_set = self.init_hmsm._active_set
+            # update HMM Model
+            self.update_model_params(P=self.init_hmsm.transition_matrix, pobs=self.init_hmsm.observation_probabilities,
+                                     dt_model=TimeUnit(self.dt_traj).get_scaled(self.lag))
 
         # check if we have a valid initial model
         import msmtools.estimation as msmest
@@ -209,13 +231,14 @@ class BayesianHMSM(_MaximumLikelihoodHMSM, _SampledHMSM, ProgressReporterMixin):
             self._progress_force_finish(stage=0)
 
         # Samples
-        sample_inp = [(m.transition_matrix, m.stationary_distribution, m.output_probabilities)
-                      for m in sampled_hmm.sampled_hmms]
+        sample_Ps = [sampled_hmm.sampled_hmms[i].transition_matrix for i in range(self.nsamples)]
+        sample_pis = [sampled_hmm.sampled_hmms[i].stationary_distribution for i in range(self.nsamples)]
+        sample_pobs = [sampled_hmm.sampled_hmms[i].output_model.output_probabilities for i in range(self.nsamples)]
         samples = []
-        for P, pi, pobs in sample_inp:  # restrict to observable set if necessary
-            Bobs = pobs[:, self.observable_set]
-            pobs = Bobs / Bobs.sum(axis=1)[:, None]  # renormalize
-            samples.append(_HMSM(P, pobs, pi=pi, dt_model=self.dt_model))
+        for i in range(self.nsamples):  # restrict to observable set if necessary
+            Bobs = sample_pobs[i][:, self.observable_set]
+            sample_pobs[i] = Bobs / Bobs.sum(axis=1)[:, None]  # renormalize
+            samples.append(_HMSM(sample_Ps[i], sample_pobs[i], pi=sample_pis[i], dt_model=self.dt_model))
 
         # store results
         self.sampled_trajs = [sampled_hmm.sampled_hmms[i].hidden_state_trajectories for i in range(self.nsamples)]
@@ -241,9 +264,10 @@ class BayesianHMSM(_MaximumLikelihoodHMSM, _SampledHMSM, ProgressReporterMixin):
         # call submodel on MaximumLikelihoodHMSM
         _MaximumLikelihoodHMSM.submodel(self, states=states, obs=obs, mincount_connectivity=mincount_connectivity)
         # if samples set, also reduce them
-        if hasattr(self, 'samples') and self.samples is not None:
-            subsamples = [sample.submodel(states=self.active_set, obs=self.observable_set)
-                          for sample in self.samples]
-            self.update_model_params(samples=subsamples)
+        if hasattr(self, 'samples'):
+            if self.samples is not None:
+                subsamples = [sample.submodel(states=self.active_set, obs=self.observable_set)
+                              for sample in self.samples]
+                self.update_model_params(samples=subsamples)
         # return
         return self

--- a/pyemma/msm/estimators/bayesian_hmsm.py
+++ b/pyemma/msm/estimators/bayesian_hmsm.py
@@ -178,6 +178,10 @@ class BayesianHMSM(_MaximumLikelihoodHMSM, _SampledHMSM, ProgressReporterMixin):
                     raise UserWarning('BayesianHMSM cannot be initialized with init_hmsm with '
                                       + 'incompatible lag or nstates.')
 
+            if not _np.array_equal(dtrajs, self.init_hmsm._dtrajs_full):
+                raise NotImplementedError('Bayesian HMM estimation with init_hmsm is currently only implemented ' +
+                                          'if applied to the same data.')
+
             # TODO: implement more elegant solution to copy-pasting effective stride evaluation from ML HMM.
             # EVALUATE STRIDE
             if self.stride == 'effective':
@@ -201,10 +205,6 @@ class BayesianHMSM(_MaximumLikelihoodHMSM, _SampledHMSM, ProgressReporterMixin):
                 _nstates_obs = _number_of_states(dtrajs_lagged_strided, only_used=True)
                 _nstates_obs_full = _number_of_states(dtrajs)
 
-                if _np.setxor1d(_np.concatenate(dtrajs),
-                                _np.concatenate(self.init_hmsm._dtrajs_full)).size != 0:
-                    raise UserWarning('Set of observed microstates in discrete trajectories must match to ' +
-                                      'the one used for init_hmsm estimation.')
                 if _np.setxor1d(_np.concatenate(dtrajs_lagged_strided),
                                  _np.concatenate(self.init_hmsm._dtrajs_lagged)).size != 0:
                     raise UserWarning('Choice of stride has excluded a different set of microstates than in ' +

--- a/pyemma/msm/tests/test_bayesian_hmsm.py
+++ b/pyemma/msm/tests/test_bayesian_hmsm.py
@@ -328,7 +328,7 @@ class TestBHMMSpecialCases(unittest.TestCase):
 
         init_hmm = pyemma.msm.estimate_hidden_markov_model(obs, 2, 10)
         bay_hmm = pyemma.msm.estimators.BayesianHMSM(nstates=init_hmm.nstates, lag=init_hmm.lag,
-                                                     init_hmsm=init_hmm)
+                                                     stride=init_hmm.stride, init_hmsm=init_hmm)
         bay_hmm.estimate(obs)
 
         assert np.isclose(bay_hmm.stationary_distribution.sum(), 1)

--- a/pyemma/msm/tests/test_bayesian_hmsm.py
+++ b/pyemma/msm/tests/test_bayesian_hmsm.py
@@ -333,6 +333,17 @@ class TestBHMMSpecialCases(unittest.TestCase):
 
         assert np.isclose(bay_hmm.stationary_distribution.sum(), 1)
 
+    def test_initialized_bhmm_newstride(self):
+        import pyemma.msm
+        obs = np.random.randint(0, 2, size=1000)
+
+        init_hmm = pyemma.msm.estimate_hidden_markov_model(obs, 2, 10)
+        bay_hmm = pyemma.msm.estimators.BayesianHMSM(nstates=init_hmm.nstates, lag=init_hmm.lag,
+                                                     stride='effective', init_hmsm=init_hmm)
+        bay_hmm.estimate(obs)
+
+        assert np.isclose(bay_hmm.stationary_distribution.sum(), 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/msm/tests/test_bayesian_hmsm.py
+++ b/pyemma/msm/tests/test_bayesian_hmsm.py
@@ -320,5 +320,19 @@ class TestBHMMSpecialCases(unittest.TestCase):
             assert strajs[0][0] == 2
             assert strajs[0][6] == 2
 
+    def test_initialized_bhmm(self):
+        import pyemma.datasets
+        import pyemma.msm
+
+        obs = pyemma.datasets.load_2well_discrete().dtraj_T100K_dt10
+
+        init_hmm = pyemma.msm.estimate_hidden_markov_model(obs, 2, 10)
+        bay_hmm = pyemma.msm.estimators.BayesianHMSM(nstates=init_hmm.nstates, lag=init_hmm.lag,
+                                                     init_hmsm=init_hmm)
+        bay_hmm.estimate(obs)
+
+        assert np.isclose(bay_hmm.stationary_distribution.sum(), 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes the Bayesian HMM estimation initialized with a ML HMM #1189.

- is the `self.observe_nonempty` handled correctly?
- are there any wrong implications that I don't immediately see by copying the attributes listed in the `copy_attributes` list?
- should we check for more user choices?