### PR TITLE
[vamp] delegate estimator params (ctor input) to model

### DIFF
--- a/pyemma/_base/estimator.py
+++ b/pyemma/_base/estimator.py
@@ -410,6 +410,8 @@ class Estimator(_BaseEstimator, Loggable):
         if params:
             self.set_params(**params)
         self._model = self._estimate(X)
+        # ensure _estimate returned something
+        assert self._model is not None
         self._estimated = True
         return self
 
@@ -437,6 +439,8 @@ class Estimator(_BaseEstimator, Loggable):
     def model(self):
         """The model estimated by this Estimator"""
         try:
+            if self._model is None:
+                raise AttributeError
             return self._model
         except AttributeError:
             raise AttributeError(
@@ -444,7 +448,7 @@ class Estimator(_BaseEstimator, Loggable):
 
     def _check_estimated(self):
         if not self._estimated:
-            raise Exception("Estimator is not parametrized.")
+            raise Exception('Estimator is not estimated. Call estimate/fit or partial_fit first.')
 
     # override get_params here, to handle PyEMMA_DeprecationWarnings as well
     def get_params(self, deep=True):

--- a/pyemma/_base/serialization/serialization.py
+++ b/pyemma/_base/serialization/serialization.py
@@ -344,7 +344,6 @@ class SerializableMixIn(object):
         """ set only fields from state, which are present in klass.__serialize_fields """
         if _debug:
             logger.debug("restoring state for class %s", klass)
-        #assert issubclass(klass, SerializableMixIn)
         # handle field renames, deletion, transformations etc.
         SerializableMixIn.__interpolate(state, klass)
 
@@ -366,7 +365,6 @@ class SerializableMixIn(object):
         try:
             if _debug:
                 logger.debug('get state of %s' % self)
-            #self._version_check()
             state = {'class_tree_versions': {}}
             # currently it is used to handle class renames etc.
             versions = state['class_tree_versions']
@@ -374,8 +372,7 @@ class SerializableMixIn(object):
                 name = _importable_name(c)
                 try:
                     v = SerializableMixIn._get_version(c)
-                # tODO: class version exception should not b e catched?
-                except (AttributeError):
+                except AttributeError:
                     v = -1
                 versions[name] = v
 

--- a/pyemma/_base/tests/test_estimator.py
+++ b/pyemma/_base/tests/test_estimator.py
@@ -15,7 +15,8 @@ class TestBaseEstimator(unittest.TestCase):
     @unittest.skipIf(not have_sklearn, 'no sklearn')
     def test_sklearn_compat_fit(self):
         class T(Estimator):
-            def _estimate(self, X): pass
+            def _estimate(self, X):
+                return self
 
         from sklearn.pipeline import Pipeline
         p = Pipeline([('test', T())])

--- a/pyemma/coordinates/estimation/covariance.py
+++ b/pyemma/coordinates/estimation/covariance.py
@@ -231,6 +231,7 @@ class LaggedCovariance(StreamingEstimator, SerializableMixIn):
         else:
             if '_rc' in self.__serialize_fields:
                 self.__serialize_fields.remove('_rc')
+        return self
 
     def partial_fit(self, X):
         """ incrementally update the estimates

--- a/pyemma/coordinates/transform/vamp.py
+++ b/pyemma/coordinates/transform/vamp.py
@@ -1002,10 +1002,10 @@ class VAMP(StreamingEstimationTransformer, SerializableMixIn):
 
 
 class VAMPChapmanKolmogorovValidator(LaggedModelValidator):
-    __serialize_version = 0
+    __serialize_version = 1
     __serialize_fields = ('nsets', 'statistics', 'observables', 'observables_mean_free', 'statistics_mean_free')
 
-    def __init__(self, model, estimator, observables, statistics, observables_mean_free, statistics_mean_free,
+    def __init__(self, test_model, test_estimator, observables, statistics, observables_mean_free, statistics_mean_free,
                  mlags=10, n_jobs=1, show_progress=True):
         r"""
          Note
@@ -1016,11 +1016,11 @@ class VAMPChapmanKolmogorovValidator(LaggedModelValidator):
 
          Parameters
          ----------
-         model : Model
+         test_model : Model
              Model with the smallest lag time. Is used to make predictions
              for larger lag times.
 
-         estimator : Estimator
+         test_estimator : Estimator
              Parametrized Estimator that has produced the model.
              Is used as a prototype for estimating models at higher lag times.
 
@@ -1063,12 +1063,20 @@ class VAMPChapmanKolmogorovValidator(LaggedModelValidator):
          The object can be plotted with :func:`plot_cktest <pyemma.plots.plot_cktest>`
          with the option `y01=False`.
          """
-        LaggedModelValidator.__init__(self, model, estimator, mlags=mlags,
+        LaggedModelValidator.__init__(self, test_model, test_estimator, mlags=mlags,
                                       n_jobs=n_jobs, show_progress=show_progress)
         self.statistics = statistics
         self.observables = observables
         self.observables_mean_free = observables_mean_free
         self.statistics_mean_free = statistics_mean_free
+
+    @property
+    def statistics(self):
+        return self._statistics
+
+    @statistics.setter
+    def statistics(self, value):
+        self._statistics = value
         if self.statistics is not None:
             self.nsets = min(self.observables.shape[1], self.statistics.shape[1])
 

--- a/pyemma/coordinates/transform/vamp.py
+++ b/pyemma/coordinates/transform/vamp.py
@@ -1065,8 +1065,8 @@ class VAMPChapmanKolmogorovValidator(LaggedModelValidator):
          """
         LaggedModelValidator.__init__(self, test_model, test_estimator, mlags=mlags,
                                       n_jobs=n_jobs, show_progress=show_progress)
-        self.statistics = statistics
         self.observables = observables
+        self.statistics = statistics
         self.observables_mean_free = observables_mean_free
         self.statistics_mean_free = statistics_mean_free
 
@@ -1077,8 +1077,8 @@ class VAMPChapmanKolmogorovValidator(LaggedModelValidator):
     @statistics.setter
     def statistics(self, value):
         self._statistics = value
-        if self.statistics is not None:
-            self.nsets = min(self.observables.shape[1], self.statistics.shape[1])
+        if self._statistics is not None:
+            self.nsets = min(self.observables.shape[1], self._statistics.shape[1])
 
     def _compute_observables(self, model, estimator, mlag=1):
         # for lag time 0 we return a matrix of nan, until the correct solution is implemented

--- a/pyemma/msm/estimators/implied_timescales.py
+++ b/pyemma/msm/estimators/implied_timescales.py
@@ -202,6 +202,7 @@ class ImpliedTimescales(Estimator, NJobsMixIn, SerializableMixIn):
         self._estimators = estimators
 
         self._postprocess_results(models)
+        return self
 
     def _postprocess_results(self, models):
         ### PROCESS RESULTS

--- a/pyemma/msm/estimators/lagged_model_validators.py
+++ b/pyemma/msm/estimators/lagged_model_validators.py
@@ -38,10 +38,10 @@ class LaggedModelValidator(Estimator, ProgressReporterMixin, SerializableMixIn):
 
     Parameters
     ----------
-    model : Model
+    test_model : Model
         Model to be tested
 
-    estimator : Estimator
+    test_estimator : Estimator
         Parametrized Estimator that has produced the model
 
     mlags : int or int-array, default=10

--- a/pyemma/msm/estimators/lagged_model_validators.py
+++ b/pyemma/msm/estimators/lagged_model_validators.py
@@ -313,6 +313,7 @@ class LaggedModelValidator(Estimator, ProgressReporterMixin, SerializableMixIn):
             if input_version == 0:
                 # this version passed the test_model in the ctor as model (reserved by Estimator),
                 # which lead to a lot of trouble.
+                self.logger.debug('applied workaround for version 0')
                 self._model = self
                 state.pop('model')
         except KeyError:
@@ -362,7 +363,7 @@ class EigenvalueDecayValidator(LaggedModelValidator):
 
 
 class ChapmanKolmogorovValidator(LaggedModelValidator):
-    __serialize_version = 0
+    __serialize_version = 1
     __serialize_fields = ('nstates', 'nsets', 'active_set', '_full2active', 'P0')
 
     def __init__(self, test_model, test_estimator, memberships, mlags=None, conf=0.95,

--- a/pyemma/msm/estimators/lagged_model_validators.py
+++ b/pyemma/msm/estimators/lagged_model_validators.py
@@ -180,6 +180,8 @@ class LaggedModelValidator(Estimator, ProgressReporterMixin, SerializableMixIn):
             self._est_L = None
             self._est_R = None
 
+        return self
+
     @property
     def lagtimes(self):
         return self._lags

--- a/pyemma/msm/estimators/lagged_model_validators.py
+++ b/pyemma/msm/estimators/lagged_model_validators.py
@@ -338,7 +338,7 @@ class EigenvalueDecayValidator(LaggedModelValidator):
         if mlag == 0 or model is None:
             return np.ones(self.nits+1), np.ones(self.nits+1)
         # otherwise compute or predict them from them model
-        samples = self.model.sample_f('eigenvalues', self.nits+1)
+        samples = self.test_model.sample_f('eigenvalues', self.nits+1)
         if mlag != 1:
             for i in range(len(samples)):
                 samples[i] = np.power(samples[i], mlag)

--- a/pyemma/msm/estimators/lagged_model_validators.py
+++ b/pyemma/msm/estimators/lagged_model_validators.py
@@ -22,7 +22,7 @@ from six.moves import range
 import math
 import numpy as np
 
-from pyemma._base.serialization.serialization import SerializableMixIn
+from pyemma._base.serialization.serialization import SerializableMixIn, Modifications
 from pyemma._base.estimator import Estimator, estimate_param_scan, param_grid
 from pyemma._base.model import SampledModel
 from pyemma._base.progress import ProgressReporterMixin
@@ -68,24 +68,27 @@ class LaggedModelValidator(Estimator, ProgressReporterMixin, SerializableMixIn):
         Show progressbars for calculation?
 
     """
-    __serialize_version = 0
-    __serialize_fields = ('test_model', 'test_estimator', '_lags',
-                         '_pred', '_pred_L', '_pred_R',
-                         '_est', '_est_L', '_est_R')
+    __serialize_version = 1
+    __serialize_fields = ('_lags',
+                          '_pred', '_pred_L', '_pred_R',
+                          '_est', '_est_L', '_est_R')
+    __serialize_modifications_map = {0: Modifications().mv('model', 'test_model') \
+                                                       .mv('estimator', 'test_estimator').list(),
+                                     }
 
-    def __init__(self, model, estimator, mlags=None, conf=0.95, err_est=False,
+    def __init__(self, test_model, test_estimator, mlags=None, conf=0.95, err_est=False,
                  n_jobs=1, show_progress=True):
 
         # set model and estimator
-        self.test_model = model
-        self.test_estimator = estimator
+        self.test_model = test_model
+        self.test_estimator = test_estimator
 
         # set mlags
         try:
-            maxlength = np.max([len(dtraj) for dtraj in estimator.discrete_trajectories_full])
+            maxlength = np.max([len(dtraj) for dtraj in test_estimator.discrete_trajectories_full])
         except AttributeError:
-            maxlength = np.max(estimator.trajectory_lengths())
-        maxmlag = int(math.floor(maxlength / estimator.lag))
+            maxlength = np.max(test_estimator.trajectory_lengths())
+        maxmlag = int(math.floor(maxlength / test_estimator.lag))
         if mlags is None:
             mlags = maxmlag
         if types.is_int(mlags):
@@ -310,9 +313,9 @@ class EigenvalueDecayValidator(LaggedModelValidator):
 
     __serialize_version = 0
 
-    def __init__(self, model, estimator, nits=1, mlags=None, conf=0.95,
+    def __init__(self, test_model, estimator, nits=1, mlags=None, conf=0.95,
                  exclude_stat=True, err_est=False, show_progress=True):
-        LaggedModelValidator.__init__(self, model, estimator, mlags=mlags,
+        LaggedModelValidator.__init__(self, test_model, estimator, mlags=mlags,
                                       conf=conf, show_progress=show_progress)
         self.nits = nits
         self.exclude_stat = exclude_stat
@@ -350,7 +353,7 @@ class ChapmanKolmogorovValidator(LaggedModelValidator):
     __serialize_version = 0
     __serialize_fields = ('nstates', 'nsets', 'active_set', '_full2active', 'P0')
 
-    def __init__(self, model, estimator, memberships, mlags=None, conf=0.95,
+    def __init__(self, test_model, test_estimator, memberships, mlags=None, conf=0.95,
                  err_est=False, n_jobs=1, show_progress=True):
         """
 
@@ -363,22 +366,44 @@ class ChapmanKolmogorovValidator(LaggedModelValidator):
             to 1).
 
         """
-        LaggedModelValidator.__init__(self, model, estimator, mlags=mlags,
+        self.memberships = memberships
+        LaggedModelValidator.__init__(self, test_model, test_estimator, mlags=mlags,
                                       conf=conf, n_jobs=n_jobs,
                                       show_progress=show_progress)
-        # check and store parameters
-        self.memberships = types.ensure_ndarray(memberships, ndim=2, kind='numeric')
-        self.nstates, self.nsets = memberships.shape
-        assert np.allclose(memberships.sum(axis=1), np.ones(self.nstates))  # stochastic matrix?
-        # active set
-        self.active_set = types.ensure_ndarray(np.array(estimator.active_set), kind='i')  # create a copy
+        self.err_est = err_est  # TODO: this is currently unused
+
+    @property
+    def memberships(self):
+        return self._memberships
+
+    @memberships.setter
+    def memberships(self, value):
+        self._memberships = types.ensure_ndarray(value, ndim=2, kind='numeric')
+        self.nstates, self.nsets = self._memberships.shape
+        assert np.allclose(self._memberships.sum(axis=1), np.ones(self.nstates))  # stochastic matrix?
+
+    @property
+    def test_estimator(self):
+        return self._test_estimator
+
+    @test_estimator.setter
+    def test_estimator(self, test_estimator):
+        self._test_estimator = test_estimator
+        self.active_set = types.ensure_ndarray(np.array(test_estimator.active_set), kind='i')  # create a copy
         # map from the full set (here defined by the largest state index in active set) to active
         self._full2active = np.zeros(np.max(self.active_set)+1, dtype=int)
         self._full2active[self.active_set] = np.arange(self.nstates)
+
+    @property
+    def test_model(self):
+        return self._test_model
+
+    @test_model.setter
+    def test_model(self, test_model):
+        self._test_model = test_model
         # define starting distribution
-        self.P0 = memberships * model.stationary_distribution[:, None]
+        self.P0 = self.memberships * test_model.stationary_distribution[:, None]
         self.P0 /= self.P0.sum(axis=0)  # column-normalize
-        self.err_est = err_est  # TODO: this is currently unused
 
     def _compute_observables(self, model, estimator, mlag=1):
         # for lag time 0 we return an identity matrix


### PR DESCRIPTION
Makes it possible to set epsilon, dim and scaling in the model via
the estimator.

Nicer handling of running covar (added abstraction).

Access self._model replaced with self.model to ensure, we always have
a valid model instance.

VAMP-CKTest didn't have a model instance, because clone_estimator
does only clone input parameters.

The CKTest didn't obey sklearn style estimator pattern, where ctor parameters are meant to be stored under the same name as the ctor argument. This caused some trouble during serialization. This fixes #1258. To ensure we can upgrade from 2.5 ck-test models, we need to override setstate in CKTest class to handle this. This is exactly handled like this, because the upgrade modifcations can not handle name clashes (there is a model attribute in Estimator as well as in CKTest, with a different meaning). 