### PR TITLE
Add pcca model

### DIFF
--- a/pyemma/msm/models/msm.py
+++ b/pyemma/msm/models/msm.py
@@ -886,7 +886,7 @@ class MSM(_Model):
         Notes
         -----
         If you coarse grain with PCCA++, the order of the obtained memberships
-        might not be preserved. This also applies for :func:`metastable_memberships`, 
+        might not be preserved. This also applies for :func:`metastable_memberships`,
         :func:`metastable_distributions`, :func:`metastable_sets`, :func:`metastable_assignments`
 
         References
@@ -900,19 +900,19 @@ class MSM(_Model):
         m = int(m)
         # can we do it?
         if not self.reversible:
-            raise ValueError(
-                'Cannot compute PCCA for non-reversible matrices. Set reversible=True when constructing the MSM.')
+            raise ValueError('Cannot compute PCCA for non-reversible matrices. '
+                             'Set reversible=True when constructing the MSM.')
 
-        from msmtools.analysis.api import _pcca_object as PCCA
+        from pyemma.msm.models.pcca import PCCA
         # ensure that we have a pcca object with the right number of states
         try:
             # this will except if we don't have a pcca object
             if self._pcca.n_metastable != m:
                 # incorrect number of states - recompute
-                self._pcca = PCCA(self.transition_matrix, m)
+                self._pcca = PCCA(self, m)
         except AttributeError:
             # didn't have a pcca object yet - compute
-            self._pcca = PCCA(self.transition_matrix, m)
+            self._pcca = PCCA(self, m)
 
         # set metastable properties
         self._metastable_computed = True

--- a/pyemma/msm/models/msm.py
+++ b/pyemma/msm/models/msm.py
@@ -907,8 +907,8 @@ class MSM(_Model):
         # ensure that we have a pcca object with the right number of states
         try:
             # this will except if we don't have a pcca object
-            if self._pcca.n_metastable != m:
-                # incorrect number of states - recompute
+            if self._pcca.n_metastable != m or self._pcca.P is not self.P:
+                # incorrect number of states or new transition matrix -> recompute
                 self._pcca = PCCA(self, m)
         except AttributeError:
             # didn't have a pcca object yet - compute

