### PR TITLE
Disable random access optimization in patches

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-2.5.1 (02-14-2018)
+2.5.1 (02-17-2018)
 ------------------
 
 Quick fix release to repair chunking in the coordinates package.
@@ -9,7 +9,7 @@ Quick fix release to repair chunking in the coordinates package.
 **Fixes**:
 
 - msm: fix bug in ImpliedTimescales, which happened when an estimation failed for a given lag time. #1248
-- coordinates: fixed handling of default chunksize. #1247, #1251
+- coordinates: fixed handling of default chunksize. #1247, #1251, #1252
 - base: updated pybind to 2.2.2. #1249
 
 

--- a/pyemma/coordinates/tests/test_random_access_stride.py
+++ b/pyemma/coordinates/tests/test_random_access_stride.py
@@ -461,6 +461,8 @@ class TestRandomAccessStride(TestCase):
 
     def test_RA_high_stride(self):
         """ ensure we use a random access pattern for high strides chunksize combinations to avoid memory issues."""
+        from pyemma.coordinates.util.patches import iterload
+
         n=int(1e5)
         n_bytes = 3*3*8*n # ~8Mb
         savable_formats_mdtra_18 = (
@@ -475,24 +477,23 @@ class TestRandomAccessStride(TestCase):
                 r = coor.source(traj, top=get_top())
                 it = r.iterator(stride=1000, chunk=100000)
                 next(it)
-                assert it._mditer.is_ra_iter
+                assert iterload._DEACTIVATE_RANDOM_ACCESS_OPTIMIZATION or it._mditer.is_ra_iter
 
                 out_ra = r.get_output(stride=1000, chunk=10000)
             it = r.iterator(stride=1)
             next(it)
-            assert not it._mditer.is_ra_iter
+            assert iterload._DEACTIVATE_RANDOM_ACCESS_OPTIMIZATION or not it._mditer.is_ra_iter
             out = r.get_output(stride=1000)
             np.testing.assert_equal(out_ra, out)
 
             # check max stride exceeding
-            from pyemma.coordinates.util.patches import iterload
             it = r.iterator(stride=iterload.MAX_STRIDE_SWITCH_TO_RA+1)
             next(it)
-            assert it._mditer.is_ra_iter
+            assert iterload._DEACTIVATE_RANDOM_ACCESS_OPTIMIZATION or it._mditer.is_ra_iter
 
             it = r.iterator(stride=iterload.MAX_STRIDE_SWITCH_TO_RA)
             next(it)
-            assert not it._mditer.is_ra_iter
+            assert iterload._DEACTIVATE_RANDOM_ACCESS_OPTIMIZATION or not it._mditer.is_ra_iter
 
 if __name__ == '__main__':
     unittest.main()

--- a/pyemma/coordinates/util/patches.py
+++ b/pyemma/coordinates/util/patches.py
@@ -148,7 +148,8 @@ class iterload(object):
         else:
             n_atoms = self._topology.n_atoms
 
-        if (self.is_ra_iter or
+        # temporarily(?) disable RA mode
+        if self.is_ra_iter and (self.is_ra_iter or
                     self._stride > iterload.MAX_STRIDE_SWITCH_TO_RA or
                 (8 * self._chunksize * self._stride * n_atoms > iterload.MEMORY_CUTOFF)):
             self._mode = 'random_access'

--- a/pyemma/coordinates/util/patches.py
+++ b/pyemma/coordinates/util/patches.py
@@ -75,6 +75,8 @@ class iterload(object):
     MEMORY_CUTOFF = int(128 * 1024**2) # 128 MB
     MAX_STRIDE_SWITCH_TO_RA = 20
 
+    _DEACTIVATE_RANDOM_ACCESS_OPTIMIZATION = True
+
     def __init__(self, filename, trajlen, chunk=1000, **kwargs):
         """An iterator over a trajectory from one or more files on disk, in fragments
 
@@ -149,9 +151,9 @@ class iterload(object):
             n_atoms = self._topology.n_atoms
 
         # temporarily(?) disable RA mode, test_lagged_iterator_optimized fails otherwise
-        if self.is_ra_iter and (self.is_ra_iter or
+        if self.is_ra_iter or (not self._DEACTIVATE_RANDOM_ACCESS_OPTIMIZATION and (self.is_ra_iter or
                     self._stride > iterload.MAX_STRIDE_SWITCH_TO_RA or
-                (8 * self._chunksize * self._stride * n_atoms > iterload.MEMORY_CUTOFF)):
+                (8 * self._chunksize * self._stride * n_atoms > iterload.MEMORY_CUTOFF))):
             self._mode = 'random_access'
             self._f = (lambda x:
                        md_open(x, n_atoms=self._topology.n_atoms)

--- a/pyemma/coordinates/util/patches.py
+++ b/pyemma/coordinates/util/patches.py
@@ -148,7 +148,7 @@ class iterload(object):
         else:
             n_atoms = self._topology.n_atoms
 
-        # temporarily(?) disable RA mode
+        # temporarily(?) disable RA mode, test_lagged_iterator_optimized fails otherwise
         if self.is_ra_iter and (self.is_ra_iter or
                     self._stride > iterload.MAX_STRIDE_SWITCH_TO_RA or
                 (8 * self._chunksize * self._stride * n_atoms > iterload.MEMORY_CUTOFF)):


### PR DESCRIPTION
In case of large strides or large chunks in terms of memory consumption an optimization is activated in `patches.py` which leads to taking the random-access mode rather than chunked reading. I observed that this can lead to undesired output in case of the lagged iterator. This is why i propose to deactivate this optimization for now.