### PR TITLE
added miniconda and pyemma install script [ci skip]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,24 +45,28 @@ If you use PyEMMA in scientific work, please cite:
 
 Installation
 ------------
+If you want to use Miniconda on Linux or OSX, you can run this script to download and install everything::
+
+   curl -s https://raw.githubusercontent.com/markovmodel/PyEMMA/devel/install_miniconda%2Bpyemma.sh | bash
+
+If you have Anaconda/Miniconda installed, use the following::
+
+   conda install -c conda-forge pyemma
+
 With pip::
 
    pip install pyemma
-
-with conda::
-
-   conda install -c conda-forge pyemma
 
 or install latest devel branch with pip::
 
    pip install git+https://github.com/markovmodel/PyEMMA.git@devel
 
-For a complete guide to installation, please have a look at the version 
+For a complete guide to installation, please have a look at the version
 `online <http://www.emma-project.org/latest/INSTALL.html>`__ or offline in file
 doc/source/INSTALL.rst
 
 To build the documentation offline you should install the requirements with::
-   
+
    pip install -r requirements-build-doc.txt
 
 Then build with make::
@@ -72,7 +76,7 @@ Then build with make::
 
 Support and development
 -----------------------
-For bug reports/suggestions/complaints please file an issue on 
+For bug reports/suggestions/complaints please file an issue on
 `GitHub <http://github.com/markovmodel/PyEMMA>`__.
 
 Or start a discussion on our mailing list: pyemma-users@lists.fu-berlin.de

--- a/doc/source/INSTALL.rst
+++ b/doc/source/INSTALL.rst
@@ -18,19 +18,31 @@ and this approach saves you many headaches and problems that frequently arise in
 methods. You are free to use a different approach (see below) if you know how to sort out problems,
 but play at your own risk.
 
-If you already have a conda installation, directly go to step 3:
 
-1. Download and install miniconda for Python 2.7 or 3+, 32 or 64 bit depending on your system. Note that
-   you can still use Python 2.7, however we recommend to use Python3:
+If you want to use Miniconda on Linux or OSX, you can run this script to download and install everything::
+
+   curl -s https://raw.githubusercontent.com/markovmodel/PyEMMA/devel/install_miniconda%2Bpyemma.sh | bash
+
+After the script finishes, you have a miniconda installation and inside of this a 'pyemma' environment.
+You need to activate the new environment by invoking::
+
+   source activate pyemma
+
+in order to work with this new environment. An environment encapsulates all software used by PyEMMA and is independent
+of other things. Further reading `here <https://conda.io/docs/user-guide/concepts.html#conda-environments>`_.
+
+If you want to download and install manually, please perform the following steps:
+
+If you already have a conda installation, directly go to step 3.
+
+1. Download and install miniconda for Python3, 32 or 64 bit depending on your system.
 
    http://conda.pydata.org/miniconda.html
-
 
    For Windows users, who do not know what to choose for 32 or 64 bit, it is strongly
    recommended to read the second question of this FAQ first:
 
    http://windows.microsoft.com/en-us/windows/32-bit-and-64-bit-windows
-
 
    Run the installer and select **yes** to add conda to the **PATH** variable.
 
@@ -118,7 +130,7 @@ by us. If unsure, use the Anaconda installation.
 1. Ensure that you fulfill the following prerequisites:
 
    * C/C++ compiler
-   * setuptools > 18 
+   * setuptools > 18
    * cython >= 0.22
    * numpy >= 1.6
    * scipy >= 0.11
@@ -133,7 +145,7 @@ by us. If unsure, use the Anaconda installation.
        pip install --upgrade numpy
        pip install --upgrade scipy
        pip install --upgrade matplotlib
-       
+
    Note that if pip finds a newer version, it will trigger an update which will
    most likely involve compilation.
    Especially NumPy and SciPy are hard to build. You might want to take a look at