--- a/pyemma/msm/models/pcca.py
+++ b/pyemma/msm/models/pcca.py
@@ -1,0 +1,121 @@
+import warnings
+
+import numpy as np
+
+from pyemma._base.model import Model
+
+
+class PCCA(Model):
+    """
+    PCCA+ spectral clustering method with optimized memberships [1]_
+    Clusters the first m eigenvectors of a transition matrix in order to cluster the states.
+    This function does not assume that the transition matrix is fully connected. Disconnected sets
+    will automatically define the first metastable states, with perfect membership assignments.
+    Parameters
+    ----------
+    P : ndarray (n,n)
+        Transition matrix.
+    m : int
+        Number of clusters to group to.
+    References
+    ----------
+    [1] S. Roeblitz and M. Weber, Fuzzy spectral clustering by PCCA+:
+        application to Markov state models and data classification.
+        Adv Data Anal Classif 7, 147-179 (2013).
+    [2] F. Noe, multiset PCCA and HMMs, in preparation.
+    [3] F. Noe, H. Wu, J.-H. Prinz and N. Plattner:
+        Projected and hidden Markov models for calculating kinetics and metastable states of complex molecules
+        J. Chem. Phys. 139, 184114 (2013)
+    """
+
+    def __init__(self, msm, m):
+        # remember input
+        P = msm.P
+        if msm.sparse:
+            warnings.warn('pcca is only implemented for dense matrices, '
+                          'converting sparse transition matrix to dense ndarray.')
+            P = msm.P.toarray()
+        self.P = P
+        self.m = m
+
+        # pcca coarse-graining
+        # --------------------
+        # PCCA memberships
+        # TODO: can be improved. pcca computes stationary distribution internally, we don't need to compute it twice.
+        from msmtools.analysis.dense.pcca import pcca
+        self._M = pcca(P, m)
+
+        # stationary distribution
+        self._pi = msm.pi
+
+        # coarse-grained stationary distribution
+        self._pi_coarse = np.dot(self._M.T, self._pi)
+
+        # HMM output matrix
+        self._B = np.dot(np.dot(np.diag(1.0 / self._pi_coarse), self._M.T), np.diag(self._pi))
+        # renormalize B to make it row-stochastic
+        self._B /= self._B.sum(axis=1)[:, None]
+        self._B /= self._B.sum(axis=1)[:, None]
+
+        # coarse-grained transition matrix
+        W = np.linalg.inv(np.dot(self._M.T, self._M))
+        A = np.dot(np.dot(self._M.T, P), self._M)
+        self._P_coarse = np.dot(W, A)
+
+        # symmetrize and renormalize to eliminate numerical errors
+        X = np.dot(np.diag(self._pi_coarse), self._P_coarse)
+        self._P_coarse = X / X.sum(axis=1)[:, None]
+
+    @property
+    def transition_matrix(self):
+        return self.P
+
+    @property
+    def stationary_probability(self):
+        return self._pi
+
+    @property
+    def n_metastable(self):
+        return self.m
+
+    @property
+    def memberships(self):
+        return self._M
+
+    @property
+    def output_probabilities(self):
+        return self._B
+
+    @property
+    def coarse_grained_transition_matrix(self):
+        return self._P_coarse
+
+    @property
+    def coarse_grained_stationary_probability(self):
+        return self._pi_coarse
+
+    @property
+    def metastable_assignment(self):
+        """
+        Crisp clustering using PCCA. This is only recommended for visualization purposes. You *cannot* compute any
+        actual quantity of the coarse-grained kinetics without employing the fuzzy memberships!
+        Returns
+        -------
+        For each microstate, the metastable state it is located in.
+        """
+        return np.argmax(self.memberships, axis=1)
+
+    @property
+    def metastable_sets(self):
+        """
+        Crisp clustering using PCCA. This is only recommended for visualization purposes. You *cannot* compute any
+        actual quantity of the coarse-grained kinetics without employing the fuzzy memberships!
+        Returns
+        -------
+        A list of length equal to metastable states. Each element is an array with microstate indexes contained in it
+        """
+        res = []
+        assignment = self.metastable_assignment
+        for i in range(self.m):
+            res.append(np.where(assignment == i)[0])
+        return res

--- a/pyemma/msm/tests/test_msm.py
+++ b/pyemma/msm/tests/test_msm.py
@@ -99,6 +99,14 @@ class TestMSMSimple(unittest.TestCase):
         assert_allclose(self.mu_MSM, msm.stationary_distribution)
         assert_allclose(self.ts[1:], msm.timescales(self.k - 1))
 
+    def test_pcca_recompute(self):
+        msm = estimate_markov_model(self.dtraj, self.tau)
+        pcca1 = msm.pcca(2)
+        msm.estimate(self.dtraj, lag=self.tau + 1)
+        pcca2 = msm.pcca(2)
+        assert pcca2 is not pcca1
+
+
 class TestMSMRevPi(unittest.TestCase):
     r"""Checks if the MLMSM correctly handles the active set computation
     if a stationary distribution is given"""
@@ -117,8 +125,8 @@ class TestMSMRevPi(unittest.TestCase):
         msm = estimate_markov_model(dtraj, 1, statdist=pi_valid)
         self.assertTrue(np.all(msm.active_set==active_set))
         with self.assertRaises(ValueError):
-            msm = estimate_markov_model(dtraj, 1, statdist=pi_invalid)       
-        
+            msm = estimate_markov_model(dtraj, 1, statdist=pi_invalid)
+
     def test_valid_trajectory(self):
         pi = np.array([0.1, 0.0, 0.9])
         dtraj_invalid = np.array([1, 1, 1, 1, 1, 1, 1])
@@ -135,9 +143,9 @@ class TestMSMDoubleWell(unittest.TestCase):
     def setUpClass(cls):
         import pyemma.datasets
         cls.dtraj = pyemma.datasets.load_2well_discrete().dtraj_T100K_dt10
