### PR TITLE
[Iterable] fix default_chunksize calculation.

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+2.5.1 (02-14-2018)
+------------------
+
+Quick fix release to repair chunking in the coordinates package.
+
+**Fixes**:
+
+- coordinates: fixed handling of default chunksize. #1247
+
+
 2.5 (02-09-2018)
 ----------------
 

--- a/pyemma/coordinates/data/_base/iterable.py
+++ b/pyemma/coordinates/data/_base/iterable.py
@@ -58,9 +58,10 @@ class Iterable(six.with_metaclass(ABCMeta, InMemoryMixin, Loggable)):
                 max_bytes = string_to_bytes(config.default_chunksize)
                 itemsize = np.dtype(self.output_type()).itemsize
                 # TODO: consider rounding this to some cache size of CPU? e.g py-cpuinfo can obtain it.
-                max_elements = max_bytes // (itemsize * self.ndim)
-                assert max_elements * self.ndim * itemsize <= max_bytes
-                self._default_chunksize = max_elements // self.ndim
+                # if one time step is already bigger than max_memory, we set the chunksize to 1.
+                max_elements = max(1, int(np.floor(max_bytes / (itemsize * self.ndim))))
+                assert max_elements * self.ndim * itemsize <= max_bytes or max_elements == 1
+                self._default_chunksize = max(1, max_elements // self.ndim)
                 assert self._default_chunksize > 0, self._default_chunksize
         return self._default_chunksize
 

--- a/pyemma/coordinates/data/_base/iterable.py
+++ b/pyemma/coordinates/data/_base/iterable.py
@@ -49,8 +49,8 @@ class Iterable(six.with_metaclass(ABCMeta, InMemoryMixin, Loggable)):
                 # some overloads of dimension can raise, eg. PCA, TICA
                 dim = self.dimension()
             except:
-                self.logger.info('could not obtain output dimension, defaulting to chunksize=100')
-                self._default_chunksize = 100
+                self.logger.info('could not obtain output dimension, defaulting to chunksize=1000')
+                self._default_chunksize = 1000
             else:
                 # obtain a human readable memory size from the config, convert it to bytes and calc maximum chunksize.
                 from pyemma import config
@@ -61,7 +61,7 @@ class Iterable(six.with_metaclass(ABCMeta, InMemoryMixin, Loggable)):
                 max_elements = max_bytes // (itemsize * self.ndim)
                 assert max_elements * self.ndim * itemsize <= max_bytes
                 self._default_chunksize = max_elements // self.ndim
-                assert self._default_chunksize >= 0, self._default_chunksize
+                assert self._default_chunksize > 0, self._default_chunksize
         return self._default_chunksize
 
     @property

--- a/pyemma/coordinates/tests/test_coordinates_iterator.py
+++ b/pyemma/coordinates/tests/test_coordinates_iterator.py
@@ -103,6 +103,15 @@ class TestCoordinatesIterator(unittest.TestCase):
             it.chunksize = cs[i]
             assert it.chunksize == cs[i]
 
+    def test_chunksize_max_memory(self):
+        from pyemma.util.contexts import settings
+        data = np.random.random((10000, 10))
+        max_size = 1024
+        with settings(default_chunksize=str(max_size)):
+            r = DataInMemory(data)
+            for itraj, x in r.iterator():
+                self.assertLessEqual(x.nbytes, max_size)
+
     def test_last_chunk(self):
         r = DataInMemory(self.d)
         it = r.iterator(chunk=0)


### PR DESCRIPTION
I think we need to release 2.5.1... 