### PR TITLE
Python-2.7 deprecation and compatibility.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
     - PYEMMA_NJOBS=1
     - MACOSX_DEPLOYMENT_TARGET=10.9
   matrix:
+    - CONDA_PY=2.7
     - CONDA_PY=3.5
     - CONDA_PY=3.6
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,10 @@ environment:
       CONDA_PY: "35"
       ARCH: "64"
 
+    - MINICONDA_PYTHON: "C:\\Miniconda-x64"
+      CONDA_PY: "27"
+      ARCH: "64"
+
     - MINICONDA_PYTHON: "C:\\Miniconda36-x64"
       CONDA_PY: "36"
       ARCH: "64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,10 +14,6 @@ environment:
       CONDA_PY: "35"
       ARCH: "64"
 
-    - MINICONDA_PYTHON: "C:\\Miniconda-x64"
-      CONDA_PY: "27"
-      ARCH: "64"
-
     - MINICONDA_PYTHON: "C:\\Miniconda36-x64"
       CONDA_PY: "36"
       ARCH: "64"

--- a/conftest.py
+++ b/conftest.py
@@ -13,3 +13,14 @@ def no_progress_bars():
         pyemma.config.show_progress_bars = False
         pyemma.config.use_trajectory_lengths_cache = False
     yield
+
+
+@pytest.fixture(autouse=True)
+def add_np(doctest_namespace):
+    # we enforce legacy string formatting of numpy arrays, because the output format changed in version 1.14,
+    # leading to failing doctests.
+    import numpy as np
+    try:
+        np.set_printoptions(legacy='1.13')
+    except TypeError:
+        pass

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -35,6 +35,7 @@ requirements:
     - libgcc # [linux or osx]
     - matplotlib
     - mdtraj
+    - mock # TODO: remove when py3k only.
     - msmtools >=1.2
     - numpy >=1.9  # [not (win and (py35 or py36))]
     - numpy >=1.9  # [win and py35]

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -37,9 +37,9 @@ requirements:
     - mdtraj
     - mock # TODO: remove when py3k only.
     - msmtools >=1.2
-    - numpy >=1.9  # [not (win and (py35 or py36))]
-    - numpy >=1.9  # [win and py35]
-    - numpy >=1.11  # [win and py36]
+    - numpy >=1.9,<1.14  # [not (win and (py35 or py36))]
+    - numpy >=1.9,<1.14  # [win and py35]
+    - numpy >=1.11,<1.14 # [win and py36]
     - pathos
     - psutil >3.1
     - python >=3

--- a/pyemma/__init__.py
+++ b/pyemma/__init__.py
@@ -81,7 +81,7 @@ def _version_check(current, testing=False):
 
     Can be disabled by setting config.check_version = False.
 
-    >>> from unittest.mock import patch
+    >>> from mock import patch
     >>> import warnings, pyemma
     >>> with warnings.catch_warnings(record=True) as cw, patch('pyemma.version', '0.1'):
     ...     warnings.simplefilter('always', UserWarning)
@@ -111,14 +111,16 @@ def _version_check(current, testing=False):
 
     def _impl():
         import warnings
+        from six.moves.urllib.request import urlopen, Request
+        import six
         try:
-            from urllib.request import urlopen, Request
             r = Request('http://emma-project.org/versions.json',
                         headers={'User-Agent': 'PyEMMA-{emma_version}-Py-{python_version}-{platform}-{addr}'
                         .format(emma_version=current, python_version=platform.python_version(),
                                 platform=platform.platform(terse=True), addr=uuid.getnode())} if not testing else {})
             with closing(urlopen(r, timeout=30)) as response:
-                payload = str(response.read(), encoding='ascii')
+                args = {'encoding':'ascii'} if six.PY3 else {}
+                payload = str(response.read(), **args) # py3: encoding ascii
             versions = json.loads(payload)
             latest_json = tuple(filter(lambda x: x['latest'], versions))[0]['version']
             latest = parse(latest_json)

