### PR TITLE
[vamp] added missing ctor to VAMPModel to initialize all fields properly

### DIFF
--- a/pyemma/coordinates/transform/vamp.py
+++ b/pyemma/coordinates/transform/vamp.py
@@ -41,6 +41,10 @@ class VAMPModel(Model, SerializableMixIn):
     __serialize_version = 0
     __serialize_fields = ('_U', '_singular_values', '_V', '_rank0', '_rankt', '_svd_performed')
 
+    def __init__(self, mean_0=None, mean_t=None, C00=None, Ctt=None, C0t=None, dim=None, epsilon=1e-6, scaling=None):
+        self.set_model_params(mean_0=mean_0, mean_t=mean_t, C00=C00, Ctt=Ctt, C0t=C0t,
+                              dim=dim, epsilon=epsilon, scaling=scaling)
+
     def set_model_params(self, mean_0, mean_t, C00, Ctt, C0t, dim, epsilon, scaling=None):
         self.mean_0 = mean_0
         self.mean_t = mean_t


### PR DESCRIPTION
Somehow this case was not covered.
I got an exception during the diagonalization, because self._scaling does not exist. This was caused by a missing constructor/invocation of the setter. I think update_model_params does not play nicely with properties, because it has been written with the assumption that attributes are always plain. Eg. it does only update/set the value, if it does not exist or the value is not None.
Perhaps we should change that too. 