### PR TITLE
[doc] filter stupid widget notice from nbconverted output.

### DIFF
--- a/doc/jupyter_nbconvert_config.py
+++ b/doc/jupyter_nbconvert_config.py
@@ -1,5 +1,5 @@
 # Configuration file for jupyter-nbconvert.
-
+c = get_config()
 #------------------------------------------------------------------------------
 # Configurable configuration
 #------------------------------------------------------------------------------
@@ -123,7 +123,7 @@ c.NbConvertApp.export_format = 'rst'
 # c.Exporter.file_extension = '.txt'
 
 # List of preprocessors, by name or namespace, to enable.
-# c.Exporter.preprocessors = []
+c.Exporter.preprocessors = ['nbconvert_filter.RemoveWidgetNotice']
 
 #------------------------------------------------------------------------------
 # TemplateExporter configuration

--- a/doc/nbconvert_filter.py
+++ b/doc/nbconvert_filter.py
@@ -1,0 +1,38 @@
+from nbconvert.preprocessors import Preprocessor
+
+
+class RemoveWidgetNotice(Preprocessor):
+    # in ipywidgets 7, the state of a closed widget (progress bars) is saved to the ipynb file, generating a stupid
+    # message like 'If you're reading this message in the Jupyter Notebook or JupyterLab Notebook, it may mean\n",
+    #   "  that the widgets JavaScript is still loading.'
+    # If this preprocessor finds such a thing in the output, we just clear it.
+
+    def preprocess_cell(self, cell, resources, index):
+        """
+        Override if you want to apply some preprocessing to each cell.
+        Must return modified cell and resource dictionary.
+
+        Parameters
+        ----------
+        cell : NotebookNode cell
+            Notebook cell being processed
+        resources : dictionary
+            Additional resources used in the conversion process.  Allows
+            preprocessors to pass variables into the Jinja engine.
+        index : int
+            Index of the cell being processed
+        """
+        if 'outputs' in cell:
+            outputs = cell['outputs']  # list
+            to_delete = []
+            for i, o in enumerate(outputs):
+                #print(o)
+                if 'data' in o:
+                    data = o['data']
+                    if 'application/vnd.jupyter.widget-view+json' in data:
+                        to_delete.append(o)
+            for o in to_delete:
+                #print('removing: ', o)
+                outputs.remove(o)
+
+        return cell, resources


### PR DESCRIPTION
In ipywidgets-7 there is a serialization method widget states. However,
there is no way to clear this state easily prior exporting (clear-all
or nothing, which we do not want, because we want to keep plots etc.).
So this hack now kicks out output elements, if they are part of this
generated widget output.