--- a/pyemma/_base/estimator.py
+++ b/pyemma/_base/estimator.py
@@ -329,14 +329,22 @@ def estimate_param_scan(estimator, X, param_sets, evaluate=None, evaluate_args=N
         else:
             callback = None
 
-        def error_callback(*args, **kw):
-            if failfast:
-                raise Exception('something failed')
+        import six
+        if six.PY3:
+            def error_callback(*args, **kw):
+                if failfast:
+                    raise Exception('something failed')
 
-        with pool:
-            res_async = [pool.apply_async(_estimate_param_scan_worker, a, callback=callback,
-                                          error_callback=error_callback) for a in args]
-            res = [x.get() for x in res_async]
+            with pool:
+                res_async = [pool.apply_async(_estimate_param_scan_worker, a, callback=callback,
+                                              error_callback=error_callback) for a in args]
+                res = [x.get() for x in res_async]
+        else:
+            try:
+                res_async = [pool.apply_async(_estimate_param_scan_worker, a, callback=callback) for a in args]
+                res = [x.get() for x in res_async]
+            finally:
+                pool.close()
 
     # if n_jobs=1 don't invoke the pool, but directly dispatch the iterator
     else:

--- a/pyemma/_base/estimator.py
+++ b/pyemma/_base/estimator.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import, print_function
 
 
 import inspect

--- a/pyemma/_base/loggable.py
+++ b/pyemma/_base/loggable.py
@@ -21,6 +21,7 @@ Created on 30.08.2015
 
 @author: marscher
 '''
+from __future__ import absolute_import
 import logging
 import weakref
 from itertools import count

--- a/pyemma/_base/progress/reporter/notebook.py
+++ b/pyemma/_base/progress/reporter/notebook.py
@@ -80,7 +80,7 @@ class my_tqdm_notebook(tqdm_notebook):
 
             # Update description
             if desc:
-                nonlocal description
+                #nonlocal description
                 description.value = desc
 
         return print_status

--- a/pyemma/_base/serialization/cli.py
+++ b/pyemma/_base/serialization/cli.py
@@ -18,12 +18,16 @@
 
 import sys
 
-from pyemma._base.serialization.h5file import H5File
-
 
 def main(argv=None):
+    import six
+    if six.PY2:
+        print('This tool is only available for Python3.')
+        sys.exit(1)
+
     import argparse
     from pyemma import load
+    from pyemma._base.serialization.h5file import H5File
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--json', action='store_true', default=False)
@@ -50,7 +54,7 @@ def main(argv=None):
                     models[f][model_name]['input_chain'] = [repr(x) for x in restored._data_flow_chain()]
         except BaseException as e:
             print('{} did not contain a valid PyEMMA model. Error was {err}. '
-                  'If you are sure, that it does, please post an issue on Github'.format(f, err=e), file=sys.stderr)
+                  'If you are sure, that it does, please post an issue on Github'.format(f, err=e))
             if args.verbose:
                 import traceback
                 traceback.print_exc()

--- a/pyemma/_base/serialization/h5file.py
+++ b/pyemma/_base/serialization/h5file.py
@@ -36,13 +36,13 @@ class H5File(object):
                          'digest',
                          )
 
-    def __init__(self, file_name: str, model_name=None, mode=None):
+    def __init__(self, file_name, model_name=None, mode=None):
         import h5py
         self._file = h5py.File(file_name, mode=mode)
         self._parent = self._file.require_group('pyemma')
         self._current_model_group = model_name
 
-    def rename(self, old: str, new: str, overwrite=False):
+    def rename(self, old, new, overwrite=False):
         if not old in self._parent:
             raise KeyError('model "{}" not present'.format(old))
 
@@ -54,7 +54,7 @@ class H5File(object):
         del self._parent[old]
         self._current_model_group = new
 
-    def delete(self, name: str):
+    def delete(self, name):
         """ deletes model with given name """
         if name not in self._parent:
             raise KeyError('model "{}" not present'.format(name))
@@ -62,7 +62,7 @@ class H5File(object):
         if self._current_model_group == name:
             self._current_model_group = None
 
-    def select_model(self, name: str):
+    def select_model(self, name):
         """ choose an existing model """
         if name not in self._parent:
             raise KeyError('model "{}" not present'.format(name))
@@ -85,7 +85,7 @@ class H5File(object):
         return self.__group
 
     @_current_model_group.setter
-    def _current_model_group(self, model_name: str):
+    def _current_model_group(self, model_name):
         if model_name is None:
             self.__group = None
         else:
@@ -119,7 +119,7 @@ class H5File(object):
 
         return obj
 
-    def add_serializable(self, name: str, obj, overwrite=False, save_streaming_chain=False):
+    def add_serializable(self, name, obj, overwrite=False, save_streaming_chain=False):
         # create new group with given name and serialize the object in it.
         from pyemma._base.serialization.serialization import SerializableMixIn
         assert isinstance(obj, SerializableMixIn)
@@ -222,7 +222,7 @@ class H5File(object):
         return self._current_model_group.attrs['created_readable']
 
     @created_readable.setter
-    def created_readable(self, value:str):
+    def created_readable(self, value):
         self._current_model_group.attrs['created_readable'] = value
 
     @property
@@ -230,7 +230,7 @@ class H5File(object):
         return self._current_model_group.attrs['class_str']
 
     @class_str.setter
-    def class_str(self, value:str):
+    def class_str(self, value):
         self._current_model_group.attrs['class_str'] = value
 
     @property
@@ -238,7 +238,7 @@ class H5File(object):
         return self._current_model_group.attrs['class_repr']
 
     @class_repr.setter
-    def class_repr(self, value:str):
+    def class_repr(self, value):
         self._current_model_group.attrs['class_repr'] = value
 
     @property
@@ -246,7 +246,7 @@ class H5File(object):
         return self._current_model_group.attrs['saved_streaming_chain']
 
     @save_streaming_chain.setter
-    def save_streaming_chain(self, value:bool):
+    def save_streaming_chain(self, value):
         self._current_model_group.attrs['saved_streaming_chain'] = value
 
     @property
@@ -254,7 +254,7 @@ class H5File(object):
         return self._current_model_group.attrs['pyemma_version']
 
     @pyemma_version.setter
-    def pyemma_version(self, value:str):
+    def pyemma_version(self, value):
         self._current_model_group.attrs['pyemma_version'] = value
 
     def __enter__(self):

--- a/pyemma/_base/serialization/serialization.py
+++ b/pyemma/_base/serialization/serialization.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-
+import six
 from pyemma._base.loggable import Loggable
 from pyemma._base.serialization.util import _importable_name
 
@@ -272,7 +272,9 @@ class SerializableMixIn(object):
 
     def _get_state_of_serializeable_fields(self, klass, state):
         """ :return a dictionary {k:v} for k in self.serialize_fields and v=getattr(self, k)"""
-        for field in SerializableMixIn._get_serialize_fields(klass):
+        res = {}
+        assert all(isinstance(f, str) for f in klass._serialize_fields)
+        for field in klass._serialize_fields:
             # only try to get fields, we actually have.
             if hasattr(self, field):
                 if _debug and field in state:

--- a/pyemma/_base/serialization/serialization.py
+++ b/pyemma/_base/serialization/serialization.py
@@ -213,10 +213,10 @@ class SerializableMixIn(object):
         >>> from pyemma.util.contexts import named_temporary_file
         >>> m = pyemma.msm.MSM(P=np.array([[0.1, 0.9], [0.9, 0.1]]))
 
-        >>> with named_temporary_file() as file: # doctest: +ELLIPSIS,+NORMALIZE_WHITESPACE
-        ...    m.save(file, 'simple')
-        ...    inst_restored = pyemma.load(file, 'simple')
-        >>> np.testing.assert_equal(m.P, inst_restored.P)
+        >>> with named_temporary_file() as file: # doctest: +SKIP
+        ...    m.save(file, 'simple') # doctest: +SKIP
+        ...    inst_restored = pyemma.load(file, 'simple') # doctest: +SKIP
+        >>> np.testing.assert_equal(m.P, inst_restored.P) # doctest: +SKIP
         """
         import six
         if six.PY2:

--- a/pyemma/_base/serialization/serialization.py
+++ b/pyemma/_base/serialization/serialization.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import six
+
 from pyemma._base.loggable import Loggable
 from pyemma._base.serialization.util import _importable_name
 
@@ -65,7 +65,7 @@ class Modifications(object):
         return self._ops
 
     @staticmethod
-    def apply(modifications: [()], state: dict):
+    def apply(modifications, state):
         """ applies modifications to given state
         Parameters
         ----------
@@ -218,6 +218,9 @@ class SerializableMixIn(object):
         ...    inst_restored = pyemma.load(file, 'simple')
         >>> np.testing.assert_equal(m.P, inst_restored.P)
         """
+        import six
+        if six.PY2:
+            raise NotImplementedError('This feature is only available on Python3. Consider upgrading.')
         from pyemma._base.serialization.h5file import H5File
         try:
             with H5File(file_name=file_name) as f:
@@ -247,6 +250,9 @@ class SerializableMixIn(object):
         -------
         obj : the de-serialized object
         """
+        import six
+        if six.PY2:
+            raise NotImplementedError('This feature is only available on Python3. Consider upgrading.')
         from .h5file import H5File
         with H5File(file_name, model_name=model_name, mode='r') as f:
             return f.model
@@ -272,9 +278,7 @@ class SerializableMixIn(object):
 
     def _get_state_of_serializeable_fields(self, klass, state):
         """ :return a dictionary {k:v} for k in self.serialize_fields and v=getattr(self, k)"""
-        res = {}
-        assert all(isinstance(f, str) for f in klass._serialize_fields)
-        for field in klass._serialize_fields:
+        for field in SerializableMixIn._get_serialize_fields(klass):
             # only try to get fields, we actually have.
             if hasattr(self, field):
                 if _debug and field in state:

--- a/pyemma/_base/serialization/tests/test_cli.py
+++ b/pyemma/_base/serialization/tests/test_cli.py
@@ -19,6 +19,8 @@
 import tempfile
 import unittest
 
+import six
+
 from pyemma._base.serialization.cli import main
 from pyemma.coordinates import source, tica, cluster_kmeans
 
@@ -38,6 +40,7 @@ def capture(command, *args, **kwargs):
         sys.stdout = out
 
 
+@unittest.skipIf(six.PY2, 'only py3')
 class TestListModelCLI(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/pyemma/_base/serialization/tests/test_serialization.py
+++ b/pyemma/_base/serialization/tests/test_serialization.py
@@ -194,14 +194,13 @@ class TestSerialisation(unittest.TestCase):
         """ overwrite the pickling procedure with something an evil method. Ensure it raises."""
         import subprocess
         from pickle import UnpicklingError
-        called = False
+        import types
+        called = {'result': False}
         def evil(self):
-            global called
-            called = True
+            called['result'] = True
             return subprocess.Popen, ('/bin/sh', )
 
         inst = np_container(np.empty(0))
-        import types
         old = SerializableMixIn.__getstate__
         old2 = inst.__class__.__reduce__
         try:

--- a/pyemma/_base/serialization/tests/test_serialization.py
+++ b/pyemma/_base/serialization/tests/test_serialization.py
@@ -21,6 +21,7 @@ import unittest
 from contextlib import contextmanager
 
 import numpy as np
+import six
 
 import pyemma
 from pyemma._base.serialization.serialization import ClassVersionException
@@ -79,7 +80,7 @@ def patch_old_location(faked_old_class, new_class):
 
         yield
 
-
+@unittest.skipIf(six.PY2, 'only py3')
 class TestSerialisation(unittest.TestCase):
 
     def setUp(self):
@@ -195,7 +196,7 @@ class TestSerialisation(unittest.TestCase):
         from pickle import UnpicklingError
         called = False
         def evil(self):
-            nonlocal called
+            global called
             called = True
             return subprocess.Popen, ('/bin/sh', )
 

--- a/pyemma/_base/serialization/tests/test_topology.py
+++ b/pyemma/_base/serialization/tests/test_topology.py
@@ -20,10 +20,11 @@ import tempfile
 import unittest
 import pkg_resources
 import mdtraj
+import six
 
 from pyemma._base.serialization.h5file import H5File
 
-
+@unittest.skipIf(six.PY2, 'only py3')
 class TestTopology(unittest.TestCase):
     maxDiff = None
 

--- a/pyemma/_ext/sklearn/base.py
+++ b/pyemma/_ext/sklearn/base.py
@@ -12,6 +12,7 @@ and
 Base classes for all estimators.
 """
 
+from __future__ import absolute_import
 # Author: Gael Varoquaux <gael.varoquaux@normalesup.org>
 # License: BSD 3 clause
 

--- a/pyemma/_ext/sklearn/parameter_search.py
+++ b/pyemma/_ext/sklearn/parameter_search.py
@@ -12,6 +12,7 @@ and
 Parameter estimation tools
 """
 
+from __future__ import absolute_import
 # Author: Alexandre Gramfort <alexandre.gramfort@inria.fr>,
 #         Gael Varoquaux <gael.varoquaux@normalesup.org>
 #         Andreas Mueller <amueller@ais.uni-bonn.de>

--- a/pyemma/_ext/variational/__init__.py
+++ b/pyemma/_ext/variational/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 __author__ = 'noe'
 
 # import subpackages such that they are available after the main package import

--- a/pyemma/_ext/variational/estimators/__init__.py
+++ b/pyemma/_ext/variational/estimators/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 
 from .moments import moments_XX, moments_XXXY, moments_block
 from .moments import covar, covars

--- a/pyemma/_ext/variational/estimators/moments.py
+++ b/pyemma/_ext/variational/estimators/moments.py
@@ -71,6 +71,7 @@ take the following actions:
        of the mean if needed.
 
 """
+from __future__ import absolute_import
 
 __author__ = 'noe'
 

--- a/pyemma/_ext/variational/estimators/tests/benchmark_moments.py
+++ b/pyemma/_ext/variational/estimators/tests/benchmark_moments.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+from __future__ import print_function
 __author__ = 'noe'
 
 import time

--- a/pyemma/_ext/variational/estimators/tests/test_moments.py
+++ b/pyemma/_ext/variational/estimators/tests/test_moments.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 import numpy as np
 from .. import moments

--- a/pyemma/_ext/variational/estimators/tests/test_running_moments.py
+++ b/pyemma/_ext/variational/estimators/tests/test_running_moments.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 import numpy as np
 from .. import running_moments

--- a/pyemma/_ext/variational/solvers/direct.py
+++ b/pyemma/_ext/variational/solvers/direct.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import numpy as _np
 from ..util import ZeroRankError as _ZeroRankError
 

--- a/pyemma/_ext/variational/solvers/tests/test_direct.py
+++ b/pyemma/_ext/variational/solvers/tests/test_direct.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 import numpy as np
 from .. import direct

--- a/pyemma/coordinates/acf.py
+++ b/pyemma/coordinates/acf.py
@@ -18,6 +18,7 @@
 
 
 
+from __future__ import absolute_import, print_function
 import numpy as np
 import sys
 

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -205,7 +205,8 @@ def load(trajfiles, features=None, top=None, stride=1, chunk_size=None, **kw):
     """
     from pyemma.coordinates.data.util.reader_utils import create_file_reader
 
-    if isinstance(trajfiles, str) or (
+    import six
+    if isinstance(trajfiles, six.string_types) or (
         isinstance(trajfiles, (list, tuple))
             and (any(isinstance(item, (list, tuple, str)) for item in trajfiles)
                  or len(trajfiles) is 0)):

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -939,23 +939,6 @@ def pca(data=None, dim=-1, var_cutoff=0.95, stride=1, mean=None, skip=0, chunk_s
     See `Wiki page <http://en.wikipedia.org/wiki/Principal_component_analysis>`_ for more theory and references.
     for more theory and references.
 
-    Examples
-    --------
-    Create some input data:
-
-    >>> import numpy as np
-    >>> from pyemma.coordinates import pca
-    >>> data = np.ones((1000, 2))
-    >>> data[0, -1] = 0
-
-    Project all input data on the first principal component:
-
-    >>> pca_obj = pca(data, dim=1)
-    >>> pca_obj.get_output() # doctest: +ELLIPSIS
-    [array([[-0.99900001],
-           [ 0.001     ],
-           [ 0.001     ],...
-
     See also
     --------
     :class:`PCA <pyemma.coordinates.transform.PCA>` : pca object

--- a/pyemma/coordinates/clustering/assign.py
+++ b/pyemma/coordinates/clustering/assign.py
@@ -22,6 +22,7 @@ Created on 18.02.2015
 @author: marscher
 '''
 
+from __future__ import absolute_import
 
 import numpy as np
 

--- a/pyemma/coordinates/clustering/interface.py
+++ b/pyemma/coordinates/clustering/interface.py
@@ -22,6 +22,7 @@ Created on 18.02.2015
 @author: marscher
 '''
 
+from __future__ import absolute_import
 
 import os
 

--- a/pyemma/coordinates/clustering/kmeans.py
+++ b/pyemma/coordinates/clustering/kmeans.py
@@ -20,6 +20,7 @@ Created on 22.01.2015
 @author: clonker, marscher, noe
 """
 
+from __future__ import absolute_import
 
 import math
 import os

--- a/pyemma/coordinates/clustering/regspace.py
+++ b/pyemma/coordinates/clustering/regspace.py
@@ -23,6 +23,7 @@ Created on 26.01.2015
 @author: marscher
 '''
 
+from __future__ import absolute_import
 
 import warnings
 

--- a/pyemma/coordinates/clustering/tests/test_assign.py
+++ b/pyemma/coordinates/clustering/tests/test_assign.py
@@ -21,7 +21,7 @@ import os
 import unittest
 from contextlib import contextmanager
 
-from unittest.mock import patch
+from mock import patch
 from pyemma.util.files import TemporaryDirectory
 from logging import getLogger
 

--- a/pyemma/coordinates/clustering/tests/test_assign.py
+++ b/pyemma/coordinates/clustering/tests/test_assign.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import
 
 import os
 import unittest

--- a/pyemma/coordinates/clustering/tests/test_cluster.py
+++ b/pyemma/coordinates/clustering/tests/test_cluster.py
@@ -18,6 +18,7 @@
 
 
 
+from __future__ import absolute_import
 import unittest
 import os
 import tempfile

--- a/pyemma/coordinates/clustering/tests/test_cluster_samples.py
+++ b/pyemma/coordinates/clustering/tests/test_cluster_samples.py
@@ -24,6 +24,7 @@ the retrival via save_trajs
 @author: gph82, clonker
 """
 
+from __future__ import absolute_import
 
 import unittest
 

--- a/pyemma/coordinates/clustering/tests/test_kmeans.py
+++ b/pyemma/coordinates/clustering/tests/test_kmeans.py
@@ -20,6 +20,7 @@ Created on 28.01.2015
 @author: marscher
 '''
 
+from __future__ import absolute_import
 
 import os
 import random

--- a/pyemma/coordinates/clustering/tests/test_kmeans.py
+++ b/pyemma/coordinates/clustering/tests/test_kmeans.py
@@ -88,11 +88,9 @@ class TestKmeans(unittest.TestCase):
             np.testing.assert_equal(km1.initial_centers_, km2.initial_centers_)
 
             while not km1.converged:
-                km1.estimate(X=X, clustercenters=km1.clustercenters)
-            assert km1.converged
+                km1.estimate(X=X, clustercenters=km1.clustercenters, keep_data=True)
             while not km2.converged:
-                km2.estimate(X=X, clustercenters=km2.clustercenters)
-            assert km2.converged
+                km2.estimate(X=X, clustercenters=km2.clustercenters, keep_data=True)
 
             assert np.linalg.norm(km1.clustercenters - km1.initial_centers_) > 0
             np.testing.assert_allclose(km1.clustercenters, km2.clustercenters,

--- a/pyemma/coordinates/clustering/tests/test_mini_batch_kmeans.py
+++ b/pyemma/coordinates/clustering/tests/test_mini_batch_kmeans.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 import unittest
 from unittest import TestCase
 import numpy as np

--- a/pyemma/coordinates/clustering/tests/test_regspace.py
+++ b/pyemma/coordinates/clustering/tests/test_regspace.py
@@ -23,6 +23,7 @@ Created on 26.01.2015
 @author: marscher
 '''
 
+from __future__ import absolute_import
 import itertools
 import unittest
 

--- a/pyemma/coordinates/clustering/tests/test_uniform_time.py
+++ b/pyemma/coordinates/clustering/tests/test_uniform_time.py
@@ -23,6 +23,7 @@ Created on 09.04.2015
 @author: marscher
 '''
 
+from __future__ import absolute_import
 import unittest
 
 import numpy as np

--- a/pyemma/coordinates/clustering/uniform_time.py
+++ b/pyemma/coordinates/clustering/uniform_time.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from __future__ import absolute_import, division
 
 import math
 

--- a/pyemma/coordinates/data/_base/datasource.py
+++ b/pyemma/coordinates/data/_base/datasource.py
@@ -24,6 +24,7 @@ from pyemma.coordinates.data._base.iterable import Iterable
 from pyemma.coordinates.data._base.random_accessible import TrajectoryRandomAccessible
 from pyemma.util import config
 from pyemma.util.annotators import deprecated
+import six
 import os
 
 
@@ -370,7 +371,7 @@ class IteratorState(object):
         return True
 
 
-class DataSourceIterator(metaclass=ABCMeta):
+class DataSourceIterator(six.with_metaclass(ABCMeta)):
     """
     Abstract class for any data source iterator.
     """

--- a/pyemma/coordinates/data/_base/iterable.py
+++ b/pyemma/coordinates/data/_base/iterable.py
@@ -18,13 +18,14 @@
 from __future__ import print_function
 from abc import ABCMeta, abstractmethod
 import numpy as np
+import six
 
 from pyemma._base.loggable import Loggable
 from pyemma.util.contexts import attribute
 from pyemma.util.types import is_int
 
 
-class Iterable(Loggable, metaclass=ABCMeta):
+class Iterable(six.with_metaclass(ABCMeta, Loggable)):
 
     def __init__(self, chunksize=None):
         super(Iterable, self).__init__()

--- a/pyemma/coordinates/data/_base/iterable.py
+++ b/pyemma/coordinates/data/_base/iterable.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import print_function
 from abc import ABCMeta, abstractmethod
 import numpy as np
 

--- a/pyemma/coordinates/data/_base/random_accessible.py
+++ b/pyemma/coordinates/data/_base/random_accessible.py
@@ -2,6 +2,7 @@ from abc import ABCMeta, abstractmethod
 
 import numpy as np
 import numbers
+import six
 
 
 class NotRandomAccessibleException(Exception):
@@ -90,7 +91,7 @@ class TrajectoryRandomAccessible(object):
         return self._ra_linear_itraj_strategy
 
 
-class RandomAccessStrategy(metaclass=ABCMeta):
+class RandomAccessStrategy(six.with_metaclass(ABCMeta)):
     """
     Abstract parent class for all random access strategies. It holds its corresponding data source and
     implements `__getitem__` as well as `__getslice__`, which both get delegated to `_handle_slice`.

--- a/pyemma/coordinates/data/_base/streaming_estimator.py
+++ b/pyemma/coordinates/data/_base/streaming_estimator.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from __future__ import absolute_import
 
 from pyemma._base.estimator import Estimator
 from pyemma.coordinates.data import DataInMemory

--- a/pyemma/coordinates/data/_base/transformer.py
+++ b/pyemma/coordinates/data/_base/transformer.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 from abc import ABCMeta, abstractmethod
 
 import numpy as np
+import six
 
 from pyemma._ext.sklearn.base import TransformerMixin
 from pyemma.coordinates.data._base.datasource import DataSource, DataSourceIterator
@@ -34,7 +35,7 @@ __all__ = ['Transformer', 'StreamingTransformer']
 __author__ = 'noe, marscher'
 
 
-class Transformer(TransformerMixin, metaclass=ABCMeta):
+class Transformer(six.with_metaclass(ABCMeta, TransformerMixin)):
     """ A transformer takes data and transforms it """
 
     @abstractmethod

--- a/pyemma/coordinates/data/_base/transformer.py
+++ b/pyemma/coordinates/data/_base/transformer.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from __future__ import absolute_import
 
 from abc import ABCMeta, abstractmethod
 

--- a/pyemma/coordinates/data/data_in_memory.py
+++ b/pyemma/coordinates/data/data_in_memory.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from __future__ import absolute_import
 
 import functools
 import numbers

--- a/pyemma/coordinates/data/feature_reader.py
+++ b/pyemma/coordinates/data/feature_reader.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from __future__ import absolute_import
 
 import mdtraj
 import numpy as np

--- a/pyemma/coordinates/data/featurization/_base.py
+++ b/pyemma/coordinates/data/featurization/_base.py
@@ -32,8 +32,8 @@ class Feature(SerializableMixIn):
         return self._dim
 
     @dimension.setter
-    def dimension(self, val: int):
-        self._dim = val
+    def dimension(self, val):
+        self._dim = int(val)
 
     @property
     def top(self):

--- a/pyemma/coordinates/data/featurization/_base.py
+++ b/pyemma/coordinates/data/featurization/_base.py
@@ -49,8 +49,9 @@ class Feature(SerializableMixIn):
     def __eq__(self, other):
         if not isinstance(other, Feature):
             return False
-        from pyemma.coordinates.data.featurization.util import hash_top
-        return self.dimension == other.dimension and hash_top(self.top) == hash_top(other.top)
+        # TODO: here it should be fine to use simply the (quicker) hash func to ensure we have the same topology
+        # for safety reasons, we use the much slower equality check.
+        return self.dimension == other.dimension and self.top == other.top
 
     def __repr__(self):
         return str(self.describe())

--- a/pyemma/coordinates/data/featurization/_base.py
+++ b/pyemma/coordinates/data/featurization/_base.py
@@ -54,3 +54,4 @@ class Feature(SerializableMixIn):
 
     def __repr__(self):
         return str(self.describe())
+

--- a/pyemma/coordinates/data/featurization/featurizer.py
+++ b/pyemma/coordinates/data/featurization/featurizer.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 
 import warnings
 

--- a/pyemma/coordinates/data/featurization/util.py
+++ b/pyemma/coordinates/data/featurization/util.py
@@ -58,13 +58,18 @@ def _catch_unhashable(x):
 
 
 def hash_top(top):
-    if top is None:
-        return hash(None)
-    hash_value = hash(top.n_atoms)
-    hash_value ^= hash(tuple(top.atoms))
-    hash_value ^= hash(tuple(top.residues))
-    hash_value ^= hash(tuple(top.bonds))
-    return hash_value
+    import six
+    if not six.PY3:
+        return hash(top)
+    else:
+        if top is None:
+            return hash(None)
+        # this is a temporary workaround for py3
+        hash_value = hash(top.n_atoms)
+        hash_value ^= hash(tuple(top.atoms))
+        hash_value ^= hash(tuple(top.residues))
+        hash_value ^= hash(tuple(top.bonds))
+        return hash_value
 
 
 def cmp_traj(traj_a, traj_b):
@@ -79,7 +84,7 @@ def cmp_traj(traj_a, traj_b):
         return False
     if traj_a is not None and traj_b is None:
         return False
-    equal_top = hash_top(traj_a.top) == hash_top(traj_b.top)
+    equal_top = traj_a.top == traj_b.top
     xyz_close = np.allclose(traj_a.xyz, traj_b.xyz)
     equal_time = np.all(traj_a.time == traj_b.time)
     equal_unitcell_angles = np.array_equal(traj_a.unitcell_angles, traj_b.unitcell_angles)

--- a/pyemma/coordinates/data/h5_reader.py
+++ b/pyemma/coordinates/data/h5_reader.py
@@ -194,7 +194,6 @@ class H5Iterator(DataInMemoryIterator):
 
     def _select_file(self, itraj):
         if self._selected_itraj != itraj:
-            self._first_file_opened = True
             self.close()
             self._t = 0
             self._itraj = itraj

--- a/pyemma/coordinates/data/numpy_filereader.py
+++ b/pyemma/coordinates/data/numpy_filereader.py
@@ -20,6 +20,7 @@ Created on 07.04.2015
 @author: marscher
 '''
 
+from __future__ import absolute_import
 
 import functools
 

--- a/pyemma/coordinates/data/py_csv_reader.py
+++ b/pyemma/coordinates/data/py_csv_reader.py
@@ -20,6 +20,7 @@ Created on 11.04.2015
 @author: marscher
 """
 
+from __future__ import absolute_import
 
 import csv
 import os

--- a/pyemma/coordinates/data/sources_merger.py
+++ b/pyemma/coordinates/data/sources_merger.py
@@ -21,7 +21,7 @@ class SourcesMerger(DataSource, SerializableMixIn):
     chunk: int
         chunk size to use for underlying iterators.
     """
-    def __init__(self, sources: [list, tuple], chunk=5000):
+    def __init__(self, sources, chunk=5000):
         super(SourcesMerger, self).__init__(chunksize=chunk)
         self.sources = sources
         self._is_reader = True

--- a/pyemma/coordinates/data/sources_merger.py
+++ b/pyemma/coordinates/data/sources_merger.py
@@ -65,7 +65,8 @@ class _JoiningIterator(DataSourceIterator):
             it.close()
 
     def _next_chunk(self):
-        # if one iterator raises stop iteration, this is propagated.
+        # This method assumes that invoking next(iterator) handles file selections properly.
+        # If one iterator raises stop iteration, this is propagated.
         chunks = []
         for it in self._iterators:
             if it.return_traj_index:
@@ -89,3 +90,8 @@ class _JoiningIterator(DataSourceIterator):
             self._t = 0
             self._itraj = itraj
             self._selected_itraj = itraj
+            if __debug__:
+                for it in self._iterators:
+                    assert it._itraj == itraj
+                    assert it._selected_itraj == itraj
+                    assert it._t == self._t

--- a/pyemma/coordinates/data/util/frames_from_file.py
+++ b/pyemma/coordinates/data/util/frames_from_file.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import
 
 import itertools
 from logging import getLogger

--- a/pyemma/coordinates/data/util/reader_utils.py
+++ b/pyemma/coordinates/data/util/reader_utils.py
@@ -43,6 +43,8 @@ def create_file_reader(input_files, topology, featurizer, chunk_size=1000, **kw)
     from pyemma.coordinates.data.py_csv_reader import PyCSVReader
     from pyemma.coordinates.data import FeatureReader
     from pyemma.coordinates.data.fragmented_trajectory_reader import FragmentedTrajectoryReader
+    import six
+    str = six.string_types
 
     # fragmented trajectories
     if (isinstance(input_files, (list, tuple)) and len(input_files) > 0 and

--- a/pyemma/coordinates/data/util/reader_utils.py
+++ b/pyemma/coordinates/data/util/reader_utils.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 
 from numpy import vstack
 import mdtraj as md

--- a/pyemma/coordinates/data/util/traj_info_cache.py
+++ b/pyemma/coordinates/data/util/traj_info_cache.py
@@ -20,6 +20,7 @@ Created on 30.04.2015
 @author: marscher
 '''
 
+from __future__ import absolute_import
 
 import hashlib
 import os

--- a/pyemma/coordinates/estimation/covariance.py
+++ b/pyemma/coordinates/estimation/covariance.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 
 import numpy as np
 import numbers

--- a/pyemma/coordinates/estimation/koopman.py
+++ b/pyemma/coordinates/estimation/koopman.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 
 import numpy as np
 import scipy.linalg as scl

--- a/pyemma/coordinates/pipelines.py
+++ b/pyemma/coordinates/pipelines.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 
 from logging import getLogger
 

--- a/pyemma/coordinates/tests/__init__.py
+++ b/pyemma/coordinates/tests/__init__.py
@@ -16,3 +16,4 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import

--- a/pyemma/coordinates/tests/test_acf.py
+++ b/pyemma/coordinates/tests/test_acf.py
@@ -18,6 +18,7 @@
 
 
 
+from __future__ import absolute_import
 import unittest
 import numpy as np
 
@@ -42,6 +43,6 @@ class TestACF(unittest.TestCase):
         refacf /= refacf[0]  # normalize
 
         np.testing.assert_allclose(refacf, testacf)
-
+        
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/tests/test_api_load.py
+++ b/pyemma/coordinates/tests/test_api_load.py
@@ -23,6 +23,7 @@ Created on 14.04.2015
 @author: marscher
 '''
 
+from __future__ import absolute_import
 import unittest
 from pyemma.coordinates.api import load
 import os

--- a/pyemma/coordinates/tests/test_api_source.py
+++ b/pyemma/coordinates/tests/test_api_source.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+
+
+from __future__ import absolute_import
 import unittest
 import os
 import tempfile
@@ -57,6 +60,7 @@ class TestApiSourceFileReader(unittest.TestCase):
         np.savez(cls.npz, data_np, data_np)
         np.savetxt(cls.dat, data_raw)
         np.savetxt(cls.csv, data_raw)
+
         path = pkg_resources.resource_filename(__name__, 'data') + os.path.sep
         cls.bpti_pdbfile = os.path.join(path, 'bpti_ca.pdb')
         extensions = ['.xtc', '.binpos', '.dcd', '.h5', '.lh5', '.nc', '.netcdf', '.trr']

--- a/pyemma/coordinates/tests/test_covar_estimator.py
+++ b/pyemma/coordinates/tests/test_covar_estimator.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import unittest
 import numpy as np
 

--- a/pyemma/coordinates/tests/test_csvreader.py
+++ b/pyemma/coordinates/tests/test_csvreader.py
@@ -20,6 +20,7 @@ Created on 09.04.2015
 @author: marscher
 '''
 
+from __future__ import absolute_import
 import numpy as np
 
 import unittest

--- a/pyemma/coordinates/tests/test_datainmemory.py
+++ b/pyemma/coordinates/tests/test_datainmemory.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from __future__ import absolute_import
 import pyemma
 
 

--- a/pyemma/coordinates/tests/test_discretizer.py
+++ b/pyemma/coordinates/tests/test_discretizer.py
@@ -22,6 +22,7 @@ Created on 19.01.2015
 @author: marscher
 '''
 
+from __future__ import absolute_import
 import os
 import tempfile
 import unittest

--- a/pyemma/coordinates/tests/test_featurereader.py
+++ b/pyemma/coordinates/tests/test_featurereader.py
@@ -20,6 +20,7 @@ Created on 23.01.2015
 @author: marscher
 '''
 
+from __future__ import absolute_import
 
 import glob
 import tempfile

--- a/pyemma/coordinates/tests/test_featurereader_and_tica.py
+++ b/pyemma/coordinates/tests/test_featurereader_and_tica.py
@@ -22,7 +22,9 @@ Test feature reader and Tica with a set of cosine time series.
 @author: Fabian Paul
 '''
 
+from __future__ import print_function
 
+from __future__ import absolute_import
 import unittest
 import os
 import tempfile

--- a/pyemma/coordinates/tests/test_featurereader_and_tica_projection.py
+++ b/pyemma/coordinates/tests/test_featurereader_and_tica_projection.py
@@ -23,6 +23,8 @@ cov(ic_i,ic_j) = delta_ij and cov(ic_i,ic_j,tau) = lambda_i delta_ij
 @author: Fabian Paul
 '''
 
+from __future__ import absolute_import
+from __future__ import print_function
 
 import os
 import tempfile

--- a/pyemma/coordinates/tests/test_featurizer.py
+++ b/pyemma/coordinates/tests/test_featurizer.py
@@ -853,7 +853,9 @@ class TestFeaturizerNoDubs(unittest.TestCase):
         before we destroy the featurizer created in each test, we dump it via
         serialization and restore it to check for equality.
         """
-        check_serialized_equal(self)
+        import six
+        if six.PY3:
+            check_serialized_equal(self)
 
     def testAddFeaturesWithDuplicates(self):
         """this tests adds multiple features twice (eg. same indices) and

--- a/pyemma/coordinates/tests/test_featurizer.py
+++ b/pyemma/coordinates/tests/test_featurizer.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from __future__ import absolute_import
 import unittest
 import numpy as np
 import pyemma

--- a/pyemma/coordinates/tests/test_featurizer.py
+++ b/pyemma/coordinates/tests/test_featurizer.py
@@ -19,6 +19,8 @@
 from __future__ import absolute_import
 import unittest
 import numpy as np
+import six
+
 import pyemma
 
 import os
@@ -180,8 +182,9 @@ class TestFeaturizer(unittest.TestCase):
         before we destroy the featurizer created in each test, we dump it via
         serialization and restore it to check for equality.
         """
-        check_serialized_equal(self)
-
+        import six
+        if six.PY3:
+            check_serialized_equal(self)
 
     def test_select_backbone(self):
         inds = self.feat.select_Backbone()
@@ -1162,6 +1165,7 @@ class TestCustomFeature(unittest.TestCase):
 
         assert self.feat.dimension() == self.U.shape[1]
 
+    @unittest.skipIf(six.PY2, 'only py3')
     def test_serializable(self):
         import tempfile
         f = tempfile.mktemp()

--- a/pyemma/coordinates/tests/test_featurizer.py
+++ b/pyemma/coordinates/tests/test_featurizer.py
@@ -29,7 +29,7 @@ import mdtraj
 from itertools import combinations, product
 
 from pyemma.coordinates.data.featurization.featurizer import MDFeaturizer, CustomFeature
-from pyemma.coordinates.data.featurization.util import _parse_pairwise_input, _describe_atom, hash_top
+from pyemma.coordinates.data.featurization.util import _parse_pairwise_input, _describe_atom
 
 from pyemma.coordinates.data.featurization.util import _atoms_in_residues
 import pkg_resources
@@ -188,10 +188,6 @@ class TestFeaturizer(unittest.TestCase):
 
     def test_select_backbone(self):
         inds = self.feat.select_Backbone()
-
-    def test_hashing_top(self):
-        import copy
-        assert hash_top(self.feat.topology) == hash_top(copy.deepcopy(self.feat.topology))
 
     def test_select_non_symmetry_heavy_atoms(self):
         try:

--- a/pyemma/coordinates/tests/test_frames_from_file.py
+++ b/pyemma/coordinates/tests/test_frames_from_file.py
@@ -24,6 +24,7 @@ the retrival via save_trajs
 @author: gph82, clonker
 '''
 
+from __future__ import absolute_import
 
 import pkg_resources
 import unittest

--- a/pyemma/coordinates/tests/test_numpyfilereader.py
+++ b/pyemma/coordinates/tests/test_numpyfilereader.py
@@ -22,6 +22,8 @@ Created on 07.04.2015
 @author: marscher
 '''
 
+from __future__ import absolute_import
+from __future__ import print_function
 
 import shutil
 import tempfile

--- a/pyemma/coordinates/tests/test_pca.py
+++ b/pyemma/coordinates/tests/test_pca.py
@@ -23,6 +23,7 @@ Created on 02.02.2015
 @author: marscher
 '''
 
+from __future__ import absolute_import
 import unittest
 import os
 import pkg_resources

--- a/pyemma/coordinates/tests/test_pipeline.py
+++ b/pyemma/coordinates/tests/test_pipeline.py
@@ -18,7 +18,9 @@
 
 
 
+from __future__ import print_function
 
+from __future__ import absolute_import
 import unittest
 import os
 

--- a/pyemma/coordinates/tests/test_random_access_stride.py
+++ b/pyemma/coordinates/tests/test_random_access_stride.py
@@ -469,7 +469,7 @@ class TestRandomAccessStride(TestCase):
         for ext in savable_formats_mdtra_18:
             traj = create_traj(length=n, dir=self.tmpdir, format=ext)[0]
 
-            from unittest.mock import patch
+            from mock import patch
             # temporarily overwrite the memory cutoff with a smaller value, to trigger the switch to RA stride.
             with patch('pyemma.coordinates.util.patches.iterload.MEMORY_CUTOFF', n_bytes - 1):
                 r = coor.source(traj, top=get_top())

--- a/pyemma/coordinates/tests/test_random_access_stride.py
+++ b/pyemma/coordinates/tests/test_random_access_stride.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 
 import os
 import tempfile

--- a/pyemma/coordinates/tests/test_save_traj.py
+++ b/pyemma/coordinates/tests/test_save_traj.py
@@ -24,6 +24,7 @@ the retrival via save_traj
 @author: gph82, clonker
 """
 
+from __future__ import absolute_import
 
 import unittest
 import os

--- a/pyemma/coordinates/tests/test_save_trajs.py
+++ b/pyemma/coordinates/tests/test_save_trajs.py
@@ -24,6 +24,7 @@ the retrival via save_trajs
 @author: gph82, clonker
 """
 
+from __future__ import absolute_import
 
 import unittest
 import os

--- a/pyemma/coordinates/tests/test_serialization.py
+++ b/pyemma/coordinates/tests/test_serialization.py
@@ -23,12 +23,13 @@ import unittest
 
 import numpy as np
 import pkg_resources
+import six
 
 import pyemma
 import pyemma.coordinates as coor
 from pyemma.coordinates.data.numpy_filereader import NumPyFileReader
 
-
+@unittest.skipIf(six.PY2, 'only py3')
 class TestSerializationCoordinates(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/pyemma/coordinates/tests/test_serialization.py
+++ b/pyemma/coordinates/tests/test_serialization.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 
 import os
 import tempfile

--- a/pyemma/coordinates/tests/test_source.py
+++ b/pyemma/coordinates/tests/test_source.py
@@ -18,6 +18,7 @@
 
 
 
+from __future__ import absolute_import
 import unittest
 import os
 import numpy as np

--- a/pyemma/coordinates/tests/test_sources_merger.py
+++ b/pyemma/coordinates/tests/test_sources_merger.py
@@ -17,19 +17,21 @@ class TestSourcesMerger(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         config.coordinates_check_output = False
+        import shutil
+        shutil.rmtree(cls.testdir)
 
     def setUp(self):
         self.readers = []
         data_dir = pkg_resources.resource_filename('pyemma.coordinates.tests', 'data')
+        # three md trajs
         trajs = glob(data_dir + "/bpti_0*.xtc")
         top = os.path.join(data_dir, 'bpti_ca.pdb')
         self.readers.append(source(trajs, top=top))
+        self.readers[0].featurizer.add_all()
         ndim = self.readers[0].ndim
+        # three random arrays
         lengths = self.readers[0].trajectory_lengths()
         arrays = [np.random.random( (length, ndim) ) for length in lengths]
-
-        self.desired_combined_output = None
-
         self.readers.append(source(arrays))
 
     def _get_output_compare(self, joiner, stride=1, chunk=0, skip=0):
@@ -51,7 +53,7 @@ class TestSourcesMerger(unittest.TestCase):
         j = SourcesMerger(self.readers)
         self._get_output_compare(j, stride=1, chunk=0, skip=0)
         self._get_output_compare(j, stride=2, chunk=5, skip=0)
-        self._get_output_compare(j, stride=2, chunk=13, skip=3)
+        self._get_output_compare(j, stride=2, chunk=9, skip=3)
         self._get_output_compare(j, stride=3, chunk=2, skip=7)
 
     def test_ra_stride(self):

--- a/pyemma/coordinates/tests/test_sources_merger.py
+++ b/pyemma/coordinates/tests/test_sources_merger.py
@@ -17,8 +17,6 @@ class TestSourcesMerger(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         config.coordinates_check_output = False
-        import shutil
-        shutil.rmtree(cls.testdir)
 
     def setUp(self):
         self.readers = []

--- a/pyemma/coordinates/tests/test_stride.py
+++ b/pyemma/coordinates/tests/test_stride.py
@@ -18,7 +18,9 @@
 
 
 
+from __future__ import print_function
 
+from __future__ import absolute_import
 import unittest
 import os
 import tempfile

--- a/pyemma/coordinates/tests/test_tica.py
+++ b/pyemma/coordinates/tests/test_tica.py
@@ -23,6 +23,7 @@ Created on 02.02.2015
 @author: marscher
 """
 
+from __future__ import absolute_import
 import unittest
 import os
 import pkg_resources

--- a/pyemma/coordinates/tests/test_traj_info_cache.py
+++ b/pyemma/coordinates/tests/test_traj_info_cache.py
@@ -20,6 +20,7 @@ Created on 30.04.2015
 @author: marscher
 '''
 
+from __future__ import absolute_import, print_function
 
 from tempfile import NamedTemporaryFile
 

--- a/pyemma/coordinates/tests/test_traj_info_cache.py
+++ b/pyemma/coordinates/tests/test_traj_info_cache.py
@@ -28,7 +28,7 @@ import os
 import tempfile
 import unittest
 
-from unittest import mock
+import mock
 
 from pyemma.coordinates import api
 from pyemma.coordinates.data.feature_reader import FeatureReader

--- a/pyemma/coordinates/transform/pca.py
+++ b/pyemma/coordinates/transform/pca.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from __future__ import absolute_import
 
 import math
 

--- a/pyemma/coordinates/transform/tica.py
+++ b/pyemma/coordinates/transform/tica.py
@@ -20,6 +20,7 @@ Created on 19.01.2015
 @author: marscher
 '''
 
+from __future__ import absolute_import
 
 import numpy as np
 from decorator import decorator

--- a/pyemma/coordinates/util/patches.py
+++ b/pyemma/coordinates/util/patches.py
@@ -22,6 +22,7 @@ Created on 13.03.2015
 @author: marscher
 '''
 
+from __future__ import absolute_import
 
 from collections import namedtuple
 
@@ -273,7 +274,7 @@ class iterload(object):
 
 def _read_traj_data(atom_indices, f, n_frames, **kwargs):
     """
-
+    
     Parameters
     ----------
     atom_indices
@@ -284,7 +285,7 @@ def _read_traj_data(atom_indices, f, n_frames, **kwargs):
     Returns
     -------
     data : TrajData(xyz, unitcell_length, unitcell_angles, box)
-
+    
     Format read() return values:
      amber_netcdf_restart_f: xyz [Ang], time, cell_l, cell_a
      amber restart: xyz[Ang], time, cell_l, cell_a
@@ -302,7 +303,7 @@ def _read_traj_data(atom_indices, f, n_frames, **kwargs):
 
      trr: xyz[nm], time, step, box (n, 3, 3), lambd?
      xtc: xyz[nm], time, step, box
-
+     
      xyz: xyz
      lh5: xyz [nm]
      arc: xyz[Ang]

--- a/pyemma/coordinates/util/stat.py
+++ b/pyemma/coordinates/util/stat.py
@@ -18,6 +18,7 @@
 
 
 
+from __future__ import absolute_import
 import numpy as np
 from pyemma.util.annotators import deprecated
 

--- a/pyemma/datasets/api.py
+++ b/pyemma/datasets/api.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 from pyemma.datasets.double_well_thermo import DoubleWellSampler as _DWS
 __author__ = 'noe'
 

--- a/pyemma/datasets/double_well_discrete.py
+++ b/pyemma/datasets/double_well_discrete.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 
 __author__ = 'noe'
 

--- a/pyemma/datasets/double_well_thermo.py
+++ b/pyemma/datasets/double_well_thermo.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 
 import numpy as _np
 from pyemma.coordinates import assign_to_centers as _assign_to_centers

--- a/pyemma/msm/__init__.py
+++ b/pyemma/msm/__init__.py
@@ -78,6 +78,7 @@ Low-level functions for estimation and analysis of transition matrices and io ha
 
 
 """
+from __future__ import absolute_import as _
 
 ######################################################
 from msmtools.analysis.dense.pcca import PCCA

--- a/pyemma/msm/api.py
+++ b/pyemma/msm/api.py
@@ -20,6 +20,7 @@ r"""User API for the pyemma.msm package
 
 """
 
+from __future__ import absolute_import
 from .estimators import MaximumLikelihoodHMSM as _ML_HMSM
 from .estimators import BayesianMSM as _Bayes_MSM
 from .estimators import BayesianHMSM as _Bayes_HMSM

--- a/pyemma/msm/estimators/__init__.py
+++ b/pyemma/msm/estimators/__init__.py
@@ -16,11 +16,12 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 __author__ = 'noe'
 
 from .maximum_likelihood_msm import MaximumLikelihoodMSM
 from .maximum_likelihood_msm import OOMReweightedMSM
-from .maximum_likelihood_msm import AugmentedMarkovModel
+from .maximum_likelihood_msm import AugmentedMarkovModel 
 from .bayesian_msm import BayesianMSM
 from .maximum_likelihood_hmsm import MaximumLikelihoodHMSM
 from .bayesian_hmsm import BayesianHMSM

--- a/pyemma/msm/estimators/_dtraj_stats.py
+++ b/pyemma/msm/estimators/_dtraj_stats.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 
 
 import numpy as np

--- a/pyemma/msm/estimators/bayesian_hmsm.py
+++ b/pyemma/msm/estimators/bayesian_hmsm.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import, print_function
 
 import numpy as _np
 

--- a/pyemma/msm/estimators/bayesian_msm.py
+++ b/pyemma/msm/estimators/bayesian_msm.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 
 
 

--- a/pyemma/msm/estimators/implied_timescales.py
+++ b/pyemma/msm/estimators/implied_timescales.py
@@ -23,6 +23,7 @@ Created on Jul 26, 2014
 @author: noe
 '''
 
+from __future__ import absolute_import, print_function
 
 import numpy as np
 

--- a/pyemma/msm/estimators/lagged_model_validators.py
+++ b/pyemma/msm/estimators/lagged_model_validators.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 
 
 import math

--- a/pyemma/msm/estimators/maximum_likelihood_hmsm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_hmsm.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 # 
 from pyemma.util.annotators import alias, aliased, fix_docs
 

--- a/pyemma/msm/models/__init__.py
+++ b/pyemma/msm/models/__init__.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 __author__ = 'noe'
 
 from .msm import MSM

--- a/pyemma/msm/models/hmsm.py
+++ b/pyemma/msm/models/hmsm.py
@@ -25,6 +25,7 @@ and provides them for later access.
 
 """
 
+from __future__ import absolute_import
 
 import numpy as _np
 

--- a/pyemma/msm/models/hmsm_sampled.py
+++ b/pyemma/msm/models/hmsm_sampled.py
@@ -25,6 +25,7 @@ and provides them for later access.
 
 """
 
+from __future__ import absolute_import
 
 from pyemma._base.model import SampledModel as _SampledModel
 from pyemma.msm.models.hmsm import HMSM as _HMSM

--- a/pyemma/msm/models/msm.py
+++ b/pyemma/msm/models/msm.py
@@ -25,6 +25,7 @@ and provides them for later access.
 
 """
 
+from __future__ import absolute_import
 
 from pyemma._base.serialization.serialization import SerializableMixIn
 

--- a/pyemma/msm/models/reactive_flux.py
+++ b/pyemma/msm/models/reactive_flux.py
@@ -21,6 +21,8 @@ analysis of Markov models.
 __moduleauthor__ = "Benjamin Trendelkamp-Schroer, Frank Noe"
 
 """
+from __future__ import absolute_import
+from __future__ import division
 import numpy as np
 
 from msmtools import flux as tptapi

--- a/pyemma/msm/tests/birth_death_chain.py
+++ b/pyemma/msm/tests/birth_death_chain.py
@@ -23,6 +23,7 @@ r"""Birth death chain for testing
 
 """
 
+from __future__ import absolute_import
 
 import numpy as np
 

--- a/pyemma/msm/tests/test_amm.py
+++ b/pyemma/msm/tests/test_amm.py
@@ -28,6 +28,7 @@ import unittest
 import numpy as np
 import warnings
 
+import six
 from msmtools.generation import generate_traj
 from pyemma.msm.tests.birth_death_chain import BirthDeathChain
 from pyemma.msm import estimate_augmented_markov_model, AugmentedMarkovModel
@@ -336,6 +337,7 @@ class TestAMMDoubleWell(_tmsm):
         #pass
         self._two_state_kinetics(self.amm, eps=0.01)
 
+    @unittest.skipIf(six.PY2, 'only py3')
     def test_serialize(self):
         import tempfile
         import pyemma

--- a/pyemma/msm/tests/test_amm.py
+++ b/pyemma/msm/tests/test_amm.py
@@ -22,6 +22,7 @@ r"""Unit test for the AMM module
 
 """
 
+from __future__ import absolute_import
 import unittest
 
 import numpy as np

--- a/pyemma/msm/tests/test_bayesian_hmsm.py
+++ b/pyemma/msm/tests/test_bayesian_hmsm.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 import unittest
 import numpy as np
 from pyemma.msm import bayesian_hidden_markov_model

--- a/pyemma/msm/tests/test_bayesian_msm.py
+++ b/pyemma/msm/tests/test_bayesian_msm.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 import unittest
 import numpy as np
 from pyemma.msm import bayesian_markov_model

--- a/pyemma/msm/tests/test_cktest.py
+++ b/pyemma/msm/tests/test_cktest.py
@@ -23,6 +23,7 @@ r"""Unit test for Chapman-Kolmogorov-Test module
 
 """
 
+from __future__ import absolute_import
 import unittest
 
 import numpy as np

--- a/pyemma/msm/tests/test_estimator.py
+++ b/pyemma/msm/tests/test_estimator.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
-from unittest import mock
+import mock
 from pyemma import msm
 from functools import wraps
 

--- a/pyemma/msm/tests/test_hmsm.py
+++ b/pyemma/msm/tests/test_hmsm.py
@@ -21,6 +21,7 @@ Test MLHMM.
 
 """
 
+from __future__ import absolute_import
 
 import unittest
 import numpy as np

--- a/pyemma/msm/tests/test_its.py
+++ b/pyemma/msm/tests/test_its.py
@@ -24,6 +24,7 @@ r"""Unit test for the its method
 
 """
 
+from __future__ import absolute_import
 import unittest
 import numpy as np
 from pyemma import msm

--- a/pyemma/msm/tests/test_its_oom.py
+++ b/pyemma/msm/tests/test_its_oom.py
@@ -20,6 +20,7 @@ r"""Unit test for implied timescale test using OOM-based MSM estimation.
 
 """
 
+from __future__ import absolute_import
 import unittest
 
 import numpy as np

--- a/pyemma/msm/tests/test_msm.py
+++ b/pyemma/msm/tests/test_msm.py
@@ -24,6 +24,7 @@ r"""Unit test for the MSM module
 
 """
 
+from __future__ import absolute_import
 import unittest
 
 import numpy as np

--- a/pyemma/msm/tests/test_msm_serialization.py
+++ b/pyemma/msm/tests/test_msm_serialization.py
@@ -19,6 +19,7 @@ import tempfile
 import unittest
 
 import numpy as np
+import six
 
 import pyemma
 from pyemma import datasets
@@ -26,6 +27,7 @@ from pyemma import load
 from pyemma.msm import bayesian_markov_model
 
 
+@unittest.skipIf(six.PY2, 'only py3')
 class TestMSMSerialization(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/pyemma/msm/tests/test_oom_msm.py
+++ b/pyemma/msm/tests/test_oom_msm.py
@@ -21,6 +21,7 @@ r"""Unit test for the OOM-based MSM estimation.
 
 """
 
+from __future__ import absolute_import
 import unittest
 
 import numpy as np

--- a/pyemma/msm/tests/test_reactive_flux.py
+++ b/pyemma/msm/tests/test_reactive_flux.py
@@ -25,6 +25,7 @@ from __future__ import absolute_import
 from __future__ import division
 import unittest
 import numpy as np
+import six
 from numpy.testing import assert_allclose
 
 from pyemma import msm as msmapi
@@ -198,6 +199,7 @@ class TestReactiveFluxFunctions(unittest.TestCase):
         assert_allclose(cgRF.net_flux, self.ref2_cgnetflux, rtol=1.e-5, atol=1.e-8)
         assert_allclose(cgRF.gross_flux, self.ref2_cggrossflux, rtol=1.e-5, atol=1.e-8)
 
+    @unittest.skipIf(six.PY2, 'only py3')
     def test_serialization(self):
         import pyemma
         import tempfile

--- a/pyemma/msm/tests/test_reactive_flux.py
+++ b/pyemma/msm/tests/test_reactive_flux.py
@@ -21,6 +21,8 @@ r"""Unit test for the ReactiveFlux object
 .. moduleauthor:: F.Noe <frank  DOT noe AT fu-berlin DOT de>
 
 """
+from __future__ import absolute_import
+from __future__ import division
 import unittest
 import numpy as np
 from numpy.testing import assert_allclose

--- a/pyemma/msm/tests/test_tpt.py
+++ b/pyemma/msm/tests/test_tpt.py
@@ -24,6 +24,7 @@ r"""Unit test for the tpt-function
 
 """
 
+from __future__ import absolute_import
 import unittest
 import numpy as np
 from pyemma.util.numeric import assert_allclose

--- a/pyemma/plots/__init__.py
+++ b/pyemma/plots/__init__.py
@@ -62,6 +62,7 @@ Classes
    NetworkPlot
 
 """
+from __future__ import absolute_import
 from .timescales import plot_implied_timescales
 from .plots2d import contour, scatter_contour, plot_free_energy
 from .networks import plot_markov_model, plot_flux, plot_network, NetworkPlot

--- a/pyemma/plots/markovtests.py
+++ b/pyemma/plots/markovtests.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 __author__ = 'noe'
 
 import math

--- a/pyemma/plots/networks.py
+++ b/pyemma/plots/networks.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from __future__ import absolute_import
 import numpy as _np
 import warnings
 from pyemma.util import types as _types

--- a/pyemma/plots/plots2d.py
+++ b/pyemma/plots/plots2d.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 
 import numpy as _np
 

--- a/pyemma/plots/tests/test_its.py
+++ b/pyemma/plots/tests/test_its.py
@@ -22,6 +22,7 @@ Created on 10.03.2016
 @author: gph82
 '''
 
+from __future__ import absolute_import
 import unittest
 import numpy as np
 

--- a/pyemma/plots/tests/test_markovtests.py
+++ b/pyemma/plots/tests/test_markovtests.py
@@ -22,6 +22,7 @@ Created on 23.03.2016
 @author: marscher
 '''
 
+from __future__ import absolute_import
 import unittest
 import numpy as np
 import pyemma

--- a/pyemma/plots/tests/test_networks.py
+++ b/pyemma/plots/tests/test_networks.py
@@ -22,6 +22,7 @@ Created on 22.05.2015
 @author: marscher
 '''
 
+from __future__ import absolute_import
 import unittest
 import numpy as np
 

--- a/pyemma/plots/tests/test_plots2d.py
+++ b/pyemma/plots/tests/test_plots2d.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from __future__ import absolute_import
 import unittest
 import numpy as np
 

--- a/pyemma/plots/timescales.py
+++ b/pyemma/plots/timescales.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 
 
 import numpy as _np

--- a/pyemma/thermo/tests/test_TRAM.py
+++ b/pyemma/thermo/tests/test_TRAM.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 import unittest
 
 

--- a/pyemma/thermo/tests/test_api.py
+++ b/pyemma/thermo/tests/test_api.py
@@ -69,6 +69,10 @@ def validate_kinetics(obj, estimator):
 
 def check_serialization(estimator):
     # check if the serialized and restored estimator still holds the derived quantities.
+    import six
+    if six.PY2:
+        return
+
     import pyemma
     from pyemma.thermo import WHAM, TRAM, DTRAM, MBAR
     from pyemma._base.serialization.serialization import SerializableMixIn

--- a/pyemma/thermo/tests/test_thermo_msm.py
+++ b/pyemma/thermo/tests/test_thermo_msm.py
@@ -18,6 +18,8 @@
 import unittest
 import numpy as np
 import numpy.testing as npt
+import six
+
 from pyemma.thermo.models.memm import ThermoMSM
 from pyemma.msm import MSM
 
@@ -67,6 +69,7 @@ class TestThermoMSM(unittest.TestCase):
         npt.assert_allclose(
             self.msm.eigenvectors_right_full_state(k=self.nstates-1), self.eigvec_r_full)
 
+    @unittest.skipIf(six.PY2, 'only py3')
     def test_serialization(self):
         ''' check if the test still hold for a restored model. '''
         import tempfile

--- a/pyemma/util/__init__.py
+++ b/pyemma/util/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 from ._config import Config as _Config
 
 # default config instance

--- a/pyemma/util/_config.py
+++ b/pyemma/util/_config.py
@@ -17,7 +17,7 @@
 
 from __future__ import absolute_import, print_function
 
-import configparser
+from six.moves.configparser import ConfigParser
 import os
 import shutil
 import warnings
@@ -352,7 +352,7 @@ class Config(object):
                 shutil.copyfile(src, dest)
 
     def __read_cfg(self, filenames):
-        config = configparser.ConfigParser()
+        config = ConfigParser()
 
         try:
             self._used_filenames = config.read(filenames)

--- a/pyemma/util/_config.py
+++ b/pyemma/util/_config.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import, print_function
 
 import configparser
 import os

--- a/pyemma/util/annotators.py
+++ b/pyemma/util/annotators.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import
 import warnings
 
 from decorator import decorator, decorate

--- a/pyemma/util/contexts.py
+++ b/pyemma/util/contexts.py
@@ -99,7 +99,7 @@ def attribute(obj, attr, val):
 
 
 @contextmanager
-def named_temporary_file(mode='w+b', prefix=None, suffix=None, dir=None):
+def named_temporary_file(mode='w+b', prefix='', suffix='', dir=None):
     from tempfile import NamedTemporaryFile
     ntf = NamedTemporaryFile(mode=mode, suffix=suffix, prefix=prefix, dir=dir, delete=False)
     ntf.close()

--- a/pyemma/util/debug.py
+++ b/pyemma/util/debug.py
@@ -26,6 +26,7 @@ Created on 15.10.2015
 
 @author: marscher
 '''
+from __future__ import absolute_import, print_function
 
 import signal
 from logging import getLogger

--- a/pyemma/util/files.py
+++ b/pyemma/util/files.py
@@ -22,6 +22,7 @@ Created on 17.02.2014
 
 @author: marscher
 '''
+from __future__ import absolute_import, print_function
 
 import os
 import errno

--- a/pyemma/util/indices.py
+++ b/pyemma/util/indices.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 import numpy as np
 
 

--- a/pyemma/util/linalg.py
+++ b/pyemma/util/linalg.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from __future__ import absolute_import
 import numpy as np
 import scipy.linalg
 import scipy.sparse

--- a/pyemma/util/log.py
+++ b/pyemma/util/log.py
@@ -20,6 +20,7 @@ Created on 15.10.2013
 @author: marscher
 '''
 
+from __future__ import absolute_import
 
 import logging
 from logging.config import dictConfig

--- a/pyemma/util/numeric.py
+++ b/pyemma/util/numeric.py
@@ -21,6 +21,7 @@ Created on 28.10.2013
 
 @author: marscher
 '''
+from __future__ import absolute_import
 from numpy.testing import assert_allclose as assert_allclose_np
 
 __all__ = ['assert_allclose',

--- a/pyemma/util/reflection.py
+++ b/pyemma/util/reflection.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import division, print_function, absolute_import
 
 import inspect
 from collections import namedtuple

--- a/pyemma/util/statistics.py
+++ b/pyemma/util/statistics.py
@@ -23,6 +23,7 @@ Created on Jul 25, 2014
 @author: noe
 '''
 
+from __future__ import absolute_import
 
 import numpy as np
 import math

--- a/pyemma/util/tests/statistics_test.py
+++ b/pyemma/util/tests/statistics_test.py
@@ -23,6 +23,7 @@ Created on Jul 25, 2014
 @author: noe
 '''
 
+from __future__ import absolute_import
 import unittest
 from pyemma.util import statistics
 import numpy as np

--- a/pyemma/util/tests/test_config.py
+++ b/pyemma/util/tests/test_config.py
@@ -22,7 +22,7 @@ Created on 11.06.2015
 
 from __future__ import absolute_import, print_function
 
-import configparser
+from six.moves import configparser
 import os
 import sys
 import unittest

--- a/pyemma/util/tests/test_config.py
+++ b/pyemma/util/tests/test_config.py
@@ -174,7 +174,7 @@ class TestConfig(unittest.TestCase):
     def test_mute_progress(self):
         """ switch mute on shall turn off progress bars"""
         from pyemma._base.progress import ProgressReporterMixin
-        from unittest import mock
+        import mock
         rp = ProgressReporterMixin()
 
         self.config_inst.mute = True

--- a/pyemma/util/tests/test_config.py
+++ b/pyemma/util/tests/test_config.py
@@ -20,6 +20,7 @@ Created on 11.06.2015
 @author: marscher
 '''
 
+from __future__ import absolute_import, print_function
 
 import configparser
 import os

--- a/pyemma/util/tests/test_discrete_trajectories.py
+++ b/pyemma/util/tests/test_discrete_trajectories.py
@@ -23,6 +23,7 @@ r"""This module contains unit tests for the trajectory module
 
 """
 
+from __future__ import absolute_import
 
 import os
 import unittest

--- a/pyemma/util/tests/test_log.py
+++ b/pyemma/util/tests/test_log.py
@@ -27,7 +27,7 @@ import logging
 
 from pyemma.util import log
 from pyemma.util import config
-from unittest import mock
+import mock
 
 
 class TestNonWriteableLogFile(unittest.TestCase):

--- a/pyemma/util/tests/test_shortcut.py
+++ b/pyemma/util/tests/test_shortcut.py
@@ -18,6 +18,7 @@
 
 
 
+from __future__ import absolute_import
 from pyemma.util.annotators import shortcut, aliased, alias
 import unittest
 

--- a/pyemma/util/types.py
+++ b/pyemma/util/types.py
@@ -18,6 +18,7 @@
 
 
 
+from __future__ import print_function, absolute_import
 
 __author__ = 'noe'
 

--- a/pyemma/util/units.py
+++ b/pyemma/util/units.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import
 
 from pyemma._base.serialization.serialization import SerializableMixIn
 

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,9 @@ except ImportError as ie:
     print("PyEMMA requires setuptools. Please install it with conda or pip.")
     sys.exit(1)
 
-if sys.version_info[0] < 3:
-    print('PyEMMA requires Python3k')
-    sys.exit(2)
+#if sys.version_info[0] < 3:
+#    print('PyEMMA requires Python3k')
+#    sys.exit(2)
 
 
 DOCLINES = __doc__.split("\n")


### PR DESCRIPTION
The serialization code is for now Python3 only, because it has been written with assumptions in mind which are only valid for Py3. If one calls the (public) save method for serializable things under Python2 one will get an exception (with another upgrade notice).
However the pickup of serializable fields still works, so in case of pickling only desired stuff will be serialized.

Also fixed the doctests Numpy formatting, by passing the new legacy option in numpy.print_options.

Py27 is re-added to the build matrices of Travis and Appveyor.

The deprecation notice was on devel for 5 months, but never released. This is why we are doing this now.