### PR TITLE
[coordinates] handle default_chunksize gracefully.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ build*
 *.egg-info
 *.so
 /temp
+/tmp
 /target
 __pycache__
 /pylint/pylint_*.txt

--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -9,7 +9,7 @@ Quick fix release to repair chunking in the coordinates package.
 **Fixes**:
 
 - msm: fix bug in ImpliedTimescales, which happened when an estimation failed for a given lag time. #1248
-- coordinates: fixed handling of default chunksize. #1247
+- coordinates: fixed handling of default chunksize. #1247, #1251
 - base: updated pybind to 2.2.2. #1249
 
 

--- a/pyemma/_base/progress/reporter/__init__.py
+++ b/pyemma/_base/progress/reporter/__init__.py
@@ -193,7 +193,9 @@ class ProgressReporterMixin(object):
 
         pg = self._prog_rep_progressbars[stage]
         pg.desc = description
-        pg.update(int(pg.total - pg.n))
+        increment = int(pg.total - pg.n)
+        if increment > 0:
+            pg.update(increment)
         pg.refresh(nolock=True)
         pg.close()
         self._prog_rep_progressbars.pop(stage, None)

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -1012,10 +1012,12 @@ def pca(data=None, dim=-1, var_cutoff=0.95, stride=1, mean=None, skip=0, chunksi
         warnings.warn("provided mean ignored", DeprecationWarning)
 
     res = PCA(dim=dim, var_cutoff=var_cutoff, mean=None, skip=skip, stride=stride)
+    from pyemma.util.reflection import get_default_args
+    cs = _check_old_chunksize_arg(chunksize, get_default_args(pca)['chunksize'], **kwargs)
     if data is not None:
-        from pyemma.util.reflection import get_default_args
-        cs = _check_old_chunksize_arg(chunksize, get_default_args(pca)['chunksize'], **kwargs)
         res.estimate(data, chunksize=cs)
+    else:
+        res.chunksize = cs
     return res
 
 
@@ -1256,6 +1258,8 @@ def tica(data=None, lag=10, dim=-1, var_cutoff=0.95, kinetic_map=True, commute_m
                weights=weights, reversible=reversible, ncov_max=ncov_max)
     if data is not None:
         res.estimate(data, chunksize=cs)
+    else:
+        res.chunksize = cs
     return res
 
 
@@ -1406,6 +1410,8 @@ def vamp(data=None, lag=10, dim=None, scaling=None, right=True, ncov_max=float('
     res = VAMP(lag, dim=dim, scaling=scaling, right=right, skip=skip, ncov_max=ncov_max)
     if data is not None:
         res.estimate(data, stride=stride, chunksize=chunksize)
+    else:
+        res.chunksize = chunksize
     return res
 
 
@@ -1502,6 +1508,8 @@ def covariance_lagged(data=None, c00=True, c0t=True, ctt=False, remove_constant_
                           weights=weights, stride=stride, skip=skip, ncov_max=ncov_max)
     if data is not None:
         lc.estimate(data, chunksize=chunksize)
+    else:
+        lc.chunksize = chunksize
     return lc
 
 
@@ -1552,10 +1560,12 @@ def cluster_mini_batch_kmeans(data=None, k=100, max_iter=10, batch_size=0.2, met
     from pyemma.coordinates.clustering.kmeans import MiniBatchKmeansClustering
     res = MiniBatchKmeansClustering(n_clusters=k, max_iter=max_iter, metric=metric, init_strategy=init_strategy,
                                     batch_size=batch_size, n_jobs=n_jobs, skip=skip, clustercenters=clustercenters)
+    from pyemma.util.reflection import get_default_args
+    cs = _check_old_chunksize_arg(chunksize, get_default_args(cluster_mini_batch_kmeans)['chunksize'], **kwargs)
     if data is not None:
-        from pyemma.util.reflection import get_default_args
-        cs = _check_old_chunksize_arg(chunksize, get_default_args(cluster_mini_batch_kmeans)['chunksize'], **kwargs)
         res.estimate(data, chunksize=cs)
+    else:
+        res.chunksize = chunksize
     return res
 
 
@@ -1687,10 +1697,12 @@ def cluster_kmeans(data=None, k=None, max_iter=10, tolerance=1e-5, stride=1,
     res = KmeansClustering(n_clusters=k, max_iter=max_iter, metric=metric, tolerance=tolerance,
                            init_strategy=init_strategy, fixed_seed=fixed_seed, n_jobs=n_jobs, skip=skip,
                            keep_data=keep_data, clustercenters=clustercenters, stride=stride)
+    from pyemma.util.reflection import get_default_args
+    cs = _check_old_chunksize_arg(chunksize, get_default_args(cluster_kmeans)['chunksize'], **kwargs)
     if data is not None:
-        from pyemma.util.reflection import get_default_args
-        cs = _check_old_chunksize_arg(chunksize, get_default_args(cluster_kmeans)['chunksize'], **kwargs)
         res.estimate(data, chunksize=cs)
+    else:
+        res.chunksize = cs
     return res
 
 
@@ -1764,10 +1776,12 @@ def cluster_uniform_time(data=None, k=None, stride=1, metric='euclidean',
     """
     from pyemma.coordinates.clustering.uniform_time import UniformTimeClustering
     res = UniformTimeClustering(k, metric=metric, n_jobs=n_jobs, skip=skip, stride=stride)
+    from pyemma.util.reflection import get_default_args
+    cs = _check_old_chunksize_arg(chunksize, get_default_args(cluster_uniform_time)['chunksize'], **kwargs)
     if data is not None:
-        from pyemma.util.reflection import get_default_args
-        cs = _check_old_chunksize_arg(chunksize, get_default_args(cluster_uniform_time)['chunksize'], **kwargs)
         res.estimate(data, chunksize=cs)
+    else:
+        res.chunksize = cs
     return res
 
 
@@ -1863,10 +1877,12 @@ def cluster_regspace(data=None, dmin=-1, max_centers=1000, stride=1, metric='euc
     from pyemma.coordinates.clustering.regspace import RegularSpaceClustering as _RegularSpaceClustering
     res = _RegularSpaceClustering(dmin, max_centers=max_centers, metric=metric,
                                   n_jobs=n_jobs, stride=stride, skip=skip)
+    from pyemma.util.reflection import get_default_args
+    cs = _check_old_chunksize_arg(chunksize, get_default_args(cluster_regspace)['chunksize'], **kwargs)
     if data is not None:
-        from pyemma.util.reflection import get_default_args
-        cs = _check_old_chunksize_arg(chunksize, get_default_args(cluster_regspace)['chunksize'], **kwargs)
         res.estimate(data, chunksize=cs)
+    else:
+        res.chunksize = cs
     return res
 
 
@@ -1952,11 +1968,13 @@ def assign_to_centers(data=None, centers=None, stride=1, return_dtrajs=True,
                          ' or NumPy array or a reader created by source function')
     from pyemma.coordinates.clustering.assign import AssignCenters
     res = AssignCenters(centers, metric=metric, n_jobs=n_jobs, skip=skip, stride=stride)
+    from pyemma.util.reflection import get_default_args
+    cs = _check_old_chunksize_arg(chunksize, get_default_args(assign_to_centers)['chunksize'], **kwargs)
     if data is not None:
-        from pyemma.util.reflection import get_default_args
-        cs = _check_old_chunksize_arg(chunksize, get_default_args(assign_to_centers)['chunksize'], **kwargs)
         res.estimate(data, chunksize=cs)
         if return_dtrajs:
             return res.dtrajs
+    else:
+        res.chunksize = cs
 
     return res

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -1271,14 +1271,13 @@ def vamp(data=None, lag=10, dim=None, scaling=None, right=True, ncov_max=float('
       ----------
       lag : int
           lag time
-      dim : float or int
+      dim : float or int, default=None
           Number of dimensions to keep:
 
-          * if dim is not set all available ranks are kept:
+          * if dim is not set (None) all available ranks are kept:
               `n_components == min(n_samples, n_features)`
           * if dim is an integer >= 1, this number specifies the number
-            of dimensions to keep. By default this will use the kinetic
-            variance.
+            of dimensions to keep.
           * if dim is a float with ``0 < dim < 1``, select the number
             of dimensions such that the amount of kinetic variance
             that needs to be explained is greater than the percentage

--- a/pyemma/coordinates/data/_base/datasource.py
+++ b/pyemma/coordinates/data/_base/datasource.py
@@ -222,7 +222,7 @@ class DataSource(Iterable, TrajectoryRandomAccessible):
             n = self.ntraj
         return n
 
-    def trajectory_length(self, itraj, stride=1, skip=None):
+    def trajectory_length(self, itraj, stride=1, skip=0):
         r"""Returns the length of trajectory of the requested index.
 
         Parameters
@@ -246,7 +246,9 @@ class DataSource(Iterable, TrajectoryRandomAccessible):
             selection = stride[stride[:, 0] == itraj][:, 0]
             return 0 if itraj not in selection else len(selection)
         else:
-            return (self._lengths[itraj] - (0 if skip is None else skip) - 1) // int(stride) + 1
+            res = (self._lengths[itraj] - skip - 1) // int(stride) + 1
+            assert res >= 0
+            return res
 
     def n_chunks(self, chunksize, stride=1, skip=0):
         """ how many chunks an iterator of this sourcde will output, starting (eg. after calling reset())

--- a/pyemma/coordinates/data/_base/datasource.py
+++ b/pyemma/coordinates/data/_base/datasource.py
@@ -246,6 +246,7 @@ class DataSource(Iterable, TrajectoryRandomAccessible):
             selection = stride[stride[:, 0] == itraj][:, 0]
             return 0 if itraj not in selection else len(selection)
         else:
+            skip = 0 if skip is None else skip
             res = (self._lengths[itraj] - skip - 1) // int(stride) + 1
             assert res >= 0
             return res

--- a/pyemma/coordinates/data/_base/datasource.py
+++ b/pyemma/coordinates/data/_base/datasource.py
@@ -661,6 +661,11 @@ class DataSourceIterator(six.with_metaclass(ABCMeta)):
         self.__init_stride(stride)
         self._pos = 0
         self._last_chunk_in_traj = False
+        if not isinstance(stride, np.ndarray) and skip > 0:
+            # skip over the trajectories that are smaller than skip
+            while self.state.itraj < self._data_source.ntraj \
+                    and self._data_source.trajectory_length(self.state.itraj, self.stride, 0) <= skip:
+                self.state.itraj += 1
         super(DataSourceIterator, self).__init__()
 
     def __init_stride(self, stride):

--- a/pyemma/coordinates/data/_base/transformer.py
+++ b/pyemma/coordinates/data/_base/transformer.py
@@ -179,12 +179,15 @@ class StreamingTransformer(Transformer, DataSource):
         return self.data_producer.chunksize
 
     @chunksize.setter
-    def chunksize(self, size):
+    def chunksize(self, value):
         if self.data_producer is None:
-            if size < 0:
-                raise ValueError('chunksize has to be positive.')
-            self._default_chunksize = size
-        self.data_producer.chunksize = size
+            if not isinstance(value, (type(None), int)):
+                raise ValueError('chunksize has to be of type: None or int')
+            if isinstance(value, int) and value < 0:
+                raise ValueError("Chunksize of %s was provided, but has to be >= 0" % value)
+            self._default_chunksize = value
+        else:
+            self.data_producer.chunksize = value
 
     def number_of_trajectories(self, stride=1):
         return self.data_producer.number_of_trajectories(stride)

--- a/pyemma/coordinates/data/sources_merger.py
+++ b/pyemma/coordinates/data/sources_merger.py
@@ -90,8 +90,8 @@ class _JoiningIterator(DataSourceIterator):
             self._t = 0
             self._itraj = itraj
             self._selected_itraj = itraj
-            if __debug__:
-                for it in self._iterators:
-                    assert it._itraj == itraj
-                    assert it._selected_itraj == itraj
-                    assert it._t == self._t
+            for it in self._iterators:
+                it._select_file(itraj)
+                assert it._itraj == itraj
+                assert it._selected_itraj == itraj
+                assert it._t == self._t

--- a/pyemma/coordinates/estimation/covariance.py
+++ b/pyemma/coordinates/estimation/covariance.py
@@ -174,7 +174,7 @@ class LaggedCovariance(StreamingEstimator, SerializableMixIn):
         self.logger.debug("will use %s total frames for %s",
                           iterable.trajectory_lengths(self.stride, skip=self.skip), self.name)
 
-        chunksize = 0 if partial_fit else iterable.chunksize
+        chunksize = 0 if partial_fit else self.chunksize
         it = iterable.iterator(lag=self.lag, return_trajindex=False, stride=self.stride, skip=self.skip,
                                chunk=chunksize)
         # iterator over input weights

--- a/pyemma/coordinates/estimation/covariance.py
+++ b/pyemma/coordinates/estimation/covariance.py
@@ -174,7 +174,7 @@ class LaggedCovariance(StreamingEstimator, SerializableMixIn):
         self.logger.debug("will use %s total frames for %s",
                           iterable.trajectory_lengths(self.stride, skip=self.skip), self.name)
 
-        chunksize = 0 if partial_fit else self.chunksize
+        chunksize = 0 if partial_fit else iterable.chunksize
         it = iterable.iterator(lag=self.lag, return_trajindex=False, stride=self.stride, skip=self.skip,
                                chunk=chunksize)
         # iterator over input weights

--- a/pyemma/coordinates/tests/test_coordinates_iterator.py
+++ b/pyemma/coordinates/tests/test_coordinates_iterator.py
@@ -62,6 +62,19 @@ class TestCoordinatesIterator(unittest.TestCase):
                                                 "returned for stride=%s, lag=%s" % (stride, lag))
                 assert chunks == it.n_chunks
 
+        dd = [np.random.random((100, 3)), np.random.random((120, 3)), np.random.random((120, 3))]
+        rr = DataInMemory(dd)
+
+        # test for lagged iterator
+        for stride in range(1, 5):
+            for lag in [x for x in range(0, 18)] + [50, 100]:
+                it = rr.iterator(lag=lag, chunk=30, stride=stride, return_trajindex=False)
+                chunks = sum(1 for _ in it)
+                np.testing.assert_equal(it.n_chunks, chunks,
+                                        err_msg="Expected number of chunks did not agree with what the iterator "
+                                                "returned for stride=%s, lag=%s" % (stride, lag))
+                assert chunks == it.n_chunks
+
     def _count_chunks(self, it):
         with it:
             it.reset()

--- a/pyemma/coordinates/tests/test_pca.py
+++ b/pyemma/coordinates/tests/test_pca.py
@@ -230,5 +230,18 @@ class TestPCAExtensive(unittest.TestCase):
         y2 = t.get_output()
         np.testing.assert_allclose(y2[0], y)
 
+    def test_api_cs(self):
+        p = pca(chunksize=1, dim=10)
+        assert p.chunksize == 1
+
+        # in case, we do not have a fixed dimension, pca can not calculate a proper chunksize.
+        p = pca(chunksize=None)
+        assert p.chunksize == p._FALLBACK_CHUNKSIZE
+
+        p = pca(chunksize=None, dim=10)
+        assert p.chunksize != 0
+        assert p.chunksize != p._FALLBACK_CHUNKSIZE
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/tests/test_random_access_stride.py
+++ b/pyemma/coordinates/tests/test_random_access_stride.py
@@ -474,10 +474,12 @@ class TestRandomAccessStride(TestCase):
             with patch('pyemma.coordinates.util.patches.iterload.MEMORY_CUTOFF', n_bytes - 1):
                 r = coor.source(traj, top=get_top())
                 it = r.iterator(stride=1000, chunk=100000)
+                next(it)
                 assert it._mditer.is_ra_iter
 
                 out_ra = r.get_output(stride=1000, chunk=10000)
             it = r.iterator(stride=1)
+            next(it)
             assert not it._mditer.is_ra_iter
             out = r.get_output(stride=1000)
             np.testing.assert_equal(out_ra, out)
@@ -485,9 +487,11 @@ class TestRandomAccessStride(TestCase):
             # check max stride exceeding
             from pyemma.coordinates.util.patches import iterload
             it = r.iterator(stride=iterload.MAX_STRIDE_SWITCH_TO_RA+1)
+            next(it)
             assert it._mditer.is_ra_iter
 
             it = r.iterator(stride=iterload.MAX_STRIDE_SWITCH_TO_RA)
+            next(it)
             assert not it._mditer.is_ra_iter
 
 if __name__ == '__main__':

--- a/pyemma/coordinates/tests/test_tica.py
+++ b/pyemma/coordinates/tests/test_tica.py
@@ -188,7 +188,11 @@ class TestTICA_Basic(unittest.TestCase):
         np.testing.assert_allclose(y2[0], y)
 
     def test_commute_map(self):
-        tica(list(range(100)), commute_map=True, kinetic_map=False)
+        tica(np.arange(100), commute_map=True, kinetic_map=False)
+
+    def test_default_cs(self):
+        t = tica(chunksize=None)
+        assert t.default_chunksize == t.chunksize == t._FALLBACK_CHUNKSIZE
 
 
 class TestTICAExtensive(unittest.TestCase):

--- a/pyemma/coordinates/tests/test_vamp.py
+++ b/pyemma/coordinates/tests/test_vamp.py
@@ -314,6 +314,10 @@ class TestVAMPModel(unittest.TestCase):
         std = np.std(np.concatenate(transformed), axis=0)
         np.testing.assert_allclose(std, self.vamp.singular_values[:self.vamp.dimension()], atol=1e-4, rtol=1e-4)
 
+    def test_default_cs(self):
+        v = pyemma_api_vamp(chunksize=None)
+        assert v.default_chunksize == v._FALLBACK_CHUNKSIZE
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/transform/tica.py
+++ b/pyemma/coordinates/transform/tica.py
@@ -234,7 +234,7 @@ class TICA(StreamingEstimationTransformer, SerializableMixIn):
         The projection matrix is first being calculated upon its first access.
         """
         from pyemma.coordinates import source
-        iterable = source(X)
+        iterable = source(X, chunksize=self.chunksize)
 
         indim = iterable.dimension()
         if not self.dim <= indim:
@@ -266,10 +266,7 @@ class TICA(StreamingEstimationTransformer, SerializableMixIn):
         if self._logger_is_active(self._loglevel_DEBUG):
             self.logger.debug("Running TICA with tau=%i; Estimating two covariance matrices"
                               " with dimension (%i, %i)", self._lag, indim, indim)
-        #chunksize = kw.pop('chunksize', self.chunksize)
-        #self.logger.debug('tica cs=%s', chunksize)
-        assert 'chunksize' not in kw
-        covar.estimate(iterable, chunksize=self.chunksize, **kw) #chunksize=chunksize, **kw)
+        covar.estimate(iterable, chunksize=self.chunksize, **kw)
         self._model.update_model_params(mean=covar.mean,
                                         cov=covar.C00_,
                                         cov_tau=covar.C0t_)

--- a/pyemma/coordinates/transform/tica.py
+++ b/pyemma/coordinates/transform/tica.py
@@ -174,7 +174,7 @@ class TICA(StreamingEstimationTransformer, SerializableMixIn):
     def describe(self):
         try:
             dim = self.dimension()
-        except AttributeError:
+        except RuntimeError:
             dim = self.dim
         return "[TICA, lag = %i; max. output dim. = %i]" % (self._lag, dim)
 
@@ -265,9 +265,11 @@ class TICA(StreamingEstimationTransformer, SerializableMixIn):
 
         if self._logger_is_active(self._loglevel_DEBUG):
             self.logger.debug("Running TICA with tau=%i; Estimating two covariance matrices"
-                               " with dimension (%i, %i)", self._lag, indim, indim)
-
-        covar.estimate(iterable, **kw)
+                              " with dimension (%i, %i)", self._lag, indim, indim)
+        #chunksize = kw.pop('chunksize', self.chunksize)
+        #self.logger.debug('tica cs=%s', chunksize)
+        assert 'chunksize' not in kw
+        covar.estimate(iterable, chunksize=self.chunksize, **kw) #chunksize=chunksize, **kw)
         self._model.update_model_params(mean=covar.mean,
                                         cov=covar.C00_,
                                         cov_tau=covar.C0t_)

--- a/pyemma/coordinates/transform/vamp.py
+++ b/pyemma/coordinates/transform/vamp.py
@@ -634,7 +634,7 @@ class VAMP(StreamingEstimationTransformer, SerializableMixIn):
 
     @property
     def singular_vectors_right(self):
-        r"""Tranformation matrix that represents the linear map from feature space to the space of right singular functions.
+        r"""Transformation matrix that represents the linear map from feature space to the space of right singular functions.
 
         Notes
         -----
@@ -655,7 +655,7 @@ class VAMP(StreamingEstimationTransformer, SerializableMixIn):
 
     @property
     def singular_vectors_left(self):
-        r"""Tranformation matrix that represents the linear map from feature space to the space of left singular functions.
+        r"""Transformation matrix that represents the linear map from feature space to the space of left singular functions.
 
         Notes
         -----

--- a/pyemma/coordinates/transform/vamp.py
+++ b/pyemma/coordinates/transform/vamp.py
@@ -384,14 +384,13 @@ class VAMP(StreamingEstimationTransformer, SerializableMixIn):
           ----------
           lag : int
               lag time
-          dim : float or int
+          dim : float or int, default=None
               Number of dimensions to keep:
 
-              * if dim is not set all available ranks are kept:
+              * if dim is not set (None) all available ranks are kept:
                   `n_components == min(n_samples, n_features)`
               * if dim is an integer >= 1, this number specifies the number
-                of dimensions to keep. By default this will use the kinetic
-                variance.
+                of dimensions to keep.
               * if dim is a float with ``0 < dim < 1``, select the number
                 of dimensions such that the amount of kinetic variance
                 that needs to be explained is greater than the percentage

--- a/pyemma/pyemma.cfg
+++ b/pyemma/pyemma.cfg
@@ -36,4 +36,5 @@ check_version = True
 mute = False
 
 # default chunksize to use for coordinate transformations, only intergers with suffix [k,m,g]
-default_chunksize = 2m
+# if you have a lot of memory available, you can try to increase this.
+default_chunksize = 256m


### PR DESCRIPTION
PCA, TICA and VAMP have dynamic dimension methods, so we need to handle
this when accessing the method to compute the desired number of time
steps for the chunk size.

The chunksize argument in the api is also passed when no data is passed.

For the FeatureReader we need to cap the passed chunksize, because we are using low-level reading routines of mdtraj.

@euhruska I'd be happy if you can run a test with your massive data set. I have tested it locally on some huge data set, but the more tests we run, the more problems we can possibly detect. Thank you in advance!
```
pip install git+https://github.com/marscher/pyemma@chunksize_fixes
```

Fixes #1250 