-        nu = 1.*np.bincount(cls.dtraj)        
+        nu = 1.*np.bincount(cls.dtraj)
         cls.statdist = nu/nu.sum()
-        
+
         cls.tau = 10
         cls.msmrev = estimate_markov_model(cls.dtraj, cls.tau)
         cls.msmrevpi = estimate_markov_model(cls.dtraj, cls.tau,
@@ -218,7 +226,7 @@ class TestMSMDoubleWell(unittest.TestCase):
     def test_sparse(self):
         self._sparse(self.msmrev_sparse)
         self._sparse(self.msmrevpi_sparse)
-        self._sparse(self.msm_sparse)        
+        self._sparse(self.msm_sparse)
 
     def _lagtime(self, msm):
         assert (msm.lagtime == self.tau)
@@ -307,10 +315,10 @@ class TestMSMDoubleWell(unittest.TestCase):
     def test_count_matrix_active(self):
         self._count_matrix_active(self.msmrev)
         self._count_matrix_active(self.msmrevpi)
-        self._count_matrix_active(self.msm) 
+        self._count_matrix_active(self.msm)
         self._count_matrix_active(self.msmrev_sparse)
         self._count_matrix_active(self.msmrevpi_sparse)
-        self._count_matrix_active(self.msm_sparse) 
+        self._count_matrix_active(self.msm_sparse)
 
     def _count_matrix_full(self, msm):
         C = msm.count_matrix_full
@@ -489,7 +497,7 @@ class TestMSMDoubleWell(unittest.TestCase):
 
     def _eigenvectors_left(self, msm):
         if not msm.is_sparse:
-            L = msm.eigenvectors_left() 
+            L = msm.eigenvectors_left()
             k = msm.nstates
         else:
             k = 4
@@ -674,12 +682,12 @@ class TestMSMDoubleWell(unittest.TestCase):
 
     def test_pcca_assignment(self):
         self._pcca_assignment(self.msmrev)
-        self._pcca_assignment(self.msm)   
+        self._pcca_assignment(self.msm)
         with warnings.catch_warnings(record=True) as w:
             self._pcca_assignment(self.msmrev_sparse)
         with warnings.catch_warnings(record=True) as w:
             self._pcca_assignment(self.msm_sparse)
-        
+
 
     def _pcca_distributions(self, msm):
         if msm.is_reversible:
@@ -703,7 +711,7 @@ class TestMSMDoubleWell(unittest.TestCase):
         self._pcca_distributions(self.msm)
         self._pcca_distributions(self.msmrev_sparse)
         self._pcca_distributions(self.msm_sparse)
-        
+
 
     def _pcca_memberships(self, msm):
         if msm.is_reversible:
@@ -763,7 +771,7 @@ class TestMSMDoubleWell(unittest.TestCase):
         if msm.is_sparse:
             k = 4
         else:
-            k = msm.nstates            
+            k = msm.nstates
         # raise assertion error because size is wrong:
         maxtime = 100000
         a = [1, 2, 3]
@@ -796,7 +804,7 @@ class TestMSMDoubleWell(unittest.TestCase):
         if msm.is_sparse:
             k = 4
         else:
-            k = msm.nstates            
+            k = msm.nstates
         pi_perturbed = (msm.stationary_distribution ** 2)
         pi_perturbed /= pi_perturbed.sum()
         a = list(range(msm.nstates))
@@ -820,7 +828,7 @@ class TestMSMDoubleWell(unittest.TestCase):
         if msm.is_sparse:
             k = 4
         else:
-            k = msm.nstates       
+            k = msm.nstates
 
         if msm.is_reversible:
             # raise assertion error because size is wrong:
@@ -865,7 +873,7 @@ class TestMSMDoubleWell(unittest.TestCase):
         if msm.is_sparse:
             k = 4
         else:
-            k = msm.nstates       
+            k = msm.nstates
 
         if msm.is_reversible:
             # raise assertion error because size is wrong:


### PR DESCRIPTION
This is important for serialization and makes the code more consistent. With the same argument, we added msmtools.ReactiveFlux to pyemma.

Fixed a bug, where pcca was not recomputed although transition matrix has changed.