### PR TITLE
[CKTest] copy test model to avoid side effects.

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+2.5.2 (??-??-????)
+------------------
+
+**Fixes**:
+
+- msm: Chapman Kolmogorov validator ensures there are no side effects on the tested model. #1255
+
+
 2.5.1 (02-17-2018)
 ------------------
 

--- a/pyemma/msm/estimators/lagged_model_validators.py
+++ b/pyemma/msm/estimators/lagged_model_validators.py
@@ -77,7 +77,9 @@ class LaggedModelValidator(Estimator, ProgressReporterMixin, SerializableMixIn):
                  n_jobs=1, show_progress=True):
 
         # set model and estimator
-        self.test_model = model
+        # copy the test model, since the estimation of cktest modifies the model.
+        from copy import deepcopy
+        self.test_model = deepcopy(model)
         self.test_estimator = estimator
 
         # set mlags


### PR DESCRIPTION
Somehow the propagation of the test models
transition matrix induces side effects on the model.

Fixes #1254 