### PR TITLE
[ci] built against an old numpy, test against recent.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,8 @@ env:
     - PYEMMA_NJOBS=1
     - MACOSX_DEPLOYMENT_TARGET=10.9
   matrix:
-    - CONDA_PY=3.5 CONDA_NPY=1.11
-    - CONDA_PY=3.6 CONDA_NPY=1.12
-    - CONDA_PY=3.6 CONDA_NPY=1.13
+    - CONDA_PY=3.5
+    - CONDA_PY=3.6
 
 before_install:
 - source devtools/ci/travis/install_miniconda.sh
@@ -36,4 +35,4 @@ script:
 - conda build -q devtools/conda-recipe
 
 after_script:
-- bash <(curl -s https://codecov.io/bash) -f $HOME/coverage.xml -e CONDA_PY,CONDA_NPY
+- bash <(curl -s https://codecov.io/bash) -f $HOME/coverage.xml -e CONDA_PY

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,11 +4,9 @@ environment:
     # /E:ON and /V:ON options are not enabled in the batch script intepreter
     # See: http://stackoverflow.com/a/13751649/163740
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\devtools\\ci\\appveyor\\run_with_env.cmd"
-    CONDA_NPY: "113"
     PYTHONHASHSEED: "0"
 
   matrix:
-
     - MINICONDA_PYTHON: "C:\\Miniconda35"
       CONDA_PY: "35"
 

--- a/circle.yml
+++ b/circle.yml
@@ -16,11 +16,10 @@ checkout:
 dependencies:
   override:
     - devtools/ci/circle/install_miniconda.sh
-    - conda config --add channels conda-forge 
+    - conda config --add channels conda-forge
     - conda config --set always_yes true
     - conda install conda-build
 
 test:
   override:
-    - conda build devtools/conda-recipe --numpy=112 --python=3.6
-
+    - conda build devtools/conda-recipe --python=3.6

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - python >=3
     - scipy
     - setuptools
+    - gcc # [ not win ]
   run:
     - bhmm >=0.6,<0.7
     - decorator >=4.0.0

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -14,15 +14,16 @@ build:
    - CIRCLE_TEST_REPORTS
    - OMP_NUM_THREADS
    - PYEMMA_NJOBS
-  script: python -B setup.py install --single-version-externally-managed --record record.txt
+  script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
   build:
     - cython
-    - gcc # [linux or osx]
     - mdtraj
-    - numpy x.x
-    - pybind11
+    # actually we could build with np18, but fastcluster (dep of mdtraj, we link against) is only avail for 1.9
+    - numpy 1.9.*  # [not (win and (py35 or py36))]
+    - numpy 1.9.*  # [win and py35]
+    - numpy 1.11.*  # [win and py36]
     - python >=3
     - scipy
     - setuptools
@@ -33,7 +34,9 @@ requirements:
     - matplotlib
     - mdtraj
     - msmtools >=1.2
-    - numpy x.x
+    - numpy >=1.9  # [not (win and (py35 or py36))]
+    - numpy >=1.9  # [win and py35]
+    - numpy >=1.11  # [win and py36]
     - pathos
     - psutil >3.1
     - python >=3


### PR DESCRIPTION
some clever people at conda-forge figured out that ABI of numpy has not changed since version 1.8 or so. All the years we have built against different numpy versions to be safe...