### PR TITLE
[coor/api] deprecate chunk_size (now called chunksize).

### DIFF
--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -80,7 +80,7 @@ def _check_old_chunksize_arg(chunksize, chunk_size_default, **kw):
     else:
         import warnings
         if is_default:  # case 2.
-            warnings.warn('Passed deprecated argument "chunksize", please use "chunksize"',
+            warnings.warn('Passed deprecated argument "chunk_size", please use "chunksize"',
                           category=_PyEMMA_DeprecationWarning)
             chosen_chunk_size = kw.pop('chunk_size')  # remove this argument to avoid further passing to other funcs.
         else:  # case 3.

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -231,7 +231,7 @@ def load(trajfiles, features=None, top=None, stride=1, chunksize=None, **kw):
     """
     from pyemma.coordinates.data.util.reader_utils import create_file_reader
     from pyemma.util.reflection import get_default_args
-    cs = _check_old_chunksize_arg(chunksize, get_default_args(pipeline)['chunksize'], **kw)
+    cs = _check_old_chunksize_arg(chunksize, get_default_args(load)['chunksize'], **kw)
     if isinstance(trajfiles, _string_types) or (
         isinstance(trajfiles, (list, tuple))
             and (any(isinstance(item, (list, tuple, str)) for item in trajfiles)
@@ -369,11 +369,12 @@ def source(inp, features=None, top=None, chunksize=None, **kw):
     """
     from pyemma.coordinates.data._base.iterable import Iterable
     from pyemma.coordinates.data.util.reader_utils import create_file_reader
+
+    from pyemma.util.reflection import get_default_args
+    cs = _check_old_chunksize_arg(chunksize, get_default_args(source)['chunksize'], **kw)
+
     # CASE 1: input is a string or list of strings
     # check: if single string create a one-element list
-    from pyemma.util.reflection import get_default_args
-    cs = _check_old_chunksize_arg(chunksize, get_default_args(pipeline)['chunksize'], **kw)
-
     if isinstance(inp, str) or (
             isinstance(inp, (list, tuple))
             and (any(isinstance(item, (list, tuple, str)) for item in inp) or len(inp) is 0)):
@@ -624,7 +625,7 @@ def discretizer(reader,
     return disc
 
 
-def save_traj(traj_inp, indexes, outfile, top=None, stride = 1, chunksize=None, image_molecules=False, verbose=True, **kwargs):
+def save_traj(traj_inp, indexes, outfile, top=None, stride = 1, chunksize=None, image_molecules=False, verbose=True):
     r""" Saves a sequence of frames as a single trajectory.
 
     Extracts the specified sequence of time/trajectory indexes from traj_inp
@@ -1009,7 +1010,7 @@ def pca(data=None, dim=-1, var_cutoff=0.95, stride=1, mean=None, skip=0, chunksi
     res = PCA(dim=dim, var_cutoff=var_cutoff, mean=None, skip=skip, stride=stride)
     if data is not None:
         from pyemma.util.reflection import get_default_args
-        cs = _check_old_chunksize_arg(chunksize, get_default_args(cluster_kmeans)['chunksize'], **kwargs)
+        cs = _check_old_chunksize_arg(chunksize, get_default_args(pca)['chunksize'], **kwargs)
         res.estimate(data, chunksize=cs)
     return res
 
@@ -1213,7 +1214,7 @@ def tica(data=None, lag=10, dim=-1, var_cutoff=0.95, kinetic_map=True, commute_m
     from pyemma.coordinates.estimation.koopman import _KoopmanEstimator
     import types
     from pyemma.util.reflection import get_default_args
-    cs = _check_old_chunksize_arg(chunksize, get_default_args(cluster_kmeans)['chunksize'], **kwargs)
+    cs = _check_old_chunksize_arg(chunksize, get_default_args(tica)['chunksize'], **kwargs)
 
     if isinstance(weights, _string_types):
         if weights == "koopman":

--- a/pyemma/coordinates/data/util/reader_utils.py
+++ b/pyemma/coordinates/data/util/reader_utils.py
@@ -24,7 +24,7 @@ import numpy as np
 import os
 
 
-def create_file_reader(input_files, topology, featurizer, chunk_size=1000, **kw):
+def create_file_reader(input_files, topology, featurizer, chunksize=None, **kw):
     r"""
     Creates a (possibly featured) file reader by a number of input files and either a topology file or a featurizer.
     Parameters
@@ -35,7 +35,7 @@ def create_file_reader(input_files, topology, featurizer, chunk_size=1000, **kw)
         A topology file. If given, the featurizer argument can be None.
     :param featurizer:
         A featurizer. If given, the topology file can be None.
-    :param chunk_size:
+    :param chunksize:
         The chunk size with which the corresponding reader gets initialized.
     :return: Returns the reader.
     """
@@ -49,7 +49,7 @@ def create_file_reader(input_files, topology, featurizer, chunk_size=1000, **kw)
     # fragmented trajectories
     if (isinstance(input_files, (list, tuple)) and len(input_files) > 0 and
             any(isinstance(item, (list, tuple)) for item in input_files)):
-        return FragmentedTrajectoryReader(input_files, topology, chunk_size, featurizer)
+        return FragmentedTrajectoryReader(input_files, topology, chunksize, featurizer)
 
     # normal trajectories
     if (isinstance(input_files, str)
@@ -96,10 +96,10 @@ def create_file_reader(input_files, topology, featurizer, chunk_size=1000, **kw)
                         from mdtraj.formats import HDF5TrajectoryFile
                         HDF5TrajectoryFile(input_list[0])
                         reader = FeatureReader(input_list, featurizer=featurizer, topologyfile=topology,
-                                               chunksize=chunk_size)
+                                               chunksize=chunksize)
                     except:
                         from pyemma.coordinates.data.h5_reader import H5Reader
-                        reader = H5Reader(filenames=input_files, chunk_size=chunk_size, **kw)
+                        reader = H5Reader(filenames=input_files, chunk_size=chunksize, **kw)
                 # CASE 1.1: file types are MD files
                 elif suffix in list(FormatRegistry.loaders.keys()):
                     # check: do we either have a featurizer or a topology file name? If not: raise ValueError.
@@ -109,13 +109,13 @@ def create_file_reader(input_files, topology, featurizer, chunk_size=1000, **kw)
                                          "featurizer or a topology file.")
 
                     reader = FeatureReader(input_list, featurizer=featurizer, topologyfile=topology,
-                                           chunksize=chunk_size)
+                                           chunksize=chunksize)
                 else:
                     if suffix in ['.npy', '.npz']:
-                        reader = NumPyFileReader(input_list, chunksize=chunk_size)
+                        reader = NumPyFileReader(input_list, chunksize=chunksize)
                     # otherwise we assume that given files are ascii tabulated data
                     else:
-                        reader = PyCSVReader(input_list, chunksize=chunk_size, **kw)
+                        reader = PyCSVReader(input_list, chunksize=chunksize, **kw)
         else:
             raise ValueError("Not all elements in the input list were of the type %s!" % suffix)
     else:

--- a/pyemma/coordinates/tests/test_api_source.py
+++ b/pyemma/coordinates/tests/test_api_source.py
@@ -116,9 +116,9 @@ class TestApiSourceFileReader(unittest.TestCase):
 
     def test_source_set_chunksize(self):
         x = np.zeros(10)
-        r = api.source(x, chunk_size=1)
+        r = api.source(x, chunksize=1)
         assert r.chunksize == 1
-        r2 = api.source(r, chunk_size=2)
+        r2 = api.source(r, chunksize=2)
         assert r2 is r
         assert r2.chunksize == 2
 

--- a/pyemma/coordinates/tests/test_save_traj.py
+++ b/pyemma/coordinates/tests/test_save_traj.py
@@ -212,7 +212,7 @@ class TestSaveTraj(unittest.TestCase):
     def test_with_fragmented_reader_chunksize_0(self):
         # intentionally group bpti dataset to a fake fragmented traj
         frag_traj = [[self.trajfiles[0], self.trajfiles[1]], self.trajfiles[2], self.trajfiles[2]]
-        reader = coor.source(frag_traj, top=self.pdbfile, chunk_size=0)
+        reader = coor.source(frag_traj, top=self.pdbfile, chunksize=0)
         assert reader.chunksize == 0
         traj = save_traj(reader, self.sets, None)
         traj_ref = save_traj_w_md_load_frame(self.reader, self.sets)


### PR DESCRIPTION
Fixes #1235 by replacing chunk_size with chunksize. One get a deprecation warning, if one uses the old parameter.