@@ -176,11 +188,11 @@ Frequently Asked Questions (FAQ)
 ================================
 
 * Q: Installation went fine with conda, but import pyemma leads to the following error: ::
-   
+
        ImportError: No module named PySide
-       
+
   A: install pyside manually with conda::
-     
+
      conda install pyside
 
 * Q: My conda installation raises errors during import
@@ -218,14 +230,14 @@ Frequently Asked Questions (FAQ)
   during "import xyz".
 
   A: Possible answer 1: you have probably mixed 32 and 64 bit. Using 32 bit Python
-     on 64 bit Windows is fine, but not the other way around. 
+     on 64 bit Windows is fine, but not the other way around.
      Possible answer 2: Do you have Python2 and Python3 on the same computer?
      To figure that you, open a cmd prompt and type in::
 
          where python
          "X:\\somepath\\miniconda2\\Scripts\\python.exe"
-    
+
      This should only display one line like. If it is displaying more than one .exe,
      you either know what you are doing or you should remove one installation (eg. decide,
-     which branch of Python [2 or 3] to keep). 
+     which branch of Python [2 or 3] to keep).
 

--- a/install_miniconda+pyemma.sh
+++ b/install_miniconda+pyemma.sh
@@ -96,16 +96,18 @@ function install_pyemma {
     packages="pyemma numpy"
     if [ ! minimal ]; then
         # add optional packages.
-        packages="$packages notebook"
+        packages="$packages notebook ipython"
     fi
     # we add numpy here to get the openblas variant (instead of MKL).
     echo "creating pyemma environment..."
     conda=${target}/bin/conda
-    # &> /dev/null
     if [[ -z $($conda env list | grep ${env_name}) ]]; then
         echo "env '$env_name' does not exist. Create new one."
         $conda create -n ${env_name} ${packages} -y -c conda-forge
+	source activate ${env_name}
         $conda config --env --add channels conda-forge
+	echo "execute the following command to activate your newly created pyemma environment:"
+	echo "> source activate ${env_name}"
     else
         echo "environment with name='${env_name}' already exists. Please specify a different name by -e new_name"
         exit 1
@@ -113,7 +115,7 @@ function install_pyemma {
 }
 
 # probe for conda, install miniconda otherwise.
-if hash conda 2>/dev/null && [ $ignore -eq 0 ]; then
+if [ -x "$(command -v conda)" ] && [ $ignore -eq 1 ]; then
     echo "Found conda. Will install to a new environment named ${env_name}"
     install_pyemma
 else

--- a/install_miniconda+pyemma.sh
+++ b/install_miniconda+pyemma.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# This script installs Miniconda and PyEMMA. If conda is already available, we install PyEMMA in a new environment.
+# By default, we use the name 'pyemma' as environment name.
+# The desired output folders and env names can be set by arguments.
+# Author: Martin Scherer, 2018
+
+function usage {
+    echo "Usage of installation script:"
+    echo "bash $0 -t 'miniconda_target_directory' path to Miniconda"
+    echo "bash $0 -e 'conda_environment' environment name in which pyemma will be installed."
+    echo "bash $0 -i ignore existing miniconda installation. Get a fresh copy."
+    echo "bash $0 -n do not add the new path of miniconda installation to PATH (bashrc update) [off by default]."
+    echo "bash $0 -m minimal set of packags, eg. omit jupyter notebook installation."
+}
+
+# default values for arguments.
+target=$HOME/miniconda3
+env_name="pyemma"
+ignore=1 # dont ignore existing miniconda installation, but just use it to install our environment.
+no_add_bashrc=1 # add new target to PATH in .bashrc
+minimal=1 # minimal set of packags, eg. omit jupyter notebook installation
+
+
+while getopts "ht:e:inm" opt; do
+   case $opt in
+       n) no_add_bashrc=0;;
+       m) minimal=0;;
+       t) target=$OPTARG;;
+       e) env_name=$OPTARG;;
+       i) ignore=0;;
+       h) usage
+         exit 0;;
+       *) echo "unknown option/combination"; exit 0;;
+   esac
+done
+
+
+function add_to_bashrc {
+    if [ $no_add_bashrc -ne 0 ]; then
+        return 0
+    fi
+
+	# add path of target to bashrc, if not yet present.
+	# note: copied from miniconda installer.
+    BASH_RC="$HOME"/.bashrc
+    if [ -f "$BASH_RC" ]; then
+        printf "\\n"
+        printf "Appending source %s/bin/activate to %s\\n" "$target" "$BASH_RC"
+        printf "A backup will be made to: %s-miniconda3.bak\\n" "$BASH_RC"
+        printf "\\n"
+        cp "$BASH_RC" "${BASH_RC}"-miniconda3.bak
+    else
+        printf "\\n"
+        printf "Appending source %s/bin/activate in\\n" "$target"
+        printf "newly created %s\\n" "$BASH_RC"
+    fi
+    printf "\\n"
+    printf "For this change to become active, you have to open a new terminal.\\n"
+    printf "\\n"
+    printf "\\n" >> "$BASH_RC"
+    printf "# added by Miniconda3 installer\\n"            >> "$BASH_RC"
+    printf "export PATH=\"%s/bin:\$PATH\"\\n" "$target"  >> "$BASH_RC"
+}
+
+
+function install_miniconda {
+    echo "installing miniconda to ${target}..."
+    if [ `uname -m` = "x86_64"  ]; then
+        arch="x86_64"
+    else
+        arch="x86"
+    fi
+
+    platform=`uname -s`
+    if [ ${platform} = "Darwin" ]; then
+        platform="MacOSX"
+        if [ $arch = "x86" ]; then
+            echo "ERROR: 32 bit on OSX is not supported by Anaconda, please compile the software yourself."
+            exit 1
+        fi
+    fi
+
+	echo "installing miniconda to $target"
+	f=`mktemp`
+	# curl should be available on Linux and OSX.
+	curl https://repo.continuum.io/miniconda/Miniconda3-latest-$platform-$arch.sh -o ${f}
+	bash ${f} -b -f -p ${target}
+	export PATH=${target}/bin:$PATH
+	hash -r
+    add_to_bashrc
+}
+
+
+function install_pyemma {
+    # installs pyemma in an env named pyemma
+    packages="pyemma numpy"
+    if [ ! minimal ]; then
+        # add optional packages.
+        packages="$packages notebook"
+    fi
+    # we add numpy here to get the openblas variant (instead of MKL).
+    echo "creating pyemma environment..."
+    conda=${target}/bin/conda
+    # &> /dev/null
+    if [[ -z $($conda env list | grep ${env_name}) ]]; then
+        echo "env '$env_name' does not exist. Create new one."
+        $conda create -n ${env_name} ${packages} -y -c conda-forge
+        $conda config --env --add channels conda-forge
+    else
+        echo "environment with name='${env_name}' already exists. Please specify a different name by -e new_name"
+        exit 1
+    fi
+}
+
+# probe for conda, install miniconda otherwise.
+if hash conda 2>/dev/null && [ $ignore -eq 0 ]; then
+    echo "Found conda. Will install to a new environment named ${env_name}"
+    install_pyemma
+else
+    if [ -d ${target} ]; then
+        echo "ERROR: Destination directory for Miniconda $target already exists, please choose another one."
+        exit 1
+    else
+        install_miniconda
+        install_pyemma
+    fi
+fi


### PR DESCRIPTION
Usage purpose is one-shot installation eg. for workshops, where people don't have miniconda installed. The installer first checks, if conda is available. If thats the case it creates an environment named pyemma containing the packages. If not, it downloads miniconda, installs it and create the env afterwards.
The bashrc is updated by default to include the new miniconda installation.

The target directories and env name can be set via parameters to the script. In addition some things can be opted out, like bashrc modification and optional packages (currently it installs notebook too).

Tested on Linux and OSX.