### PR TITLE
[coordinates.transform] Sparse sampling TICA transformer

### DIFF
--- a/pyemma/_ext/variational/estimators/moments.py
+++ b/pyemma/_ext/variational/estimators/moments.py
@@ -509,8 +509,8 @@ def _M2_sparse_sym(Xvar, mask_X, Yvar, mask_Y, weights=None, column_selection=No
     else:
         mask_Xk = mask_X[column_selection]
         mask_Yk = mask_Y[column_selection]
-        Xvark = Xvar[:, _filter_variable_indices(mask_X, column_selection)].copy()
-        Yvark = Yvar[:, _filter_variable_indices(mask_Y, column_selection)].copy()
+        Xvark = Xvar[:, _filter_variable_indices(mask_X, column_selection)]
+        Yvark = Yvar[:, _filter_variable_indices(mask_Y, column_selection)]
 
     Cxxyy = np.zeros((len(mask_X), len(mask_Yk)))
     Cxxyy[np.ix_(mask_X, mask_Xk)] = _M2_dense(Xvar, Xvark, weights=weights)
@@ -551,8 +551,8 @@ def _M2_symmetric(Xvar, Yvar, mask_X=None, mask_Y=None, xsum=0, xconst=0, ysum=0
             Xvark = Xvar
             Yvark = Yvar
         else:
-            Xvark = Xvar[:, column_selection].copy()
-            Yvark = Yvar[:, column_selection].copy()
+            Xvark = Xvar[:, column_selection]
+            Yvark = Yvar[:, column_selection]
         Cxxyy = _M2_dense(Xvar, Xvark, weights=weights, diag_only=diag_only) \
                 + _M2_dense(Yvar, Yvark, weights=weights, diag_only=diag_only)
         Cxy = _M2_dense(Xvar, Yvark, weights=weights, diag_only=diag_only)
@@ -581,12 +581,12 @@ def _M2_symmetric(Xvar, Yvar, mask_X=None, mask_Y=None, xsum=0, xconst=0, ysum=0
                 ykvarsum = yvarsum
                 ykconst = yconst
             else:
-                Xvark = Xvar[:, _filter_variable_indices(mask_X, column_selection)].copy()
+                Xvark = Xvar[:, _filter_variable_indices(mask_X, column_selection)]
                 mask_Xk = mask_X[column_selection]
                 xksum = xsum[column_selection]
                 xkvarsum = xksum[mask_Xk]
                 xkconst = xconst[_filter_variable_indices(~mask_X, column_selection)]
-                Yvark = Yvar[:, _filter_variable_indices(mask_Y, column_selection)].copy()
+                Yvark = Yvar[:, _filter_variable_indices(mask_Y, column_selection)]
                 mask_Yk = mask_Y[column_selection]
                 yksum = ysum[column_selection]
                 ykvarsum = yksum[mask_Yk]
@@ -688,7 +688,7 @@ def moments_XX(X, remove_mean=False, modify_data=False, weights=None, sparse_mod
             C = _M2(X0, X0k, mask_X=mask_X, mask_Y=mask_Xk, xsum=sx0_centered, xconst=xconst, ysum=xksum, yconst=xkconst,
                     weights=weights)
         else:
-            X0k = X0[:, column_selection].copy()
+            X0k = X0[:, column_selection]
             C = _M2(X0, X0k, mask_X=mask_X, mask_Y=mask_X, xsum=sx0_centered, xconst=xconst,
                     ysum=sx0_centered[column_selection], yconst=xconst, weights=weights)
     else:
@@ -825,8 +825,8 @@ def moments_XXXY(X, Y, remove_mean=False, symmetrize=False, weights=None,
                 Cxy = _M2(X0, Y0k, mask_X=mask_X, mask_Y=mask_Yk, xsum=sx_centered, xconst=xconst, ysum=yksum, yconst=ykconst,
                         weights=weights)
             else:
-                X0k = X0[:, column_selection].copy()
-                Y0k = Y0[:, column_selection].copy()
+                X0k = X0[:, column_selection]
+                Y0k = Y0[:, column_selection]
                 Cxx = _M2(X0, X0k, mask_X=mask_X, mask_Y=mask_X, xsum=sx_centered, xconst=xconst,
                         ysum=sx_centered[column_selection], yconst=xconst, weights=weights)
                 Cxy = _M2(X0, Y0k, mask_X=mask_X, mask_Y=mask_Y, xsum=sx_centered, xconst=xconst,
@@ -940,17 +940,22 @@ def moments_block(X, Y, remove_mean=False, modify_data=False,
                       xsum=sx_centered, xconst=xconst, ysum=xksum, yconst=xkconst)
             Cxy = _M2(X0, Y0k, mask_X=mask_X, mask_Y=mask_Yk,
                       xsum=sx_centered, xconst=xconst, ysum=yksum, yconst=ykconst)
+            Cyx = _M2(Y0, X0k, mask_X=mask_Y, mask_Y=mask_Xk,
+                      xsum=sy_centered, xconst=yconst, ysum=xksum, yconst=xkconst)
             Cyy = _M2(Y0, Y0k, mask_X=mask_Y, mask_Y=mask_Yk,
                       xsum=sy_centered, xconst=yconst, ysum=yksum, yconst=ykconst)
         else:
-            X0k = X0[:, column_selection].copy()
-            Y0k = Y0[:, column_selection].copy()
+            X0k = X0[:, column_selection]
+            Y0k = Y0[:, column_selection]
             Cxx = _M2(X0, X0k, mask_X=mask_X, mask_Y=mask_X,
                       xsum=sx_centered, xconst=xconst,
                       ysum=sx_centered[column_selection], yconst=xconst)
             Cxy = _M2(X0, Y0k, mask_X=mask_X, mask_Y=mask_Y,
                       xsum=sx_centered, xconst=xconst,
                       ysum=sy_centered[column_selection], yconst=yconst)
+            Cyx = _M2(Y0, X0k, mask_X=mask_Y, mask_Y=mask_X,
+                      xsum=sy_centered, xconst=yconst,
+                      ysum=sx_centered[column_selection], yconst=xconst)
             Cyy = _M2(Y0, Y0k, mask_X=mask_Y, mask_Y=mask_Y,
                       xsum=sy_centered, xconst=yconst,
                       ysum=sy_centered[column_selection], yconst=yconst)
@@ -961,11 +966,12 @@ def moments_block(X, Y, remove_mean=False, modify_data=False,
         Cxy = _M2(X0, Y0, mask_X=mask_X, mask_Y=mask_Y,
                   xsum=sx_centered, xconst=xconst, ysum=sy_centered, yconst=yconst,
                   diag_only=diag_only)
+        Cyx = Cxy.T
         Cyy = _M2(Y0, Y0, mask_X=mask_Y, mask_Y=mask_Y,
                   xsum=sy_centered, xconst=yconst, ysum=sy_centered, yconst=yconst,
                   diag_only=diag_only)
 
-    return w, [sx, sy], [[Cxx, Cxy], [Cxy.T, Cyy]]
+    return w, [sx, sy], [[Cxx, Cxy], [Cyx, Cyy]]
 
 
 def covar(X, remove_mean=False, modify_data=False, weights=None, sparse_mode='auto', sparse_tol=0.0):

--- a/pyemma/_ext/variational/estimators/moments.py
+++ b/pyemma/_ext/variational/estimators/moments.py
@@ -359,20 +359,47 @@ def _center(X, w, s, mask=None, const=None, inplace=True):
     return X, const
 
 
+def _filter_variable_indices(mask, column_selection):
+    """ Returns column indices restricted to the variable columns as determined by the given mask.
+
+    Parameters
+    ----------
+    mask : ndarray(N, dtype=bool)
+        Array indicating the variable columns.
+    column_selection : ndarray(k, dtype=int)
+        Column indices to be filtered and mapped.
+
+    Returns
+    -------
+    ix : ndarray(l, dtype=int)
+        Column indices restricted to the variable columns, mapped to the correct index range.
+
+    """
+    a = np.where(mask)[0]
+    b = column_selection[np.in1d(column_selection, a)]
+    return np.searchsorted(a, b)
+
+
 # ====================================================================================
 # SECOND MOMENT MATRICES / COVARIANCES
 # ====================================================================================
 
-def _M2_dense(X, Y, weights=None):
+def _M2_dense(X, Y, weights=None, diag_only=False):
     """ 2nd moment matrix using dense matrix computations.
 
     This function is encapsulated such that we can make easy modifications of the basic algorithms
 
     """
     if weights is not None:
-        return np.dot((weights[:, None] * X).T, Y)
+        if diag_only:
+            return np.sum(weights[:, None] * X * Y, axis=0)
+        else:
+            return np.dot((weights[:, None] * X).T, Y)
     else:
-        return np.dot(X.T, Y)
+        if diag_only:
+            return np.sum(X * Y, axis=0)
+        else:
+            return np.dot(X.T, Y)
 
 
 def _M2_const(Xvar, mask_X, xvarsum, xconst, Yvar, mask_Y, yvarsum, yconst, weights=None):
@@ -466,7 +493,7 @@ def _M2_sparse(Xvar, mask_X, Yvar, mask_Y, weights=None):
     return C
 
 
-def _M2_sparse_sym(Xvar, mask_X, Yvar, mask_Y, weights=None):
+def _M2_sparse_sym(Xvar, mask_X, Yvar, mask_Y, weights=None, column_selection=None):
     """ 2nd self-symmetric moment matrix exploiting zero input columns
 
     Computes X'X + Y'Y and X'Y + Y'X
@@ -474,23 +501,34 @@ def _M2_sparse_sym(Xvar, mask_X, Yvar, mask_Y, weights=None):
     """
     assert len(mask_X) == len(mask_Y), 'X and Y need to have equal sizes for symmetrization'
 
-    Cxxyy = np.zeros((len(mask_X), len(mask_Y)))
-    Cxxyy[np.ix_(mask_X, mask_X)] = _M2_dense(Xvar, Xvar, weights=weights)
-    Cxxyy[np.ix_(mask_Y, mask_Y)] += _M2_dense(Yvar, Yvar, weights=weights)
+    if column_selection is None:
+        mask_Xk = mask_X
+        mask_Yk = mask_Y
+        Xvark = Xvar
+        Yvark = Yvar
+    else:
+        mask_Xk = mask_X[column_selection]
+        mask_Yk = mask_Y[column_selection]
+        Xvark = Xvar[:, _filter_variable_indices(mask_X, column_selection)].copy()
+        Yvark = Yvar[:, _filter_variable_indices(mask_Y, column_selection)].copy()
 
-    Cxyyx = np.zeros((len(mask_X), len(mask_Y)))
-    Cxy = _M2_dense(Xvar, Yvar, weights=weights)
-    Cyx = _M2_dense(Yvar, Xvar, weights=weights)
-    Cxyyx[np.ix_(mask_X, mask_Y)] = Cxy
-    Cxyyx[np.ix_(mask_Y, mask_X)] += Cyx
+    Cxxyy = np.zeros((len(mask_X), len(mask_Yk)))
+    Cxxyy[np.ix_(mask_X, mask_Xk)] = _M2_dense(Xvar, Xvark, weights=weights)
+    Cxxyy[np.ix_(mask_Y, mask_Yk)] += _M2_dense(Yvar, Yvark, weights=weights)
+
+    Cxyyx = np.zeros((len(mask_X), len(mask_Yk)))
+    Cxy = _M2_dense(Xvar, Yvark, weights=weights)
+    Cyx = _M2_dense(Yvar, Xvark, weights=weights)
+    Cxyyx[np.ix_(mask_X, mask_Yk)] = Cxy
+    Cxyyx[np.ix_(mask_Y, mask_Xk)] += Cyx
 
     return Cxxyy, Cxyyx
 
 
-def _M2(Xvar, Yvar, mask_X=None, mask_Y=None, xsum=0, xconst=0, ysum=0, yconst=0, weights=None):
+def _M2(Xvar, Yvar, mask_X=None, mask_Y=None, xsum=0, xconst=0, ysum=0, yconst=0, weights=None, diag_only=False):
     """ direct (nonsymmetric) second moment matrix. Decide if we need dense, sparse, const"""
     if mask_X is None and mask_Y is None:
-        return _M2_dense(Xvar, Yvar, weights=weights)
+        return _M2_dense(Xvar, Yvar, weights=weights, diag_only=diag_only)
     else:
         # Check if one of the masks is not None, modify it and also adjust the constant columns:
         if mask_X is None:
@@ -505,12 +543,20 @@ def _M2(Xvar, Yvar, mask_X=None, mask_Y=None, xsum=0, xconst=0, ysum=0, yconst=0
         return _M2_const(Xvar, mask_X, xsum[mask_X], xconst, Yvar, mask_Y, ysum[mask_Y], yconst, weights=weights)
 
 
-def _M2_symmetric(Xvar, Yvar, mask_X=None, mask_Y=None, xsum=0, xconst=0, ysum=0, yconst=0, weights=None):
+def _M2_symmetric(Xvar, Yvar, mask_X=None, mask_Y=None, xsum=0, xconst=0, ysum=0, yconst=0, weights=None,
+                  column_selection=None, diag_only=False):
     """ symmetric second moment matrices. Decide if we need dense, sparse, const"""
     if mask_X is None and mask_Y is None:
-        Cxxyy = _M2_dense(Xvar, Xvar, weights=weights) + _M2_dense(Yvar, Yvar, weights=weights)
-        Cxy = _M2_dense(Xvar, Yvar, weights=weights)
-        Cyx = _M2_dense(Yvar, Xvar, weights=weights)
+        if column_selection is None:
+            Xvark = Xvar
+            Yvark = Yvar
+        else:
+            Xvark = Xvar[:, column_selection].copy()
+            Yvark = Yvar[:, column_selection].copy()
+        Cxxyy = _M2_dense(Xvar, Xvark, weights=weights, diag_only=diag_only) \
+                + _M2_dense(Yvar, Yvark, weights=weights, diag_only=diag_only)
+        Cxy = _M2_dense(Xvar, Yvark, weights=weights, diag_only=diag_only)
+        Cyx = _M2_dense(Yvar, Xvark, weights=weights, diag_only=diag_only)
         Cxyyx = Cxy + Cyx
     else:
         # Check if one of the masks is not None, modify it and also adjust the constant columns:
@@ -521,14 +567,34 @@ def _M2_symmetric(Xvar, Yvar, mask_X=None, mask_Y=None, xsum=0, xconst=0, ysum=0
             mask_Y = np.ones(Yvar.shape[1], dtype=np.bool)
             yconst = np.ones(0, dtype=float)
         if _is_zero(xsum) and _is_zero(ysum) or _is_zero(xconst) and _is_zero(yconst):
-            Cxxyy, Cxyyx = _M2_sparse_sym(Xvar, mask_X, Yvar, mask_Y, weights=weights)
+            Cxxyy, Cxyyx = _M2_sparse_sym(Xvar, mask_X, Yvar, mask_Y, weights=weights, column_selection=column_selection)
         else:
             xvarsum = xsum[mask_X]  # to variable part
             yvarsum = ysum[mask_Y]  # to variable part
-            Cxxyy = _M2_const(Xvar, mask_X, xvarsum, xconst, Xvar, mask_X, xvarsum, xconst, weights=weights) \
-                    + _M2_const(Yvar, mask_Y, yvarsum, yconst, Yvar, mask_Y, yvarsum, yconst, weights=weights)
-            Cxy = _M2_const(Xvar, mask_X, xvarsum, xconst, Yvar, mask_Y, yvarsum, yconst, weights=weights)
-            Cyx = _M2_const(Yvar, mask_Y, yvarsum, yconst, Xvar, mask_X, xvarsum, xconst, weights=weights)
+            if column_selection is None:
+                Xvark = Xvar
+                mask_Xk = mask_X
+                xkvarsum = xvarsum
+                xkconst = xconst
+                Yvark = Yvar
+                mask_Yk = mask_Y
+                ykvarsum = yvarsum
+                ykconst = yconst
+            else:
+                Xvark = Xvar[:, _filter_variable_indices(mask_X, column_selection)].copy()
+                mask_Xk = mask_X[column_selection]
+                xksum = xsum[column_selection]
+                xkvarsum = xksum[mask_Xk]
+                xkconst = xconst[_filter_variable_indices(~mask_X, column_selection)]
+                Yvark = Yvar[:, _filter_variable_indices(mask_Y, column_selection)].copy()
+                mask_Yk = mask_Y[column_selection]
+                yksum = ysum[column_selection]
+                ykvarsum = yksum[mask_Yk]
+                ykconst = yconst[_filter_variable_indices(~mask_Y, column_selection)]
+            Cxxyy = _M2_const(Xvar, mask_X, xvarsum, xconst, Xvark, mask_Xk, xkvarsum, xkconst, weights=weights) \
+                    + _M2_const(Yvar, mask_Y, yvarsum, yconst, Yvark, mask_Yk, ykvarsum, ykconst, weights=weights)
+            Cxy = _M2_const(Xvar, mask_X, xvarsum, xconst, Yvark, mask_Yk, ykvarsum, ykconst, weights=weights)
+            Cyx = _M2_const(Yvar, mask_Y, yvarsum, yconst, Xvark, mask_Xk, xkvarsum, xkconst, weights=weights)
             Cxyyx = Cxy + Cyx
     return Cxxyy, Cxyyx
 
@@ -538,7 +604,8 @@ def _M2_symmetric(Xvar, Yvar, mask_X=None, mask_Y=None, xsum=0, xconst=0, ysum=0
 # =================================================
 
 
-def moments_XX(X, remove_mean=False, modify_data=False, weights=None, sparse_mode='auto', sparse_tol=0.0):
+def moments_XX(X, remove_mean=False, modify_data=False, weights=None, sparse_mode='auto', sparse_tol=0.0,
+               column_selection=None, diag_only=False):
     r""" Computes the first two unnormalized moments of X
 
     Computes :math:`s = \sum_t x_t` and :math:`C = X^\top X` while exploiting
@@ -569,6 +636,10 @@ def moments_XX(X, remove_mean=False, modify_data=False, weights=None, sparse_mod
         is not given) of the covariance matrix will be set to zero. If Y is
         given and max(abs(Y[:, i])) < sparse_tol, then column i of the
         covariance matrix will be set to zero.
+    column_selection: ndarray(k, dtype=int) or None
+        Indices of those columns that are to be computed. If None, all columns are computed.
+    diag_only: bool
+        If True, the computation is restricted to the diagonal entries (autocorrelations) only.
 
     Returns
     -------
@@ -583,6 +654,11 @@ def moments_XX(X, remove_mean=False, modify_data=False, weights=None, sparse_mod
     # Check consistency of inputs:
     if weights is not None:
         assert X.shape[0] == weights.shape[0], 'X and weights_x must have equal length'
+    # diag_only is only implemented for dense mode
+    if diag_only and sparse_mode is not 'dense':
+        if sparse_mode is 'sparse':
+            warnings.warn('Computing diagonal entries only is not implemented for sparse mode. Switching to dense mode.')
+        sparse_mode = 'dense'
     # sparsify
     X0, mask_X, xconst = _sparsify(X, remove_mean=remove_mean, modify_data=modify_data,
                                    sparse_mode=sparse_mode, sparse_tol=sparse_tol)
@@ -599,14 +675,31 @@ def moments_XX(X, remove_mean=False, modify_data=False, weights=None, sparse_mod
     # TODO: we could make a second const check here. If after summation not enough zeros have appeared in the
     # TODO: consts, we switch back to dense treatment here.
     # compute covariance matrix
-    C = _M2(X0, X0, mask_X=mask_X, mask_Y=mask_X, xsum=sx0_centered, xconst=xconst, ysum=sx0_centered, yconst=xconst,
-            weights=weights)
+    if column_selection is not None:
+        if is_sparse:
+            Xk = X[:, column_selection]
+            mask_Xk = mask_X[column_selection]
+            X0k = Xk[:, mask_Xk]
+            xksum = sx0_centered[column_selection]
+            xkconst = Xk[0, ~mask_Xk]
+            X0k, xkconst = _copy_convert(X0k, const=xkconst, remove_mean=remove_mean,
+                                         copy=True)
+            C = _M2(X0, X0k, mask_X=mask_X, mask_Y=mask_Xk, xsum=sx0_centered, xconst=xconst, ysum=xksum, yconst=xkconst,
+                    weights=weights)
+        else:
+            X0k = X0[:, column_selection].copy()
+            C = _M2(X0, X0k, mask_X=mask_X, mask_Y=mask_X, xsum=sx0_centered, xconst=xconst,
+                    ysum=sx0_centered[column_selection], yconst=xconst, weights=weights)
+    else:
+        C = _M2(X0, X0, mask_X=mask_X, mask_Y=mask_X, xsum=sx0_centered, xconst=xconst, ysum=sx0_centered, yconst=xconst,
+                weights=weights, diag_only=diag_only)
     return w, sx, C
 
 
 def moments_XXXY(X, Y, remove_mean=False, symmetrize=False, weights=None,
-                 modify_data=False, sparse_mode='auto', sparse_tol=0.0):
-    r""" Computes the first two unnormalized moments of X and Y
+                 modify_data=False, sparse_mode='auto', sparse_tol=0.0,
+                 column_selection=None, diag_only=False):
+    """ Computes the first two unnormalized moments of X and Y
 
     If symmetrize is False, computes
 
@@ -656,6 +749,10 @@ def moments_XXXY(X, Y, remove_mean=False, symmetrize=False, weights=None,
         is not given) of the covariance matrix will be set to zero. If Y is
         given and max(abs(Y[:, i])) < sparse_tol, then column i of the
         covariance matrix will be set to zero.
+    column_selection: ndarray(k, dtype=int) or None
+        Indices of those columns that are to be computed. If None, all columns are computed.
+    diag_only: bool
+        If True, the computation is restricted to the diagonal entries (autocorrelations) only.
 
     Returns
     -------
@@ -676,6 +773,13 @@ def moments_XXXY(X, Y, remove_mean=False, symmetrize=False, weights=None,
         assert Y.shape[0] == X.shape[0], 'X and Y must have equal length.'
     if weights is not None:
         assert X.shape[0] == weights.shape[0], 'X and weights_x must have equal length'
+    # diag_only is only implemented for dense mode
+    if diag_only and sparse_mode is not 'dense':
+        if sparse_mode is 'sparse':
+            warnings.warn('Computing diagonal entries only is not implemented for sparse mode. Switching to dense mode.')
+        sparse_mode = 'dense'
+    if diag_only and X.shape[1] != Y.shape[1]:
+        raise ValueError('Computing diagonal entries only does not make sense for rectangular covariance matrix.')
     # sparsify
     X0, mask_X, xconst, Y0, mask_Y, yconst = _sparsify_pair(X, Y, remove_mean=remove_mean, modify_data=modify_data,
                                                             symmetrize=symmetrize, sparse_mode=sparse_mode, sparse_tol=sparse_tol)
@@ -693,18 +797,50 @@ def moments_XXXY(X, Y, remove_mean=False, symmetrize=False, weights=None,
 
     if symmetrize:
         Cxx, Cxy = _M2_symmetric(X0, Y0, mask_X=mask_X, mask_Y=mask_Y,
-                                 xsum=sx_centered, xconst=xconst, ysum=sy_centered, yconst=yconst, weights=weights)
+                                 xsum=sx_centered, xconst=xconst, ysum=sy_centered, yconst=yconst, weights=weights,
+                                 column_selection=column_selection, diag_only=diag_only)
     else:
-        Cxx = _M2(X0, X0, mask_X=mask_X, mask_Y=mask_X,
-                  xsum=sx_centered, xconst=xconst, ysum=sx_centered, yconst=xconst, weights=weights)
-        Cxy = _M2(X0, Y0, mask_X=mask_X, mask_Y=mask_Y,
-                  xsum=sx_centered, xconst=xconst, ysum=sy_centered, yconst=yconst, weights=weights)
+        if column_selection is not None:
+            if is_sparse:
+                Xk = X[:, column_selection]
+                mask_Xk = mask_X[column_selection]
+                X0k = Xk[:, mask_Xk]
+                xksum = sx_centered[column_selection]
+                xkconst = Xk[0, ~mask_Xk]
+                X0k, xkconst = _copy_convert(X0k, const=xkconst, remove_mean=remove_mean,
+                                             copy=True)
+
+                Yk = Y[:, column_selection]
+                mask_Yk = mask_Y[column_selection]
+                Y0k = Yk[:, mask_Yk]
+                yksum = sy_centered[column_selection]
+                ykconst = Yk[0, ~mask_Yk]
+                Y0k, ykconst = _copy_convert(Y0k, const=ykconst, remove_mean=remove_mean,
+                                             copy=True)
+
+                Cxx = _M2(X0, X0k, mask_X=mask_X, mask_Y=mask_Xk, xsum=sx_centered, xconst=xconst, ysum=xksum, yconst=xkconst,
+                        weights=weights)
+                Cxy = _M2(X0, Y0k, mask_X=mask_X, mask_Y=mask_Yk, xsum=sx_centered, xconst=xconst, ysum=yksum, yconst=ykconst,
+                        weights=weights)
+            else:
+                X0k = X0[:, column_selection].copy()
+                Y0k = Y0[:, column_selection].copy()
+                Cxx = _M2(X0, X0k, mask_X=mask_X, mask_Y=mask_X, xsum=sx_centered, xconst=xconst,
+                        ysum=sx_centered[column_selection], yconst=xconst, weights=weights)
+                Cxy = _M2(X0, Y0k, mask_X=mask_X, mask_Y=mask_Y, xsum=sx_centered, xconst=xconst,
+                        ysum=sy_centered[column_selection], yconst=yconst, weights=weights)
+        else:
+            Cxx = _M2(X0, X0, mask_X=mask_X, mask_Y=mask_X, xsum=sx_centered, xconst=xconst, ysum=sx_centered, yconst=xconst,
+                      weights=weights, diag_only=diag_only)
+            Cxy = _M2(X0, Y0, mask_X=mask_X, mask_Y=mask_Y, xsum=sx_centered, xconst=xconst, ysum=sy_centered, yconst=yconst,
+                      weights=weights, diag_only=diag_only)
 
     return w, sx, sy, Cxx, Cxy
 
 
 def moments_block(X, Y, remove_mean=False, modify_data=False,
-                  sparse_mode='auto', sparse_tol=0.0):
+                  sparse_mode='auto', sparse_tol=0.0,
+                  column_selection=None, diag_only=False):
     """ Computes the first two unnormalized moments of X and Y
 
     Computes
@@ -743,6 +879,10 @@ def moments_block(X, Y, remove_mean=False, modify_data=False,
         is not given) of the covariance matrix will be set to zero. If Y is
         given and max(abs(Y[:, i])) < sparse_tol, then column i of the
         covariance matrix will be set to zero.
+    column_selection: ndarray(k, dtype=int) or None
+        Indices of those columns that are to be computed. If None, all columns are computed.
+    diag_only: bool
+        If True, the computation is restricted to the diagonal entries (autocorrelations) only.
 
     Returns
     -------
@@ -755,6 +895,11 @@ def moments_block(X, Y, remove_mean=False, modify_data=False,
         C[0,0] = Cxx, C[0,1] = Cxy, C[1,0] = Cyx, C[1,1] = Cyy
 
     """
+    # diag_only is only implemented for dense mode
+    if diag_only and sparse_mode is not 'dense':
+        if sparse_mode is 'sparse':
+            warnings.warn('Computing diagonal entries only is not implemented for sparse mode. Switching to dense mode.')
+        sparse_mode = 'dense'
     # sparsify
     X0, mask_X, xconst = _sparsify(X, sparse_mode=sparse_mode, sparse_tol=sparse_tol)
     Y0, mask_Y, yconst = _sparsify(Y, sparse_mode=sparse_mode, sparse_tol=sparse_tol)
@@ -769,12 +914,39 @@ def moments_block(X, Y, remove_mean=False, modify_data=False,
         _center(X0, w, sx, mask=mask_X, const=xconst, inplace=True)  # fast in-place centering
         _center(Y0, w, sy, mask=mask_Y, const=yconst, inplace=True)  # fast in-place centering
 
-    Cxx = _M2(X0, X0, mask_X=mask_X, mask_Y=mask_X,
-              xsum=sx_centered, xconst=xconst, ysum=sx_centered, yconst=xconst)
-    Cxy = _M2(X0, Y0, mask_X=mask_X, mask_Y=mask_Y,
-              xsum=sx_centered, xconst=xconst, ysum=sy_centered, yconst=yconst)
-    Cyy = _M2(Y0, Y0, mask_X=mask_Y, mask_Y=mask_Y,
-              xsum=sy_centered, xconst=yconst, ysum=sy_centered, yconst=yconst)
+    if column_selection is not None:
+        Xk = X[:, column_selection]
+        mask_Xk = mask_X[column_selection]
+        X0k = Xk[:, mask_Xk]
+        xksum = sx0_centered[column_selection]
+        xkconst = Xk[0, ~mask_Xk]
+        X0k, xkconst = _copy_convert(X0k, const=xkconst, remove_mean=remove_mean,
+                                     copy=True)
+
+        Yk = Y[:, column_selection]
+        mask_Yk = mask_Y[column_selection]
+        Y0k = Yk[:, mask_Yk]
+        yksum = sy_centered[column_selection]
+        ykconst = Yk[0, ~mask_Yk]
+        Y0k, ykconst = _copy_convert(Y0k, const=ykconst, remove_mean=remove_mean,
+                                     copy=True)
+
+        Cxx = _M2(X0, X0k, mask_X=mask_X, mask_Y=mask_Xk,
+                  xsum=sx_centered, xconst=xconst, ysum=xksum, yconst=xkconst)
+        Cxy = _M2(X0, Y0k, mask_X=mask_X, mask_Y=mask_Yk,
+                  xsum=sx_centered, xconst=xconst, ysum=yksum, yconst=ykconst)
+        Cyy = _M2(Y0, Y0k, mask_X=mask_Y, mask_Y=mask_Yk,
+                  xsum=sy_centered, xconst=yconst, ysum=yksum, yconst=ykconst)
+    else:
+        Cxx = _M2(X0, X0, mask_X=mask_X, mask_Y=mask_X,
+                  xsum=sx_centered, xconst=xconst, ysum=sx_centered, yconst=xconst,
+                  diag_only=diag_only)
+        Cxy = _M2(X0, Y0, mask_X=mask_X, mask_Y=mask_Y,
+                  xsum=sx_centered, xconst=xconst, ysum=sy_centered, yconst=yconst,
+                  diag_only=diag_only)
+        Cyy = _M2(Y0, Y0, mask_X=mask_Y, mask_Y=mask_Y,
+                  xsum=sy_centered, xconst=yconst, ysum=sy_centered, yconst=yconst,
+                  diag_only=diag_only)
 
     return w, [sx, sy], [[Cxx, Cxy], [Cxy.T, Cyy]]
 

--- a/pyemma/_ext/variational/estimators/running_moments.py
+++ b/pyemma/_ext/variational/estimators/running_moments.py
@@ -302,10 +302,10 @@ class RunningCovar(object):
                 s0k = s[0]
                 s1k = s[1]
             if self.compute_XX:
-                self.storage_XX.store(Moments(w, s[0], s0k, C[0, 0]))
+                self.storage_XX.store(Moments(w, s[0], s0k, C[0][0]))
             if self.compute_XY:
-                self.storage_XY.store(Moments(w, s[0], s1k, C[0, 1]))
-            self.storage_YY.store(Moments(w, s[1], s1k, C[1, 1]))
+                self.storage_XY.store(Moments(w, s[0], s1k, C[0][1]))
+            self.storage_YY.store(Moments(w, s[1], s1k, C[1][1]))
 
     def sum_X(self):
         if self.compute_XX:

--- a/pyemma/_ext/variational/estimators/tests/test_moments.py
+++ b/pyemma/_ext/variational/estimators/tests/test_moments.py
@@ -32,7 +32,7 @@ class TestMoments(unittest.TestCase):
         cls.Y_10_sparseconst[:, 0] = cls.Y_10[:, 0]
         cls.X_100_sparseconst = np.ones((10000, 100))
         cls.X_100_sparseconst[:, :10] = cls.X_100[:, :10]
-        cls.Y_100_sparseconst = 2*np.zeros((10000, 100))
+        cls.Y_100_sparseconst = 2*np.ones((10000, 100))
         cls.Y_100_sparseconst[:, :10] = cls.Y_100[:, :10]
         # boolean data
         cls.Xb_2 = np.random.randint(0, 2, size=(10000, 2))
@@ -45,10 +45,14 @@ class TestMoments(unittest.TestCase):
         cls.weights = np.random.rand(10000)
         # Set the lag time for time-lagged tests:
         cls.lag = 50
+        # column subsets
+        cls.cols_2 = np.array([0])
+        cls.cols_10 = np.random.choice(10, 5, replace=False)
+        cls.cols_100 = np.random.choice(100, 20, replace=False)
 
         return cls
 
-    def _test_moments_X(self, X, remove_mean=False, sparse_mode='auto', weights=None):
+    def _test_moments_X(self, X, column_selection, remove_mean=False, sparse_mode='auto', weights=None):
         # proposed solution
         w, s_X, C_XX = moments.moments_XX(X, remove_mean=remove_mean, modify_data=False,
                                           sparse_mode=sparse_mode, weights=weights)
@@ -71,55 +75,66 @@ class TestMoments(unittest.TestCase):
         # test
         assert np.allclose(s_X, s_X_ref)
         assert np.allclose(C_XX, C_XX_ref)
+        # column subsets
+        w, s_X, C_XX = moments.moments_XX(X, remove_mean=remove_mean, modify_data=False,
+                                          sparse_mode=sparse_mode, weights=weights,
+                                          column_selection=column_selection)
+        assert np.allclose(C_XX, C_XX_ref[:, column_selection])
+        # diagonal only
+        if sparse_mode is not 'sparse':
+            w, s_X, C_XX = moments.moments_XX(X, remove_mean=remove_mean, modify_data=False,
+                                              sparse_mode=sparse_mode, weights=weights,
+                                              diag_only=True)
+            assert np.allclose(C_XX, np.diag(C_XX_ref))
 
     def test_moments_X(self):
         # simple test, dense
-        self._test_moments_X(self.X_10, remove_mean=False, sparse_mode='dense')
-        self._test_moments_X(self.X_100, remove_mean=False, sparse_mode='dense')
+        self._test_moments_X(self.X_10, self.cols_10, remove_mean=False, sparse_mode='dense')
+        self._test_moments_X(self.X_100, self.cols_100, remove_mean=False, sparse_mode='dense')
         # mean-free, dense
-        self._test_moments_X(self.X_10, remove_mean=True, sparse_mode='dense')
-        self._test_moments_X(self.X_100, remove_mean=True, sparse_mode='dense')
+        self._test_moments_X(self.X_10, self.cols_10, remove_mean=True, sparse_mode='dense')
+        self._test_moments_X(self.X_100, self.cols_100, remove_mean=True, sparse_mode='dense')
         # weighted test, simple, dense:
-        self._test_moments_X(self.X_10, remove_mean=False, sparse_mode='dense', weights=self.weights)
-        self._test_moments_X(self.X_100, remove_mean=False, sparse_mode='dense', weights=self.weights)
+        self._test_moments_X(self.X_10, self.cols_10, remove_mean=False, sparse_mode='dense', weights=self.weights)
+        self._test_moments_X(self.X_100, self.cols_100, remove_mean=False, sparse_mode='dense', weights=self.weights)
         # weighted test, mean-free, dense:
-        self._test_moments_X(self.X_10, remove_mean=True, sparse_mode='dense', weights=self.weights)
-        self._test_moments_X(self.X_100, remove_mean=True, sparse_mode='dense', weights=self.weights)
+        self._test_moments_X(self.X_10, self.cols_10, remove_mean=True, sparse_mode='dense', weights=self.weights)
+        self._test_moments_X(self.X_100, self.cols_100, remove_mean=True, sparse_mode='dense', weights=self.weights)
 
     def test_moments_X_sparsezero(self):
         # simple test, sparse
-        self._test_moments_X(self.X_10_sparsezero, remove_mean=False, sparse_mode='sparse')
-        self._test_moments_X(self.X_100_sparsezero, remove_mean=False, sparse_mode='sparse')
+        self._test_moments_X(self.X_10_sparsezero, self.cols_10, remove_mean=False, sparse_mode='sparse')
+        self._test_moments_X(self.X_100_sparsezero, self.cols_100, remove_mean=False, sparse_mode='sparse')
         # mean-free, sparse
-        self._test_moments_X(self.X_10_sparsezero, remove_mean=True, sparse_mode='sparse')
-        self._test_moments_X(self.X_100_sparsezero, remove_mean=True, sparse_mode='sparse')
+        self._test_moments_X(self.X_10_sparsezero, self.cols_10, remove_mean=True, sparse_mode='sparse')
+        self._test_moments_X(self.X_100_sparsezero, self.cols_100, remove_mean=True, sparse_mode='sparse')
         # weighted, sparse
-        self._test_moments_X(self.X_10_sparsezero, remove_mean=False, sparse_mode='sparse', weights=self.weights)
-        self._test_moments_X(self.X_100_sparsezero, remove_mean=False, sparse_mode='sparse', weights=self.weights)
+        self._test_moments_X(self.X_10_sparsezero, self.cols_10, remove_mean=False, sparse_mode='sparse', weights=self.weights)
+        self._test_moments_X(self.X_100_sparsezero, self.cols_100, remove_mean=False, sparse_mode='sparse', weights=self.weights)
         # weighted, mean-free, sparse
-        self._test_moments_X(self.X_10_sparsezero, remove_mean=True, sparse_mode='sparse', weights=self.weights)
-        self._test_moments_X(self.X_100_sparsezero, remove_mean=True, sparse_mode='sparse', weights=self.weights)
+        self._test_moments_X(self.X_10_sparsezero, self.cols_10, remove_mean=True, sparse_mode='sparse', weights=self.weights)
+        self._test_moments_X(self.X_100_sparsezero, self.cols_100, remove_mean=True, sparse_mode='sparse', weights=self.weights)
 
     def test_moments_X_sparseconst(self):
         # simple test, sparse
-        self._test_moments_X(self.X_10_sparseconst, remove_mean=False, sparse_mode='sparse')
-        self._test_moments_X(self.X_100_sparseconst, remove_mean=False, sparse_mode='sparse')
+        self._test_moments_X(self.X_10_sparseconst, self.cols_10, remove_mean=False, sparse_mode='sparse')
+        self._test_moments_X(self.X_100_sparseconst, self.cols_100, remove_mean=False, sparse_mode='sparse')
         # mean-free, sparse
-        self._test_moments_X(self.X_10_sparseconst, remove_mean=True, sparse_mode='sparse')
-        self._test_moments_X(self.X_100_sparseconst, remove_mean=True, sparse_mode='sparse')
+        self._test_moments_X(self.X_10_sparseconst, self.cols_10, remove_mean=True, sparse_mode='sparse')
+        self._test_moments_X(self.X_100_sparseconst, self.cols_100, remove_mean=True, sparse_mode='sparse')
         # weighted, sparse:
-        self._test_moments_X(self.X_10_sparseconst, remove_mean=False, sparse_mode='dense', weights=self.weights)
-        self._test_moments_X(self.X_100_sparseconst, remove_mean=False, sparse_mode='dense', weights=self.weights)
+        self._test_moments_X(self.X_10_sparseconst, self.cols_10, remove_mean=False, sparse_mode='dense', weights=self.weights)
+        self._test_moments_X(self.X_100_sparseconst, self.cols_100, remove_mean=False, sparse_mode='dense', weights=self.weights)
         # weighted, mean-free, sparse:
-        self._test_moments_X(self.X_10_sparseconst, remove_mean=True, sparse_mode='dense', weights=self.weights)
-        self._test_moments_X(self.X_100_sparseconst, remove_mean=True, sparse_mode='dense', weights=self.weights)
+        self._test_moments_X(self.X_10_sparseconst, self.cols_10, remove_mean=True, sparse_mode='dense', weights=self.weights)
+        self._test_moments_X(self.X_100_sparseconst, self.cols_100, remove_mean=True, sparse_mode='dense', weights=self.weights)
 
     def test_boolean_moments(self):
         # standard tests
-        self._test_moments_X(self.Xb_10, remove_mean=False, sparse_mode='dense')
-        self._test_moments_X(self.Xb_10, remove_mean=True, sparse_mode='dense')
-        self._test_moments_X(self.Xb_10_sparsezero, remove_mean=False, sparse_mode='sparse')
-        self._test_moments_X(self.Xb_10_sparsezero, remove_mean=True, sparse_mode='sparse')
+        self._test_moments_X(self.Xb_10, self.cols_10, remove_mean=False, sparse_mode='dense')
+        self._test_moments_X(self.Xb_10, self.cols_10, remove_mean=True, sparse_mode='dense')
+        self._test_moments_X(self.Xb_10_sparsezero, self.cols_10, remove_mean=False, sparse_mode='sparse')
+        self._test_moments_X(self.Xb_10_sparsezero, self.cols_10, remove_mean=True, sparse_mode='sparse')
         # test integer recovery
         Cxx_ref = np.dot(self.Xb_10.astype(np.int64).T, self.Xb_10.astype(np.int64))  # integer
         s_X_ref = np.sum(self.Xb_10, axis=0)
@@ -130,7 +145,7 @@ class TestMoments(unittest.TestCase):
         assert np.array_equal(Cxx, Cxx_ref)
 
 
-    def _test_moments_XY(self, X, Y, symmetrize=False, remove_mean=False, sparse_mode='auto', weights=None):
+    def _test_moments_XY(self, X, Y, column_selection, symmetrize=False, remove_mean=False, sparse_mode='auto', weights=None):
         w1, s_X, s_Y, C_XX, C_XY = moments.moments_XXXY(X, Y, remove_mean=remove_mean, modify_data=False,
                                                        symmetrize=symmetrize, sparse_mode=sparse_mode,
                                                        weights=weights)
@@ -177,157 +192,170 @@ class TestMoments(unittest.TestCase):
         assert np.allclose(s_Y, s_Y_ref)
         assert np.allclose(C_XX, C_XX_ref)
         assert np.allclose(C_XY, C_XY_ref)
+        # column subsets
+        w1, s_X, s_Y, C_XX, C_XY = moments.moments_XXXY(X, Y, remove_mean=remove_mean, modify_data=False,
+                                                       symmetrize=symmetrize, sparse_mode=sparse_mode,
+                                                       weights=weights, column_selection=column_selection)
+        assert np.allclose(C_XX, C_XX_ref[:, column_selection])
+        assert np.allclose(C_XY, C_XY_ref[:, column_selection])
+        # diagonal only
+        if sparse_mode is not 'sparse' and X.shape[1] == Y.shape[1]:
+            w1, s_X, s_Y, C_XX, C_XY = moments.moments_XXXY(X, Y, remove_mean=remove_mean, modify_data=False,
+                                                           symmetrize=symmetrize, sparse_mode=sparse_mode,
+                                                           weights=weights, diag_only=True)
+            assert np.allclose(C_XX, np.diag(C_XX_ref))
+            assert np.allclose(C_XY, np.diag(C_XY_ref))
 
     def test_moments_XY(self):
         # simple test, dense
-        self._test_moments_XY(self.X_10, self.Y_10, symmetrize=False, remove_mean=False, sparse_mode='dense')
-        self._test_moments_XY(self.X_100, self.Y_10, symmetrize=False, remove_mean=False, sparse_mode='dense')
-        self._test_moments_XY(self.X_100, self.Y_100, symmetrize=False, remove_mean=False, sparse_mode='dense')
+        self._test_moments_XY(self.X_10, self.Y_10, self.cols_10, symmetrize=False, remove_mean=False, sparse_mode='dense')
+        self._test_moments_XY(self.X_100, self.Y_10, self.cols_10, symmetrize=False, remove_mean=False, sparse_mode='dense')
+        self._test_moments_XY(self.X_100, self.Y_100, self.cols_100, symmetrize=False, remove_mean=False, sparse_mode='dense')
         # mean-free, dense
-        self._test_moments_XY(self.X_10, self.Y_10, symmetrize=False, remove_mean=True, sparse_mode='dense')
-        self._test_moments_XY(self.X_100, self.Y_10, symmetrize=False, remove_mean=True, sparse_mode='dense')
-        self._test_moments_XY(self.X_100, self.Y_100, symmetrize=False, remove_mean=True, sparse_mode='dense')
+        self._test_moments_XY(self.X_10, self.Y_10, self.cols_10, symmetrize=False, remove_mean=True, sparse_mode='dense')
+        self._test_moments_XY(self.X_100, self.Y_10, self.cols_10, symmetrize=False, remove_mean=True, sparse_mode='dense')
+        self._test_moments_XY(self.X_100, self.Y_100, self.cols_100, symmetrize=False, remove_mean=True, sparse_mode='dense')
 
     def test_moments_XY_weighted(self):
         # weighted test, dense
-        self._test_moments_XY(self.X_10, self.X_10, symmetrize=False, remove_mean=False,
+        self._test_moments_XY(self.X_10, self.X_10, self.cols_10, symmetrize=False, remove_mean=False,
                               sparse_mode='dense', weights=self.weights)
-        self._test_moments_XY(self.X_100, self.X_100, symmetrize=False, remove_mean=False,
+        self._test_moments_XY(self.X_100, self.X_100, self.cols_100, symmetrize=False, remove_mean=False,
                               sparse_mode='dense', weights=self.weights)
         # weighted test, mean-free, dense
-        self._test_moments_XY(self.X_10, self.X_10, symmetrize=False, remove_mean=True,
+        self._test_moments_XY(self.X_10, self.X_10, self.cols_10, symmetrize=False, remove_mean=True,
                               sparse_mode='dense', weights=self.weights)
-        self._test_moments_XY(self.X_100, self.X_100, symmetrize=False, remove_mean=True,
+        self._test_moments_XY(self.X_100, self.X_100, self.cols_100, symmetrize=False, remove_mean=True,
                               sparse_mode='dense', weights=self.weights)
 
     def test_moments_XY_sym(self):
         # simple test, dense, symmetric
-        self._test_moments_XY(self.X_2, self.Y_2, symmetrize=True, remove_mean=False, sparse_mode='dense')
-        self._test_moments_XY(self.X_10, self.Y_10, symmetrize=True, remove_mean=False, sparse_mode='dense')
-        self._test_moments_XY(self.X_100, self.Y_100, symmetrize=True, remove_mean=False, sparse_mode='dense')
+        self._test_moments_XY(self.X_2, self.Y_2, self.cols_2, symmetrize=True, remove_mean=False, sparse_mode='dense')
+        self._test_moments_XY(self.X_10, self.Y_10, self.cols_10, symmetrize=True, remove_mean=False, sparse_mode='dense')
+        self._test_moments_XY(self.X_100, self.Y_100, self.cols_100, symmetrize=True, remove_mean=False, sparse_mode='dense')
         # mean-free, dense, symmetric
-        self._test_moments_XY(self.X_2, self.Y_2, symmetrize=True, remove_mean=True, sparse_mode='dense')
-        self._test_moments_XY(self.X_10, self.Y_10, symmetrize=True, remove_mean=True, sparse_mode='dense')
-        self._test_moments_XY(self.X_100, self.Y_100, symmetrize=True, remove_mean=True, sparse_mode='dense')
+        self._test_moments_XY(self.X_2, self.Y_2, self.cols_2, symmetrize=True, remove_mean=True, sparse_mode='dense')
+        self._test_moments_XY(self.X_10, self.Y_10, self.cols_10, symmetrize=True, remove_mean=True, sparse_mode='dense')
+        self._test_moments_XY(self.X_100, self.Y_100, self.cols_100, symmetrize=True, remove_mean=True, sparse_mode='dense')
 
     def test_moments_XY_weighted_sym(self):
         # simple test, dense, symmetric
-        self._test_moments_XY(self.X_2, self.Y_2, symmetrize=True, remove_mean=False, sparse_mode='dense',
+        self._test_moments_XY(self.X_2, self.Y_2, self.cols_2, symmetrize=True, remove_mean=False, sparse_mode='dense',
                               weights=self.weights)
-        self._test_moments_XY(self.X_10, self.Y_10, symmetrize=True, remove_mean=False, sparse_mode='dense'
+        self._test_moments_XY(self.X_10, self.Y_10, self.cols_10, symmetrize=True, remove_mean=False, sparse_mode='dense'
                               , weights=self.weights)
-        self._test_moments_XY(self.X_100, self.Y_100, symmetrize=True, remove_mean=False, sparse_mode='dense',
+        self._test_moments_XY(self.X_100, self.Y_100, self.cols_100, symmetrize=True, remove_mean=False, sparse_mode='dense',
                               weights=self.weights)
         # mean-free, dense, symmetric
-        self._test_moments_XY(self.X_2, self.Y_2, symmetrize=True, remove_mean=True, sparse_mode='dense',
+        self._test_moments_XY(self.X_2, self.Y_2, self.cols_2, symmetrize=True, remove_mean=True, sparse_mode='dense',
                               weights=self.weights)
-        self._test_moments_XY(self.X_10, self.Y_10, symmetrize=True, remove_mean=True, sparse_mode='dense',
+        self._test_moments_XY(self.X_10, self.Y_10, self.cols_10, symmetrize=True, remove_mean=True, sparse_mode='dense',
                               weights=self.weights)
-        self._test_moments_XY(self.X_100, self.Y_100, symmetrize=True, remove_mean=True, sparse_mode='dense',
+        self._test_moments_XY(self.X_100, self.Y_100, self.cols_100, symmetrize=True, remove_mean=True, sparse_mode='dense',
                               weights=self.weights)
 
     def test_moments_XY_sparsezero(self):
-        # simple test, dense
-        self._test_moments_XY(self.X_10_sparsezero, self.Y_10_sparsezero, symmetrize=False, remove_mean=False,
+        # simple test, sparse
+        self._test_moments_XY(self.X_10_sparsezero, self.Y_10_sparsezero, self.cols_10, symmetrize=False, remove_mean=False,
                               sparse_mode='sparse')
-        self._test_moments_XY(self.X_100_sparsezero, self.Y_10_sparsezero, symmetrize=False, remove_mean=False,
+        self._test_moments_XY(self.X_100_sparsezero, self.Y_10_sparsezero, self.cols_10, symmetrize=False, remove_mean=False,
                               sparse_mode='sparse')
-        self._test_moments_XY(self.X_100_sparsezero, self.Y_100_sparsezero, symmetrize=False, remove_mean=False,
+        self._test_moments_XY(self.X_100_sparsezero, self.Y_100_sparsezero, self.cols_100, symmetrize=False, remove_mean=False,
                               sparse_mode='sparse')
-        # mean-free, dense
-        self._test_moments_XY(self.X_10_sparsezero, self.Y_10_sparsezero, symmetrize=False, remove_mean=True,
+        # mean-free, sparse
+        self._test_moments_XY(self.X_10_sparsezero, self.Y_10_sparsezero, self.cols_10, symmetrize=False, remove_mean=True,
                               sparse_mode='sparse')
-        self._test_moments_XY(self.X_100_sparsezero, self.Y_10_sparsezero, symmetrize=False, remove_mean=True,
+        self._test_moments_XY(self.X_100_sparsezero, self.Y_10_sparsezero, self.cols_10, symmetrize=False, remove_mean=True,
                               sparse_mode='sparse')
-        self._test_moments_XY(self.X_100_sparsezero, self.Y_100_sparsezero, symmetrize=False, remove_mean=True,
-                              sparse_mode='dense')
+        self._test_moments_XY(self.X_100_sparsezero, self.Y_100_sparsezero, self.cols_100, symmetrize=False, remove_mean=True,
+                              sparse_mode='sparse')
 
     def test_moments_XY_weighted_sparsezero(self):
         # weighted test, sparse
-        self._test_moments_XY(self.X_10_sparsezero, self.X_10_sparsezero, symmetrize=False, remove_mean=False,
+        self._test_moments_XY(self.X_10_sparsezero, self.X_10_sparsezero, self.cols_10, symmetrize=False, remove_mean=False,
                               sparse_mode='sparse', weights=self.weights)
-        self._test_moments_XY(self.X_100_sparsezero, self.X_100_sparsezero, symmetrize=False, remove_mean=False,
+        self._test_moments_XY(self.X_100_sparsezero, self.X_100_sparsezero, self.cols_100, symmetrize=False, remove_mean=False,
                               sparse_mode='sparse', weights=self.weights)
         # weighted test, mean-free, sparse
-        self._test_moments_XY(self.X_10_sparsezero, self.X_10_sparsezero, symmetrize=False, remove_mean=True,
+        self._test_moments_XY(self.X_10_sparsezero, self.X_10_sparsezero, self.cols_10, symmetrize=False, remove_mean=True,
                               sparse_mode='sparse', weights=self.weights)
-        self._test_moments_XY(self.X_100_sparsezero, self.X_100_sparsezero, symmetrize=False, remove_mean=True,
+        self._test_moments_XY(self.X_100_sparsezero, self.X_100_sparsezero, self.cols_100, symmetrize=False, remove_mean=True,
                               sparse_mode='sparse', weights=self.weights)
 
     def test_moments_XY_sym_sparsezero(self):
         # simple test, sparse, symmetric
-        self._test_moments_XY(self.X_10_sparsezero, self.Y_10_sparsezero, symmetrize=True, remove_mean=False,
+        self._test_moments_XY(self.X_10_sparsezero, self.Y_10_sparsezero, self.cols_10, symmetrize=True, remove_mean=False,
                               sparse_mode='sparse')
-        self._test_moments_XY(self.X_100_sparsezero, self.Y_100_sparsezero, symmetrize=True, remove_mean=False,
+        self._test_moments_XY(self.X_100_sparsezero, self.Y_100_sparsezero, self.cols_100, symmetrize=True, remove_mean=False,
                               sparse_mode='sparse')
         # mean-free, sparse, symmetric
-        self._test_moments_XY(self.X_10_sparsezero, self.Y_10_sparsezero, symmetrize=True, remove_mean=True,
+        self._test_moments_XY(self.X_10_sparsezero, self.Y_10_sparsezero, self.cols_10, symmetrize=True, remove_mean=True,
                               sparse_mode='sparse')
-        self._test_moments_XY(self.X_100_sparsezero, self.Y_100_sparsezero, symmetrize=True, remove_mean=True,
+        self._test_moments_XY(self.X_100_sparsezero, self.Y_100_sparsezero, self.cols_100, symmetrize=True, remove_mean=True,
                               sparse_mode='sparse')
 
     def test_moments_XY_weighted_sym_sparsezero(self):
         # simple test, sparse, symmetric
-        self._test_moments_XY(self.X_10_sparsezero, self.Y_10_sparsezero, symmetrize=True, remove_mean=False,
+        self._test_moments_XY(self.X_10_sparsezero, self.Y_10_sparsezero, self.cols_10, symmetrize=True, remove_mean=False,
                               sparse_mode='sparse', weights=self.weights)
-        self._test_moments_XY(self.X_100_sparsezero, self.Y_100_sparsezero, symmetrize=True, remove_mean=False,
+        self._test_moments_XY(self.X_100_sparsezero, self.Y_100_sparsezero, self.cols_100, symmetrize=True, remove_mean=False,
                               sparse_mode='sparse', weights=self.weights)
         # mean-free, sparse, symmetric
-        self._test_moments_XY(self.X_10_sparsezero, self.Y_10_sparsezero, symmetrize=True, remove_mean=True,
+        self._test_moments_XY(self.X_10_sparsezero, self.Y_10_sparsezero, self.cols_10, symmetrize=True, remove_mean=True,
                               sparse_mode='sparse', weights=self.weights)
-        self._test_moments_XY(self.X_100_sparsezero, self.Y_100_sparsezero, symmetrize=True, remove_mean=True,
+        self._test_moments_XY(self.X_100_sparsezero, self.Y_100_sparsezero, self.cols_100, symmetrize=True, remove_mean=True,
                               sparse_mode='sparse', weights=self.weights)
 
     def test_moments_XY_sparseconst(self):
-        # simple test, dense
-        self._test_moments_XY(self.X_10_sparseconst, self.Y_10_sparseconst, symmetrize=False, remove_mean=False,
+        # simple test, sparse
+        self._test_moments_XY(self.X_10_sparseconst, self.Y_10_sparseconst, self.cols_10, symmetrize=False, remove_mean=False,
                               sparse_mode='sparse')
-        self._test_moments_XY(self.X_100_sparseconst, self.Y_10_sparseconst, symmetrize=False, remove_mean=False,
+        self._test_moments_XY(self.X_100_sparseconst, self.Y_10_sparseconst, self.cols_10, symmetrize=False, remove_mean=False,
                               sparse_mode='sparse')
-        self._test_moments_XY(self.X_100_sparseconst, self.Y_100_sparseconst, symmetrize=False, remove_mean=False,
+        self._test_moments_XY(self.X_100_sparseconst, self.Y_100_sparseconst, self.cols_100, symmetrize=False, remove_mean=False,
                               sparse_mode='sparse')
-        # mean-free, dense
-        self._test_moments_XY(self.X_10_sparseconst, self.Y_10_sparseconst, symmetrize=False, remove_mean=True,
+        # mean-free, sparse
+        self._test_moments_XY(self.X_10_sparseconst, self.Y_10_sparseconst, self.cols_10, symmetrize=False, remove_mean=True,
                               sparse_mode='sparse')
-        self._test_moments_XY(self.X_100_sparseconst, self.Y_10_sparseconst, symmetrize=False, remove_mean=True,
+        self._test_moments_XY(self.X_100_sparseconst, self.Y_10_sparseconst, self.cols_10, symmetrize=False, remove_mean=True,
                               sparse_mode='sparse')
-        self._test_moments_XY(self.X_100_sparseconst, self.Y_100_sparseconst, symmetrize=False, remove_mean=True,
-                              sparse_mode='dense')
+        self._test_moments_XY(self.X_100_sparseconst, self.Y_100_sparseconst, self.cols_100, symmetrize=False, remove_mean=True,
+                              sparse_mode='sparse')
 
     def test_moments_XY_weighted_sparseconst(self):
         # weighted test, sparse
-        self._test_moments_XY(self.X_10_sparseconst, self.X_10_sparseconst, symmetrize=False, remove_mean=False,
+        self._test_moments_XY(self.X_10_sparseconst, self.X_10_sparseconst, self.cols_10, symmetrize=False, remove_mean=False,
                               sparse_mode='sparse', weights=self.weights)
-        self._test_moments_XY(self.X_100_sparseconst, self.X_100_sparseconst, symmetrize=False, remove_mean=False,
+        self._test_moments_XY(self.X_100_sparseconst, self.X_100_sparseconst, self.cols_100, symmetrize=False, remove_mean=False,
                               sparse_mode='sparse', weights=self.weights)
         # weighted test, mean-free, sparse
-        self._test_moments_XY(self.X_10_sparseconst, self.X_10_sparseconst, symmetrize=False, remove_mean=True,
+        self._test_moments_XY(self.X_10_sparseconst, self.X_10_sparseconst, self.cols_10, symmetrize=False, remove_mean=True,
                               sparse_mode='sparse', weights=self.weights)
-        self._test_moments_XY(self.X_100_sparseconst, self.X_100_sparseconst, symmetrize=False, remove_mean=True,
+        self._test_moments_XY(self.X_100_sparseconst, self.X_100_sparseconst, self.cols_100, symmetrize=False, remove_mean=True,
                               sparse_mode='sparse', weights=self.weights)
 
     def test_moments_XY_sym_sparseconst(self):
         # simple test, sparse, symmetric
-        self._test_moments_XY(self.X_10_sparseconst, self.Y_10_sparseconst, symmetrize=True, remove_mean=False,
+        self._test_moments_XY(self.X_10_sparseconst, self.Y_10_sparseconst, self.cols_10, symmetrize=True, remove_mean=False,
                               sparse_mode='sparse')
-        self._test_moments_XY(self.X_100_sparseconst, self.Y_100_sparseconst, symmetrize=True, remove_mean=False,
+        self._test_moments_XY(self.X_100_sparseconst, self.Y_100_sparseconst, self.cols_100, symmetrize=True, remove_mean=False,
                               sparse_mode='sparse')
         # mean-free, sparse, symmetric
-        self._test_moments_XY(self.X_10_sparseconst, self.Y_10_sparseconst, symmetrize=True, remove_mean=True,
+        self._test_moments_XY(self.X_10_sparseconst, self.Y_10_sparseconst, self.cols_10, symmetrize=True, remove_mean=True,
                               sparse_mode='sparse')
-        self._test_moments_XY(self.X_100_sparseconst, self.Y_100_sparseconst, symmetrize=True, remove_mean=True,
+        self._test_moments_XY(self.X_100_sparseconst, self.Y_100_sparseconst, self.cols_100, symmetrize=True, remove_mean=True,
                               sparse_mode='sparse')
 
     def test_moments_XY_weighted_sym_sparseconst(self):
         # simple test, sparse, symmetric
-        self._test_moments_XY(self.X_10_sparseconst, self.Y_10_sparseconst, symmetrize=True, remove_mean=False,
+        self._test_moments_XY(self.X_10_sparseconst, self.Y_10_sparseconst, self.cols_10, symmetrize=True, remove_mean=False,
                               sparse_mode='sparse', weights=self.weights)
-        self._test_moments_XY(self.X_100_sparseconst, self.Y_100_sparseconst, symmetrize=True, remove_mean=False,
+        self._test_moments_XY(self.X_100_sparseconst, self.Y_100_sparseconst, self.cols_100, symmetrize=True, remove_mean=False,
                               sparse_mode='sparse', weights=self.weights)
         # mean-free, sparse, symmetric
-        self._test_moments_XY(self.X_10_sparseconst, self.Y_10_sparseconst, symmetrize=True, remove_mean=True,
+        self._test_moments_XY(self.X_10_sparseconst, self.Y_10_sparseconst, self.cols_10, symmetrize=True, remove_mean=True,
                               sparse_mode='sparse', weights=self.weights)
-        self._test_moments_XY(self.X_100_sparseconst, self.Y_100_sparseconst, symmetrize=True, remove_mean=True,
+        self._test_moments_XY(self.X_100_sparseconst, self.Y_100_sparseconst, self.cols_100, symmetrize=True, remove_mean=True,
                               sparse_mode='sparse', weights=self.weights)
 
 

--- a/pyemma/_ext/variational/estimators/tests/test_moments.py
+++ b/pyemma/_ext/variational/estimators/tests/test_moments.py
@@ -49,13 +49,16 @@ class TestMoments(unittest.TestCase):
         cls.cols_2 = np.array([0])
         cls.cols_10 = np.random.choice(10, 5, replace=False)
         cls.cols_100 = np.random.choice(100, 20, replace=False)
+        # sparse tolerance
+        cls.sparse_tol = 1e-14
 
         return cls
 
-    def _test_moments_X(self, X, column_selection, remove_mean=False, sparse_mode='auto', weights=None):
+    def _test_moments_X(self, X, column_selection, remove_mean=False, sparse_mode='auto', sparse_tol=0.0, weights=None):
         # proposed solution
         w, s_X, C_XX = moments.moments_XX(X, remove_mean=remove_mean, modify_data=False,
-                                          sparse_mode=sparse_mode, weights=weights)
+                                          sparse_mode=sparse_mode, sparse_tol=sparse_tol,
+                                          weights=weights)
         # reference
         X = X.astype(np.float64)
         if weights is not None:
@@ -77,14 +80,13 @@ class TestMoments(unittest.TestCase):
         assert np.allclose(C_XX, C_XX_ref)
         # column subsets
         w, s_X, C_XX = moments.moments_XX(X, remove_mean=remove_mean, modify_data=False,
-                                          sparse_mode=sparse_mode, weights=weights,
-                                          column_selection=column_selection)
+                                          sparse_mode=sparse_mode, sparse_tol=sparse_tol,
+                                          weights=weights, column_selection=column_selection)
         assert np.allclose(C_XX, C_XX_ref[:, column_selection])
         # diagonal only
         if sparse_mode is not 'sparse':
             w, s_X, C_XX = moments.moments_XX(X, remove_mean=remove_mean, modify_data=False,
-                                              sparse_mode=sparse_mode, weights=weights,
-                                              diag_only=True)
+                                              sparse_mode=sparse_mode, weights=weights, diag_only=True)
             assert np.allclose(C_XX, np.diag(C_XX_ref))
 
     def test_moments_X(self):
@@ -103,38 +105,38 @@ class TestMoments(unittest.TestCase):
 
     def test_moments_X_sparsezero(self):
         # simple test, sparse
-        self._test_moments_X(self.X_10_sparsezero, self.cols_10, remove_mean=False, sparse_mode='sparse')
-        self._test_moments_X(self.X_100_sparsezero, self.cols_100, remove_mean=False, sparse_mode='sparse')
+        self._test_moments_X(self.X_10_sparsezero, self.cols_10, remove_mean=False, sparse_mode='sparse', sparse_tol=self.sparse_tol)
+        self._test_moments_X(self.X_100_sparsezero, self.cols_100, remove_mean=False, sparse_mode='sparse', sparse_tol=self.sparse_tol)
         # mean-free, sparse
-        self._test_moments_X(self.X_10_sparsezero, self.cols_10, remove_mean=True, sparse_mode='sparse')
-        self._test_moments_X(self.X_100_sparsezero, self.cols_100, remove_mean=True, sparse_mode='sparse')
+        self._test_moments_X(self.X_10_sparsezero, self.cols_10, remove_mean=True, sparse_mode='sparse', sparse_tol=self.sparse_tol)
+        self._test_moments_X(self.X_100_sparsezero, self.cols_100, remove_mean=True, sparse_mode='sparse', sparse_tol=self.sparse_tol)
         # weighted, sparse
-        self._test_moments_X(self.X_10_sparsezero, self.cols_10, remove_mean=False, sparse_mode='sparse', weights=self.weights)
-        self._test_moments_X(self.X_100_sparsezero, self.cols_100, remove_mean=False, sparse_mode='sparse', weights=self.weights)
+        self._test_moments_X(self.X_10_sparsezero, self.cols_10, remove_mean=False, sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
+        self._test_moments_X(self.X_100_sparsezero, self.cols_100, remove_mean=False, sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
         # weighted, mean-free, sparse
-        self._test_moments_X(self.X_10_sparsezero, self.cols_10, remove_mean=True, sparse_mode='sparse', weights=self.weights)
-        self._test_moments_X(self.X_100_sparsezero, self.cols_100, remove_mean=True, sparse_mode='sparse', weights=self.weights)
+        self._test_moments_X(self.X_10_sparsezero, self.cols_10, remove_mean=True, sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
+        self._test_moments_X(self.X_100_sparsezero, self.cols_100, remove_mean=True, sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
 
     def test_moments_X_sparseconst(self):
         # simple test, sparse
-        self._test_moments_X(self.X_10_sparseconst, self.cols_10, remove_mean=False, sparse_mode='sparse')
-        self._test_moments_X(self.X_100_sparseconst, self.cols_100, remove_mean=False, sparse_mode='sparse')
+        self._test_moments_X(self.X_10_sparseconst, self.cols_10, remove_mean=False, sparse_mode='sparse', sparse_tol=self.sparse_tol)
+        self._test_moments_X(self.X_100_sparseconst, self.cols_100, remove_mean=False, sparse_mode='sparse', sparse_tol=self.sparse_tol)
         # mean-free, sparse
-        self._test_moments_X(self.X_10_sparseconst, self.cols_10, remove_mean=True, sparse_mode='sparse')
-        self._test_moments_X(self.X_100_sparseconst, self.cols_100, remove_mean=True, sparse_mode='sparse')
+        self._test_moments_X(self.X_10_sparseconst, self.cols_10, remove_mean=True, sparse_mode='sparse', sparse_tol=self.sparse_tol)
+        self._test_moments_X(self.X_100_sparseconst, self.cols_100, remove_mean=True, sparse_mode='sparse', sparse_tol=self.sparse_tol)
         # weighted, sparse:
-        self._test_moments_X(self.X_10_sparseconst, self.cols_10, remove_mean=False, sparse_mode='dense', weights=self.weights)
-        self._test_moments_X(self.X_100_sparseconst, self.cols_100, remove_mean=False, sparse_mode='dense', weights=self.weights)
+        self._test_moments_X(self.X_10_sparseconst, self.cols_10, remove_mean=False, sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
+        self._test_moments_X(self.X_100_sparseconst, self.cols_100, remove_mean=False, sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
         # weighted, mean-free, sparse:
-        self._test_moments_X(self.X_10_sparseconst, self.cols_10, remove_mean=True, sparse_mode='dense', weights=self.weights)
-        self._test_moments_X(self.X_100_sparseconst, self.cols_100, remove_mean=True, sparse_mode='dense', weights=self.weights)
+        self._test_moments_X(self.X_10_sparseconst, self.cols_10, remove_mean=True, sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
+        self._test_moments_X(self.X_100_sparseconst, self.cols_100, remove_mean=True, sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
 
     def test_boolean_moments(self):
         # standard tests
         self._test_moments_X(self.Xb_10, self.cols_10, remove_mean=False, sparse_mode='dense')
         self._test_moments_X(self.Xb_10, self.cols_10, remove_mean=True, sparse_mode='dense')
-        self._test_moments_X(self.Xb_10_sparsezero, self.cols_10, remove_mean=False, sparse_mode='sparse')
-        self._test_moments_X(self.Xb_10_sparsezero, self.cols_10, remove_mean=True, sparse_mode='sparse')
+        self._test_moments_X(self.Xb_10_sparsezero, self.cols_10, remove_mean=False, sparse_mode='sparse', sparse_tol=self.sparse_tol)
+        self._test_moments_X(self.Xb_10_sparsezero, self.cols_10, remove_mean=True, sparse_mode='sparse', sparse_tol=self.sparse_tol)
         # test integer recovery
         Cxx_ref = np.dot(self.Xb_10.astype(np.int64).T, self.Xb_10.astype(np.int64))  # integer
         s_X_ref = np.sum(self.Xb_10, axis=0)
@@ -145,10 +147,10 @@ class TestMoments(unittest.TestCase):
         assert np.array_equal(Cxx, Cxx_ref)
 
 
-    def _test_moments_XY(self, X, Y, column_selection, symmetrize=False, remove_mean=False, sparse_mode='auto', weights=None):
+    def _test_moments_XY(self, X, Y, column_selection, symmetrize=False, remove_mean=False, sparse_mode='auto', sparse_tol=0.0, weights=None):
         w1, s_X, s_Y, C_XX, C_XY = moments.moments_XXXY(X, Y, remove_mean=remove_mean, modify_data=False,
-                                                       symmetrize=symmetrize, sparse_mode=sparse_mode,
-                                                       weights=weights)
+                                                        symmetrize=symmetrize, sparse_mode=sparse_mode,
+                                                        sparse_tol=sparse_tol, weights=weights)
         # reference
         T = X.shape[0]
         if weights is not None:
@@ -194,14 +196,14 @@ class TestMoments(unittest.TestCase):
         assert np.allclose(C_XY, C_XY_ref)
         # column subsets
         w1, s_X, s_Y, C_XX, C_XY = moments.moments_XXXY(X, Y, remove_mean=remove_mean, modify_data=False,
-                                                       symmetrize=symmetrize, sparse_mode=sparse_mode,
+                                                       symmetrize=symmetrize, sparse_mode=sparse_mode, sparse_tol=sparse_tol,
                                                        weights=weights, column_selection=column_selection)
         assert np.allclose(C_XX, C_XX_ref[:, column_selection])
         assert np.allclose(C_XY, C_XY_ref[:, column_selection])
         # diagonal only
         if sparse_mode is not 'sparse' and X.shape[1] == Y.shape[1]:
             w1, s_X, s_Y, C_XX, C_XY = moments.moments_XXXY(X, Y, remove_mean=remove_mean, modify_data=False,
-                                                           symmetrize=symmetrize, sparse_mode=sparse_mode,
+                                                           symmetrize=symmetrize, sparse_mode=sparse_mode, sparse_tol=sparse_tol,
                                                            weights=weights, diag_only=True)
             assert np.allclose(C_XX, np.diag(C_XX_ref))
             assert np.allclose(C_XY, np.diag(C_XY_ref))
@@ -218,14 +220,14 @@ class TestMoments(unittest.TestCase):
 
     def test_moments_XY_weighted(self):
         # weighted test, dense
-        self._test_moments_XY(self.X_10, self.X_10, self.cols_10, symmetrize=False, remove_mean=False,
+        self._test_moments_XY(self.X_10, self.Y_10, self.cols_10, symmetrize=False, remove_mean=False,
                               sparse_mode='dense', weights=self.weights)
-        self._test_moments_XY(self.X_100, self.X_100, self.cols_100, symmetrize=False, remove_mean=False,
+        self._test_moments_XY(self.X_100, self.Y_100, self.cols_100, symmetrize=False, remove_mean=False,
                               sparse_mode='dense', weights=self.weights)
         # weighted test, mean-free, dense
-        self._test_moments_XY(self.X_10, self.X_10, self.cols_10, symmetrize=False, remove_mean=True,
+        self._test_moments_XY(self.X_10, self.Y_10, self.cols_10, symmetrize=False, remove_mean=True,
                               sparse_mode='dense', weights=self.weights)
-        self._test_moments_XY(self.X_100, self.X_100, self.cols_100, symmetrize=False, remove_mean=True,
+        self._test_moments_XY(self.X_100, self.Y_100, self.cols_100, symmetrize=False, remove_mean=True,
                               sparse_mode='dense', weights=self.weights)
 
     def test_moments_XY_sym(self):
@@ -257,106 +259,176 @@ class TestMoments(unittest.TestCase):
     def test_moments_XY_sparsezero(self):
         # simple test, sparse
         self._test_moments_XY(self.X_10_sparsezero, self.Y_10_sparsezero, self.cols_10, symmetrize=False, remove_mean=False,
-                              sparse_mode='sparse')
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol)
         self._test_moments_XY(self.X_100_sparsezero, self.Y_10_sparsezero, self.cols_10, symmetrize=False, remove_mean=False,
-                              sparse_mode='sparse')
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol)
         self._test_moments_XY(self.X_100_sparsezero, self.Y_100_sparsezero, self.cols_100, symmetrize=False, remove_mean=False,
-                              sparse_mode='sparse')
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol)
         # mean-free, sparse
         self._test_moments_XY(self.X_10_sparsezero, self.Y_10_sparsezero, self.cols_10, symmetrize=False, remove_mean=True,
-                              sparse_mode='sparse')
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol)
         self._test_moments_XY(self.X_100_sparsezero, self.Y_10_sparsezero, self.cols_10, symmetrize=False, remove_mean=True,
-                              sparse_mode='sparse')
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol)
         self._test_moments_XY(self.X_100_sparsezero, self.Y_100_sparsezero, self.cols_100, symmetrize=False, remove_mean=True,
-                              sparse_mode='sparse')
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol)
 
     def test_moments_XY_weighted_sparsezero(self):
         # weighted test, sparse
-        self._test_moments_XY(self.X_10_sparsezero, self.X_10_sparsezero, self.cols_10, symmetrize=False, remove_mean=False,
-                              sparse_mode='sparse', weights=self.weights)
-        self._test_moments_XY(self.X_100_sparsezero, self.X_100_sparsezero, self.cols_100, symmetrize=False, remove_mean=False,
-                              sparse_mode='sparse', weights=self.weights)
+        self._test_moments_XY(self.X_10_sparsezero, self.Y_10_sparsezero, self.cols_10, symmetrize=False, remove_mean=False,
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
+        self._test_moments_XY(self.X_100_sparsezero, self.Y_100_sparsezero, self.cols_100, symmetrize=False, remove_mean=False,
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
         # weighted test, mean-free, sparse
-        self._test_moments_XY(self.X_10_sparsezero, self.X_10_sparsezero, self.cols_10, symmetrize=False, remove_mean=True,
-                              sparse_mode='sparse', weights=self.weights)
-        self._test_moments_XY(self.X_100_sparsezero, self.X_100_sparsezero, self.cols_100, symmetrize=False, remove_mean=True,
-                              sparse_mode='sparse', weights=self.weights)
+        self._test_moments_XY(self.X_10_sparsezero, self.Y_10_sparsezero, self.cols_10, symmetrize=False, remove_mean=True,
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
+        self._test_moments_XY(self.X_100_sparsezero, self.Y_100_sparsezero, self.cols_100, symmetrize=False, remove_mean=True,
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
 
     def test_moments_XY_sym_sparsezero(self):
         # simple test, sparse, symmetric
         self._test_moments_XY(self.X_10_sparsezero, self.Y_10_sparsezero, self.cols_10, symmetrize=True, remove_mean=False,
-                              sparse_mode='sparse')
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol)
         self._test_moments_XY(self.X_100_sparsezero, self.Y_100_sparsezero, self.cols_100, symmetrize=True, remove_mean=False,
-                              sparse_mode='sparse')
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol)
         # mean-free, sparse, symmetric
         self._test_moments_XY(self.X_10_sparsezero, self.Y_10_sparsezero, self.cols_10, symmetrize=True, remove_mean=True,
-                              sparse_mode='sparse')
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol)
         self._test_moments_XY(self.X_100_sparsezero, self.Y_100_sparsezero, self.cols_100, symmetrize=True, remove_mean=True,
-                              sparse_mode='sparse')
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol)
 
     def test_moments_XY_weighted_sym_sparsezero(self):
         # simple test, sparse, symmetric
         self._test_moments_XY(self.X_10_sparsezero, self.Y_10_sparsezero, self.cols_10, symmetrize=True, remove_mean=False,
-                              sparse_mode='sparse', weights=self.weights)
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
         self._test_moments_XY(self.X_100_sparsezero, self.Y_100_sparsezero, self.cols_100, symmetrize=True, remove_mean=False,
-                              sparse_mode='sparse', weights=self.weights)
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
         # mean-free, sparse, symmetric
         self._test_moments_XY(self.X_10_sparsezero, self.Y_10_sparsezero, self.cols_10, symmetrize=True, remove_mean=True,
-                              sparse_mode='sparse', weights=self.weights)
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
         self._test_moments_XY(self.X_100_sparsezero, self.Y_100_sparsezero, self.cols_100, symmetrize=True, remove_mean=True,
-                              sparse_mode='sparse', weights=self.weights)
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
 
     def test_moments_XY_sparseconst(self):
         # simple test, sparse
         self._test_moments_XY(self.X_10_sparseconst, self.Y_10_sparseconst, self.cols_10, symmetrize=False, remove_mean=False,
-                              sparse_mode='sparse')
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol)
         self._test_moments_XY(self.X_100_sparseconst, self.Y_10_sparseconst, self.cols_10, symmetrize=False, remove_mean=False,
-                              sparse_mode='sparse')
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol)
         self._test_moments_XY(self.X_100_sparseconst, self.Y_100_sparseconst, self.cols_100, symmetrize=False, remove_mean=False,
-                              sparse_mode='sparse')
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol)
         # mean-free, sparse
         self._test_moments_XY(self.X_10_sparseconst, self.Y_10_sparseconst, self.cols_10, symmetrize=False, remove_mean=True,
-                              sparse_mode='sparse')
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol)
         self._test_moments_XY(self.X_100_sparseconst, self.Y_10_sparseconst, self.cols_10, symmetrize=False, remove_mean=True,
-                              sparse_mode='sparse')
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol)
         self._test_moments_XY(self.X_100_sparseconst, self.Y_100_sparseconst, self.cols_100, symmetrize=False, remove_mean=True,
-                              sparse_mode='sparse')
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol)
 
     def test_moments_XY_weighted_sparseconst(self):
         # weighted test, sparse
-        self._test_moments_XY(self.X_10_sparseconst, self.X_10_sparseconst, self.cols_10, symmetrize=False, remove_mean=False,
-                              sparse_mode='sparse', weights=self.weights)
-        self._test_moments_XY(self.X_100_sparseconst, self.X_100_sparseconst, self.cols_100, symmetrize=False, remove_mean=False,
-                              sparse_mode='sparse', weights=self.weights)
+        self._test_moments_XY(self.X_10_sparseconst, self.Y_10_sparseconst, self.cols_10, symmetrize=False, remove_mean=False,
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
+        self._test_moments_XY(self.X_100_sparseconst, self.Y_100_sparseconst, self.cols_100, symmetrize=False, remove_mean=False,
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
         # weighted test, mean-free, sparse
-        self._test_moments_XY(self.X_10_sparseconst, self.X_10_sparseconst, self.cols_10, symmetrize=False, remove_mean=True,
-                              sparse_mode='sparse', weights=self.weights)
-        self._test_moments_XY(self.X_100_sparseconst, self.X_100_sparseconst, self.cols_100, symmetrize=False, remove_mean=True,
-                              sparse_mode='sparse', weights=self.weights)
+        self._test_moments_XY(self.X_10_sparseconst, self.Y_10_sparseconst, self.cols_10, symmetrize=False, remove_mean=True,
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
+        self._test_moments_XY(self.X_100_sparseconst, self.Y_100_sparseconst, self.cols_100, symmetrize=False, remove_mean=True,
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
 
     def test_moments_XY_sym_sparseconst(self):
         # simple test, sparse, symmetric
         self._test_moments_XY(self.X_10_sparseconst, self.Y_10_sparseconst, self.cols_10, symmetrize=True, remove_mean=False,
-                              sparse_mode='sparse')
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol)
         self._test_moments_XY(self.X_100_sparseconst, self.Y_100_sparseconst, self.cols_100, symmetrize=True, remove_mean=False,
-                              sparse_mode='sparse')
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol)
         # mean-free, sparse, symmetric
         self._test_moments_XY(self.X_10_sparseconst, self.Y_10_sparseconst, self.cols_10, symmetrize=True, remove_mean=True,
-                              sparse_mode='sparse')
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol)
         self._test_moments_XY(self.X_100_sparseconst, self.Y_100_sparseconst, self.cols_100, symmetrize=True, remove_mean=True,
-                              sparse_mode='sparse')
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol)
 
     def test_moments_XY_weighted_sym_sparseconst(self):
         # simple test, sparse, symmetric
         self._test_moments_XY(self.X_10_sparseconst, self.Y_10_sparseconst, self.cols_10, symmetrize=True, remove_mean=False,
-                              sparse_mode='sparse', weights=self.weights)
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
         self._test_moments_XY(self.X_100_sparseconst, self.Y_100_sparseconst, self.cols_100, symmetrize=True, remove_mean=False,
-                              sparse_mode='sparse', weights=self.weights)
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
         # mean-free, sparse, symmetric
         self._test_moments_XY(self.X_10_sparseconst, self.Y_10_sparseconst, self.cols_10, symmetrize=True, remove_mean=True,
-                              sparse_mode='sparse', weights=self.weights)
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
         self._test_moments_XY(self.X_100_sparseconst, self.Y_100_sparseconst, self.cols_100, symmetrize=True, remove_mean=True,
-                              sparse_mode='sparse', weights=self.weights)
+                              sparse_mode='sparse', sparse_tol=self.sparse_tol, weights=self.weights)
+
+    def _test_moments_block(self, X, Y, column_selection, remove_mean=False, sparse_mode='auto', sparse_tol=0.0):
+        w1, s, C = moments.moments_block(X, Y, remove_mean=remove_mean, modify_data=False,
+                                         sparse_mode=sparse_mode, sparse_tol=sparse_tol)
+        # reference
+        w = X.shape[0]
+        s_X_ref = X.sum(axis=0)
+        s_Y_ref = Y.sum(axis=0)
+        if remove_mean:
+            X = X - s_X_ref/float(w)
+            Y = Y - s_Y_ref/float(w)
+        C_XX_ref = np.dot(X.T, X)
+        C_XY_ref = np.dot(X.T, Y)
+        C_YX_ref = np.dot(Y.T, X)
+        C_YY_ref = np.dot(Y.T, Y)
+        # test
+        assert np.allclose(w1, w)
+        assert np.allclose(s[0], s_X_ref)
+        assert np.allclose(s[1], s_Y_ref)
+        assert np.allclose(C[0][0], C_XX_ref)
+        assert np.allclose(C[0][1], C_XY_ref)
+        assert np.allclose(C[1][0], C_YX_ref)
+        assert np.allclose(C[1][1], C_YY_ref)
+        # column subsets
+        w1, s, C = moments.moments_block(X, Y, remove_mean=remove_mean, modify_data=False,
+                                         sparse_mode=sparse_mode, sparse_tol=sparse_tol, column_selection=column_selection)
+        assert np.allclose(C[0][0], C_XX_ref[:, column_selection])
+        assert np.allclose(C[0][1], C_XY_ref[:, column_selection])
+        assert np.allclose(C[1][0], C_YX_ref[:, column_selection])
+        assert np.allclose(C[1][1], C_YY_ref[:, column_selection])
+        # diagonal only
+        if sparse_mode is not 'sparse' and X.shape[1] == Y.shape[1]:
+            w1, s, C = moments.moments_block(X, Y, remove_mean=remove_mean, modify_data=False,
+                                             sparse_mode=sparse_mode, sparse_tol=sparse_tol, diag_only=True)
+            assert np.allclose(C[0][0], np.diag(C_XX_ref))
+            assert np.allclose(C[0][1], np.diag(C_XY_ref))
+            assert np.allclose(C[1][0], np.diag(C_YX_ref))
+            assert np.allclose(C[1][1], np.diag(C_YY_ref))
+
+    def test_moments_block(self):
+        # simple test, dense
+        self._test_moments_block(self.X_10, self.Y_10, self.cols_10, remove_mean=False, sparse_mode='dense')
+        self._test_moments_block(self.X_100, self.Y_100, self.cols_100, remove_mean=False, sparse_mode='dense')
+        # mean-free, dense
+        self._test_moments_block(self.X_10, self.Y_10, self.cols_10, remove_mean=True, sparse_mode='dense')
+        self._test_moments_block(self.X_100, self.Y_100, self.cols_100, remove_mean=True, sparse_mode='dense')
+
+    def test_moments_block_sparsezero(self):
+        # simple test, sparse
+        self._test_moments_block(self.X_10_sparsezero, self.Y_10_sparsezero, self.cols_10, remove_mean=False,
+                                 sparse_mode='sparse', sparse_tol=self.sparse_tol)
+        self._test_moments_block(self.X_100_sparsezero, self.Y_100_sparsezero, self.cols_100, remove_mean=False,
+                                 sparse_mode='sparse', sparse_tol=self.sparse_tol)
+        # mean-free, sparse
+        self._test_moments_block(self.X_10_sparsezero, self.Y_10_sparsezero, self.cols_10, remove_mean=True,
+                                 sparse_mode='sparse', sparse_tol=self.sparse_tol)
+        self._test_moments_block(self.X_100_sparsezero, self.Y_100_sparsezero, self.cols_100, remove_mean=True,
+                                 sparse_mode='sparse', sparse_tol=self.sparse_tol)
+
+    def test_moments_block_sparseconst(self):
+        # simple test, sparse
+        self._test_moments_block(self.X_10_sparseconst, self.Y_10_sparseconst, self.cols_10, remove_mean=False,
+                                 sparse_mode='sparse', sparse_tol=self.sparse_tol)
+        self._test_moments_block(self.X_100_sparseconst, self.Y_100_sparseconst, self.cols_100, remove_mean=False,
+                                 sparse_mode='sparse', sparse_tol=self.sparse_tol)
+        # mean-free, sparse
+        self._test_moments_block(self.X_10_sparseconst, self.Y_10_sparseconst, self.cols_10, remove_mean=True,
+                                 sparse_mode='sparse', sparse_tol=self.sparse_tol)
+        self._test_moments_block(self.X_100_sparseconst, self.Y_100_sparseconst, self.cols_100, remove_mean=True,
+                                 sparse_mode='sparse', sparse_tol=self.sparse_tol)
 
 
 if __name__ == "__main__":

--- a/pyemma/_ext/variational/estimators/tests/test_running_moments.py
+++ b/pyemma/_ext/variational/estimators/tests/test_running_moments.py
@@ -308,14 +308,15 @@ class TestRunningMoments(unittest.TestCase):
         np.testing.assert_allclose(cc.moments_XX(), self.Mxx0)
         np.testing.assert_allclose(cc.moments_XY(), self.Mxy0)
         np.testing.assert_allclose(cc.moments_YY(), self.Myy0)
-        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, compute_YY=True, remove_mean=True, 
+        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, compute_YY=True, remove_mean=True,
                                           column_selection=self.cols_2)
         for i in range(0, self.T, self.L):
             cc.add(self.X[i:i+self.L], self.Y[i:i+self.L])
         np.testing.assert_allclose(cc.moments_XX(), self.Mxx0[:, self.cols_2])
         np.testing.assert_allclose(cc.moments_XY(), self.Mxy0[:, self.cols_2])
         np.testing.assert_allclose(cc.moments_YY(), self.Myy0[:, self.cols_2])
-        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, compute_YY=True, remove_mean=True, diag_only=True)
+        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, compute_YY=True, remove_mean=True,
+                                          diag_only=True)
         for i in range(0, self.T, self.L):
             cc.add(self.X[i:i+self.L], self.Y[i:i+self.L])
         np.testing.assert_allclose(cc.moments_XX(), np.diag(self.Mxx0))

--- a/pyemma/_ext/variational/estimators/tests/test_running_moments.py
+++ b/pyemma/_ext/variational/estimators/tests/test_running_moments.py
@@ -26,6 +26,9 @@ class TestRunningMoments(unittest.TestCase):
         # bias the first part
         cls.X[:2000] += 1.0
         cls.Y[:2000] -= 1.0
+        # column subsets
+        cls.cols_2 = np.array([0])
+
         # direct calculation, moments of X and Y
         cls.w = np.shape(cls.X)[0]
         cls.wsym = 2*np.shape(cls.X)[0]
@@ -64,6 +67,7 @@ class TestRunningMoments(unittest.TestCase):
         cls.Y0_w = cls.Y - cls.my_w
         cls.Mxx0_w = np.dot((cls.weights[:, None] * cls.X0_w).T, cls.X0_w)
         cls.Mxy0_w = np.dot((cls.weights[:, None] * cls.X0_w).T, cls.Y0_w)
+
         # direct calculation, weighted symmetric moments
         cls.s_sym_w = cls.sx_w + cls.sy_w
         cls.Mxx_sym_w = np.dot((cls.weights[:, None] * cls.X).T, cls.X) + np.dot((cls.weights[:, None] * cls.Y).T, cls.Y)
@@ -84,6 +88,14 @@ class TestRunningMoments(unittest.TestCase):
         np.testing.assert_allclose(cc.weight_XX(), self.T)
         np.testing.assert_allclose(cc.sum_X(), self.sx)
         np.testing.assert_allclose(cc.moments_XX(), self.Mxx)
+        cc = running_moments.RunningCovar(remove_mean=False, column_selection=self.cols_2)
+        for i in range(0, self.T, self.L):
+            cc.add(self.X[i:i+self.L])
+        np.testing.assert_allclose(cc.moments_XX(), self.Mxx[:, self.cols_2])
+        cc = running_moments.RunningCovar(remove_mean=False, diag_only=True)
+        for i in range(0, self.T, self.L):
+            cc.add(self.X[i:i+self.L])
+        np.testing.assert_allclose(cc.moments_XX(), np.diag(self.Mxx))
 
     def test_XX_meanfree(self):
         # many passes
@@ -93,6 +105,14 @@ class TestRunningMoments(unittest.TestCase):
         np.testing.assert_allclose(cc.weight_XX(), self.T)
         np.testing.assert_allclose(cc.sum_X(), self.sx)
         np.testing.assert_allclose(cc.moments_XX(), self.Mxx0)
+        cc = running_moments.RunningCovar(remove_mean=True, column_selection=self.cols_2)
+        for i in range(0, self.T, self.L):
+            cc.add(self.X[i:i+self.L])
+        np.testing.assert_allclose(cc.moments_XX(), self.Mxx0[:, self.cols_2])
+        cc = running_moments.RunningCovar(remove_mean=True, diag_only=True)
+        for i in range(0, self.T, self.L):
+            cc.add(self.X[i:i+self.L])
+        np.testing.assert_allclose(cc.moments_XX(), np.diag(self.Mxx0))
 
     def test_XXXY_withmean(self):
         # many passes
@@ -103,17 +123,36 @@ class TestRunningMoments(unittest.TestCase):
         np.testing.assert_allclose(cc.sum_X(), self.sx)
         np.testing.assert_allclose(cc.moments_XX(), self.Mxx)
         np.testing.assert_allclose(cc.moments_XY(), self.Mxy)
+        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, remove_mean=False, column_selection=self.cols_2)
+        for i in range(0, self.T, self.L):
+            cc.add(self.X[i:i+self.L], self.Y[i:i+self.L])
+        np.testing.assert_allclose(cc.moments_XX(), self.Mxx[:, self.cols_2])
+        np.testing.assert_allclose(cc.moments_XY(), self.Mxy[:, self.cols_2])
+        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, remove_mean=False, diag_only=True)
+        for i in range(0, self.T, self.L):
+            cc.add(self.X[i:i+self.L], self.Y[i:i+self.L])
+        np.testing.assert_allclose(cc.moments_XX(), np.diag(self.Mxx))
+        np.testing.assert_allclose(cc.moments_XY(), np.diag(self.Mxy))
 
     def test_XXXY_meanfree(self):
         # many passes
         cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, remove_mean=True)
-        L = 1000
-        for i in range(0, self.X.shape[0], L):
-            cc.add(self.X[i:i+L], self.Y[i:i+L])
+        for i in range(0, self.T, self.L):
+            cc.add(self.X[i:i+self.L], self.Y[i:i+self.L])
         np.testing.assert_allclose(cc.weight_XY(), self.T)
         np.testing.assert_allclose(cc.sum_X(), self.sx)
         np.testing.assert_allclose(cc.moments_XX(), self.Mxx0)
         np.testing.assert_allclose(cc.moments_XY(), self.Mxy0)
+        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, remove_mean=True, column_selection=self.cols_2)
+        for i in range(0, self.T, self.L):
+            cc.add(self.X[i:i+self.L], self.Y[i:i+self.L])
+        np.testing.assert_allclose(cc.moments_XX(), self.Mxx0[:, self.cols_2])
+        np.testing.assert_allclose(cc.moments_XY(), self.Mxy0[:, self.cols_2])
+        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, remove_mean=True, diag_only=True)
+        for i in range(0, self.T, self.L):
+            cc.add(self.X[i:i+self.L], self.Y[i:i+self.L])
+        np.testing.assert_allclose(cc.moments_XX(), np.diag(self.Mxx0))
+        np.testing.assert_allclose(cc.moments_XY(), np.diag(self.Mxy0))
 
     def test_XXXY_weighted_withmean(self):
         # many passes
@@ -127,6 +166,22 @@ class TestRunningMoments(unittest.TestCase):
         np.testing.assert_allclose(cc.sum_X(), self.sx_w)
         np.testing.assert_allclose(cc.moments_XX(), self.Mxx_w)
         np.testing.assert_allclose(cc.moments_XY(), self.Mxy_w)
+        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, remove_mean=False, column_selection=self.cols_2)
+        for i in range(0, self.T, self.L):
+            iX = self.X[i:i+self.L, :]
+            iY = self.Y[i:i+self.L, :]
+            iwe = self.weights[i:i+self.L]
+            cc.add(iX, iY, weights=iwe)
+        np.testing.assert_allclose(cc.moments_XX(), self.Mxx_w[:, self.cols_2])
+        np.testing.assert_allclose(cc.moments_XY(), self.Mxy_w[:, self.cols_2])
+        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, remove_mean=False, diag_only=True)
+        for i in range(0, self.T, self.L):
+            iX = self.X[i:i+self.L, :]
+            iY = self.Y[i:i+self.L, :]
+            iwe = self.weights[i:i+self.L]
+            cc.add(iX, iY, weights=iwe)
+        np.testing.assert_allclose(cc.moments_XX(), np.diag(self.Mxx_w))
+        np.testing.assert_allclose(cc.moments_XY(), np.diag(self.Mxy_w))
 
     def test_XXXY_weighted_meanfree(self):
         # many passes
@@ -140,6 +195,22 @@ class TestRunningMoments(unittest.TestCase):
         np.testing.assert_allclose(cc.sum_X(), self.sx_w)
         np.testing.assert_allclose(cc.moments_XX(), self.Mxx0_w)
         np.testing.assert_allclose(cc.moments_XY(), self.Mxy0_w)
+        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, remove_mean=True, column_selection=self.cols_2)
+        for i in range(0, self.T, self.L):
+            iX = self.X[i:i+self.L, :]
+            iY = self.Y[i:i+self.L, :]
+            iwe = self.weights[i:i+self.L]
+            cc.add(iX, iY, weights=iwe)
+        np.testing.assert_allclose(cc.moments_XX(), self.Mxx0_w[:, self.cols_2])
+        np.testing.assert_allclose(cc.moments_XY(), self.Mxy0_w[:, self.cols_2])
+        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, remove_mean=True, diag_only=True)
+        for i in range(0, self.T, self.L):
+            iX = self.X[i:i+self.L, :]
+            iY = self.Y[i:i+self.L, :]
+            iwe = self.weights[i:i+self.L]
+            cc.add(iX, iY, weights=iwe)
+        np.testing.assert_allclose(cc.moments_XX(), np.diag(self.Mxx0_w))
+        np.testing.assert_allclose(cc.moments_XY(), np.diag(self.Mxy0_w))
 
     def test_XXXY_sym_withmean(self):
         # many passes
@@ -150,6 +221,16 @@ class TestRunningMoments(unittest.TestCase):
         np.testing.assert_allclose(cc.sum_X(), self.s_sym)
         np.testing.assert_allclose(cc.moments_XX(), self.Mxx_sym)
         np.testing.assert_allclose(cc.moments_XY(), self.Mxy_sym)
+        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, remove_mean=False, symmetrize=True, column_selection=self.cols_2)
+        for i in range(0, self.T, self.L):
+            cc.add(self.X[i:i+self.L], self.Y[i:i+self.L])
+        np.testing.assert_allclose(cc.moments_XX(), self.Mxx_sym[:, self.cols_2])
+        np.testing.assert_allclose(cc.moments_XY(), self.Mxy_sym[:, self.cols_2])
+        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, remove_mean=False, symmetrize=True, diag_only=True)
+        for i in range(0, self.T, self.L):
+            cc.add(self.X[i:i+self.L], self.Y[i:i+self.L])
+        np.testing.assert_allclose(cc.moments_XX(), np.diag(self.Mxx_sym))
+        np.testing.assert_allclose(cc.moments_XY(), np.diag(self.Mxy_sym))
 
     def test_XXXY_sym_meanfree(self):
         # many passes
@@ -160,6 +241,16 @@ class TestRunningMoments(unittest.TestCase):
         np.testing.assert_allclose(cc.sum_X(), self.s_sym)
         np.testing.assert_allclose(cc.moments_XX(), self.Mxx0_sym)
         np.testing.assert_allclose(cc.moments_XY(), self.Mxy0_sym)
+        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, remove_mean=True, symmetrize=True, column_selection=self.cols_2)
+        for i in range(0, self.T, self.L):
+            cc.add(self.X[i:i+self.L], self.Y[i:i+self.L])
+        np.testing.assert_allclose(cc.moments_XX(), self.Mxx0_sym[:, self.cols_2])
+        np.testing.assert_allclose(cc.moments_XY(), self.Mxy0_sym[:, self.cols_2])
+        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, remove_mean=True, symmetrize=True, diag_only=True)
+        for i in range(0, self.T, self.L):
+            cc.add(self.X[i:i+self.L], self.Y[i:i+self.L])
+        np.testing.assert_allclose(cc.moments_XX(), np.diag(self.Mxx0_sym))
+        np.testing.assert_allclose(cc.moments_XY(), np.diag(self.Mxy0_sym))
 
     def test_XXXY_weighted_sym_withmean(self):
         # many passes
@@ -171,6 +262,18 @@ class TestRunningMoments(unittest.TestCase):
         np.testing.assert_allclose(cc.sum_X(), self.s_sym_w)
         np.testing.assert_allclose(cc.moments_XX(), self.Mxx_sym_w)
         np.testing.assert_allclose(cc.moments_XY(), self.Mxy_sym_w)
+        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, remove_mean=False, symmetrize=True, column_selection=self.cols_2)
+        for i in range(0, self.T, self.L):
+            iwe = self.weights[i:i+self.L]
+            cc.add(self.X[i:i+self.L], self.Y[i:i+self.L], weights=iwe)
+        np.testing.assert_allclose(cc.moments_XX(), self.Mxx_sym_w[:, self.cols_2])
+        np.testing.assert_allclose(cc.moments_XY(), self.Mxy_sym_w[:, self.cols_2])
+        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, remove_mean=False, symmetrize=True, diag_only=True)
+        for i in range(0, self.T, self.L):
+            iwe = self.weights[i:i+self.L]
+            cc.add(self.X[i:i+self.L], self.Y[i:i+self.L], weights=iwe)
+        np.testing.assert_allclose(cc.moments_XX(), np.diag(self.Mxx_sym_w))
+        np.testing.assert_allclose(cc.moments_XY(), np.diag(self.Mxy_sym_w))
 
     def test_XXXY_weighted_sym_meanfree(self):
         # many passes
@@ -182,18 +285,42 @@ class TestRunningMoments(unittest.TestCase):
         np.testing.assert_allclose(cc.sum_X(), self.s_sym_w)
         np.testing.assert_allclose(cc.moments_XX(), self.Mxx0_sym_w)
         np.testing.assert_allclose(cc.moments_XY(), self.Mxy0_sym_w)
+        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, remove_mean=True, symmetrize=True, column_selection=self.cols_2)
+        for i in range(0, self.T, self.L):
+            iwe = self.weights[i:i+self.L]
+            cc.add(self.X[i:i+self.L], self.Y[i:i+self.L], weights=iwe)
+        np.testing.assert_allclose(cc.moments_XX(), self.Mxx0_sym_w[:, self.cols_2])
+        np.testing.assert_allclose(cc.moments_XY(), self.Mxy0_sym_w[:, self.cols_2])
+        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, remove_mean=True, symmetrize=True, diag_only=True)
+        for i in range(0, self.T, self.L):
+            iwe = self.weights[i:i+self.L]
+            cc.add(self.X[i:i+self.L], self.Y[i:i+self.L], weights=iwe)
+        np.testing.assert_allclose(cc.moments_XX(), np.diag(self.Mxx0_sym_w))
+        np.testing.assert_allclose(cc.moments_XY(), np.diag(self.Mxy0_sym_w))
 
     def test_XXYY_meanfree(self):
         # many passes
         cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, compute_YY=True, remove_mean=True)
-        L = 1000
-        for i in range(0, self.X.shape[0], L):
-            cc.add(self.X[i:i+L], self.Y[i:i+L])
+        for i in range(0, self.T, self.L):
+            cc.add(self.X[i:i+self.L], self.Y[i:i+self.L])
         np.testing.assert_allclose(cc.weight_XY(), self.T)
         np.testing.assert_allclose(cc.sum_X(), self.sx)
         np.testing.assert_allclose(cc.moments_XX(), self.Mxx0)
         np.testing.assert_allclose(cc.moments_XY(), self.Mxy0)
         np.testing.assert_allclose(cc.moments_YY(), self.Myy0)
+        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, compute_YY=True, remove_mean=True, 
+                                          column_selection=self.cols_2)
+        for i in range(0, self.T, self.L):
+            cc.add(self.X[i:i+self.L], self.Y[i:i+self.L])
+        np.testing.assert_allclose(cc.moments_XX(), self.Mxx0[:, self.cols_2])
+        np.testing.assert_allclose(cc.moments_XY(), self.Mxy0[:, self.cols_2])
+        np.testing.assert_allclose(cc.moments_YY(), self.Myy0[:, self.cols_2])
+        cc = running_moments.RunningCovar(compute_XX=True, compute_XY=True, compute_YY=True, remove_mean=True, diag_only=True)
+        for i in range(0, self.T, self.L):
+            cc.add(self.X[i:i+self.L], self.Y[i:i+self.L])
+        np.testing.assert_allclose(cc.moments_XX(), np.diag(self.Mxx0))
+        np.testing.assert_allclose(cc.moments_XY(), np.diag(self.Mxy0))
+        np.testing.assert_allclose(cc.moments_YY(), np.diag(self.Myy0))
 
 
 if __name__ == "__main__":

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -1415,21 +1415,21 @@ def vamp(data=None, lag=10, dim=None, scaling=None, right=True, ncov_max=float('
     return res
 
 
-def tica_nystroem(data, lag, max_columns,
+def tica_nystroem(max_columns, data=None, lag=10,
                   dim=-1, var_cutoff=0.95, epsilon=1e-6,
-                  stride=1, skip=0, reversible=True, ncov_max=float('inf'),
+                  stride=1, skip=0, reversible=True, ncov_max=float('inf'), chunksize=None,
                   initial_columns=None, nsel=1, neig=None):
     r""" Sparse sampling implementation [1]_ of time-lagged independent component analysis (TICA) [2]_, [3]_, [4]_.
 
     Parameters
     ----------
+    max_columns : int
+        Maximum number of columns (features) to use in the approximation.
     data : ndarray (T, d) or list of ndarray (T_i, d) or a reader created by
         source function array with the data. With it, the TICA
         transformation is immediately computed and can be used to transform data.
-    lag : int
+    lag : int, optional, default 10
         lag time
-    max_columns : int
-        Maximum number of columns (features) to use in the approximation.
     dim : int, optional, default -1
         Maximum number of significant independent components to use to reduce dimension of input data. -1 means
         all numerically available dimensions (see epsilon) will be used unless reduced by var_cutoff.
@@ -1515,7 +1515,10 @@ def tica_nystroem(data, lag, max_columns,
                        stride=stride, skip=skip, reversible=reversible,
                        ncov_max=ncov_max,
                        initial_columns=initial_columns, nsel=nsel, neig=neig)
-    res.estimate(data, stride=stride)
+    if data is not None:
+        res.estimate(data, stride=stride, chunksize=chunksize)
+    else:
+        res.chunksize = chunksize
     return res
 
 

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -1415,10 +1415,10 @@ def vamp(data=None, lag=10, dim=None, scaling=None, right=True, ncov_max=float('
     return res
 
 
-def nystroem_tica(data, lag, max_columns, initial_columns=None, nsel=1, neig=None,
+def nystroem_tica(data, lag, max_columns,
                   dim=-1, var_cutoff=0.95, epsilon=1e-6,
-                  stride=1, skip=0, reversible=True,
-                  ncov_max=float('inf')):
+                  stride=1, skip=0, reversible=True, ncov_max=float('inf'),
+                  initial_columns=None, nsel=1, neig=None):
     r""" Sparse sampling implementation [1]_ of time-lagged independent component analysis (TICA) [2]_, [3]_, [4]_.
 
     Parameters
@@ -1430,17 +1430,6 @@ def nystroem_tica(data, lag, max_columns, initial_columns=None, nsel=1, neig=Non
         lag time
     max_columns : int
         Maximum number of columns (features) to use in the approximation.
-    initial_columns : list, ndarray(k, dtype=int), int, or None, optional, default None
-        Columns used for an initial approximation. If a list or an 1-d ndarray
-        of integers is given, use these column indices. If an integer is given,
-        use that number of randomly selected indices. If None is given, use
-        one randomly selected column.
-    nsel : int, optional, default 1
-        Number of columns to select and add per iteration and pass through the data.
-        Larger values provide for better pass-efficiency.
-    neig : int or None, optional, default None
-        Number of eigenvalues to be optimized by the selection process.
-        If None, use the whole available eigenspace.
     dim : int, optional, default -1
         Maximum number of significant independent components to use to reduce dimension of input data. -1 means
         all numerically available dimensions (see epsilon) will be used unless reduced by var_cutoff.
@@ -1459,6 +1448,17 @@ def nystroem_tica(data, lag, max_columns, initial_columns=None, nsel=1, neig=Non
         Skip the first initial n frames per trajectory.
     reversible: bool, optional, default True
         Symmetrize correlation matrices :math:`C_0`, :math:`C_{\tau}`.
+    initial_columns : list, ndarray(k, dtype=int), int, or None, optional, default None
+        Columns used for an initial approximation. If a list or an 1-d ndarray
+        of integers is given, use these column indices. If an integer is given,
+        use that number of randomly selected indices. If None is given, use
+        one randomly selected column.
+    nsel : int, optional, default 1
+        Number of columns to select and add per iteration and pass through the data.
+        Larger values provide for better pass-efficiency.
+    neig : int or None, optional, default None
+        Number of eigenvalues to be optimized by the selection process.
+        If None, use the whole available eigenspace.
 
     Returns
     -------
@@ -1490,7 +1490,8 @@ def nystroem_tica(data, lag, max_columns, initial_columns=None, nsel=1, neig=Non
 
     References
     ----------
-    .. [1] upcoming paper
+    .. [1] F. Litzinger, L. Boninsegna, H. Wu, F. Nüske, R. Patel, R. Baraniuk, F. Noé, and C. Clementi.
+       Rapid calculation of molecular kinetics using compressed sensing (2018). (submitted)
     .. [2] Perez-Hernandez G, F Paul, T Giorgino, G De Fabritiis and F Noe. 2013.
        Identification of slow molecular order parameters for Markov model construction
        J. Chem. Phys. 139, 015102. doi:10.1063/1.4811489
@@ -1509,10 +1510,11 @@ def nystroem_tica(data, lag, max_columns, initial_columns=None, nsel=1, neig=Non
 
     """
     from pyemma.coordinates.transform.nystroem_tica import NystroemTICA
-    res = NystroemTICA(lag, max_columns, initial_columns=initial_columns, nsel=nsel, neig=neig,
+    res = NystroemTICA(lag, max_columns,
                        dim=dim, var_cutoff=var_cutoff, epsilon=epsilon,
                        stride=stride, skip=skip, reversible=reversible,
-                       ncov_max=ncov_max)
+                       ncov_max=ncov_max,
+                       initial_columns=initial_columns, nsel=nsel, neig=neig)
     return _param_stage(data, res, stride=stride)
 
 

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -51,6 +51,7 @@ __all__ = ['featurizer',  # IO
            'save_trajs',
            'pca',  # transform
            'tica',
+           'nystroem_tica',
            'vamp',
            'covariance_lagged',
            'cluster_regspace',  # cluster
@@ -1412,6 +1413,104 @@ def vamp(data=None, lag=10, dim=None, scaling=None, right=True, ncov_max=float('
     else:
         res.chunksize = chunksize
     return res
+
+
+def nystroem_tica(data, lag, max_columns, initial_columns=None, nsel=1, dim=-1,
+                  var_cutoff=0.95, epsilon=1e-6,
+                  stride=1, skip=0, reversible=True,
+                  ncov_max=float('inf')):
+    r""" Sparse sampling implementation [1]_ of time-lagged independent component analysis (TICA) [2]_, [3]_, [4]_.
+
+    Parameters
+    ----------
+    data : ndarray (T, d) or list of ndarray (T_i, d) or a reader created by
+        source function array with the data. With it, the TICA
+        transformation is immediately computed and can be used to transform data.
+    lag : int
+        lag time
+    max_columns : int
+        Maximum number of columns (features) to use in the approximation.
+    initial_columns : list, ndarray(k, dtype=int), int, or None, optional, default None
+        Columns used for an initial approximation. If a list or an 1-d ndarray
+        of integers is given, use these column indices. If an integer is given,
+        use that number of randomly selected indices. If None is given, use
+        one randomly selected column.
+    nsel : int, optional, default 1
+        Number of columns to select and add per iteration and pass through the data.
+        Larger values provide for better pass-efficiency.
+    dim : int, optional, default -1
+        Maximum number of significant independent components to use to reduce dimension of input data. -1 means
+        all numerically available dimensions (see epsilon) will be used unless reduced by var_cutoff.
+        Setting dim to a positive value is exclusive with var_cutoff.
+    var_cutoff : float in the range [0,1], optional, default 0.95
+        Determines the number of output dimensions by including dimensions until their cumulative kinetic variance
+        exceeds the fraction subspace_variance. var_cutoff=1.0 means all numerically available dimensions
+        (see epsilon) will be used, unless set by dim. Setting var_cutoff smaller than 1.0 is exclusive with dim.
+    epsilon : float, optional, default 1e-6
+        Eigenvalue norm cutoff. Eigenvalues of :math:`C_0` with norms <= epsilon will be
+        cut off. The remaining number of eigenvalues define the size
+        of the output.
+    stride: int, optional, default 1
+        Use only every stride-th time step. By default, every time step is used.
+    skip : int, optional, default 0
+        Skip the first initial n frames per trajectory.
+    reversible: bool, optional, default True
+        Symmetrize correlation matrices :math:`C_0`, :math:`C_{\tau}`.
+
+    Returns
+    -------
+    nystroem_tica : a :class:`NystroemTICA <pyemma.coordinates.transform.NystroemTICA>`
+                    transformation object
+        Object for sparse sampling time-lagged independent component (TICA) analysis.
+        It contains TICA eigenvalues and eigenvectors, and the projection of
+        input data to the dominant TICs.
+
+    Notes
+    -----
+    Perform a sparse approximation of time-lagged independent component analysis (TICA)
+    :class:`TICA <pyemma.coordinates.transform.TICA>`. The starting point is the
+    generalized eigenvalue problem
+
+    .. math:: C_{\tau} r_i = C_0 \lambda_i(\tau) r_i.
+
+    Instead of computing the full matrices involved in this problem, we conduct
+    a Nyström approximation [5]_ of the matrix :math:`C_0` by means of the
+    accelerated sequential incoherence selection (oASIS) algorithm [6]_ and,
+    in particular, its extension called spectral oASIS [1]_.
+
+    Iteratively, we select a small number of columns such that the resulting
+    Nyström approximation is sufficiently accurate. This selection represents
+    in turn a subset of important features, for which we obtain a generalized
+    eigenvalue problem similar to the one above, but much smaller in size.
+    Its generalized eigenvalues and eigenvectors provide an approximation
+    to those of the full TICA solution [1]_.
+
+    References
+    ----------
+    .. [1] upcoming paper
+    .. [2] Perez-Hernandez G, F Paul, T Giorgino, G De Fabritiis and F Noe. 2013.
+       Identification of slow molecular order parameters for Markov model construction
+       J. Chem. Phys. 139, 015102. doi:10.1063/1.4811489
+    .. [3] Schwantes C, V S Pande. 2013.
+       Improvements in Markov State Model Construction Reveal Many Non-Native Interactions in the Folding of NTL9
+       J. Chem. Theory. Comput. 9, 2000-2009. doi:10.1021/ct300878a
+    .. [4] L. Molgedey and H. G. Schuster. 1994.
+       Separation of a mixture of independent signals using time delayed correlations
+       Phys. Rev. Lett. 72, 3634.
+    .. [5] P. Drineas and M. W. Mahoney.
+       On the Nystrom method for approximating a Gram matrix for improved kernel-based learning.
+       Journal of Machine Learning Research, 6:2153-2175 (2005).
+    .. [6] Raajen Patel, Thomas A. Goldstein, Eva L. Dyer, Azalia Mirhoseini, Richard G. Baraniuk.
+       oASIS: Adaptive Column Sampling for Kernel Matrix Approximation.
+       arXiv: 1505.05208 [stat.ML].
+
+    """
+    from pyemma.coordinates.transform.nystroem_tica import NystroemTICA
+    res = NystroemTICA(lag, max_columns, initial_columns=initial_columns, nsel=nsel, dim=dim,
+                       var_cutoff=var_cutoff, epsilon=epsilon,
+                       stride=stride, skip=skip, reversible=reversible,
+                       ncov_max=ncov_max)
+    return _param_stage(data, res, stride=stride)
 
 
 def covariance_lagged(data=None, c00=True, c0t=True, ctt=False, remove_constant_mean=None, remove_data_mean=False,

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -1415,8 +1415,8 @@ def vamp(data=None, lag=10, dim=None, scaling=None, right=True, ncov_max=float('
     return res
 
 
-def nystroem_tica(data, lag, max_columns, initial_columns=None, nsel=1, dim=-1,
-                  var_cutoff=0.95, epsilon=1e-6,
+def nystroem_tica(data, lag, max_columns, initial_columns=None, nsel=1, neig=None,
+                  dim=-1, var_cutoff=0.95, epsilon=1e-6,
                   stride=1, skip=0, reversible=True,
                   ncov_max=float('inf')):
     r""" Sparse sampling implementation [1]_ of time-lagged independent component analysis (TICA) [2]_, [3]_, [4]_.
@@ -1438,6 +1438,9 @@ def nystroem_tica(data, lag, max_columns, initial_columns=None, nsel=1, dim=-1,
     nsel : int, optional, default 1
         Number of columns to select and add per iteration and pass through the data.
         Larger values provide for better pass-efficiency.
+    neig : int or None, optional, default None
+        Number of eigenvalues to be optimized by the selection process.
+        If None, use the whole available eigenspace.
     dim : int, optional, default -1
         Maximum number of significant independent components to use to reduce dimension of input data. -1 means
         all numerically available dimensions (see epsilon) will be used unless reduced by var_cutoff.
@@ -1506,8 +1509,8 @@ def nystroem_tica(data, lag, max_columns, initial_columns=None, nsel=1, dim=-1,
 
     """
     from pyemma.coordinates.transform.nystroem_tica import NystroemTICA
-    res = NystroemTICA(lag, max_columns, initial_columns=initial_columns, nsel=nsel, dim=dim,
-                       var_cutoff=var_cutoff, epsilon=epsilon,
+    res = NystroemTICA(lag, max_columns, initial_columns=initial_columns, nsel=nsel, neig=neig,
+                       dim=dim, var_cutoff=var_cutoff, epsilon=epsilon,
                        stride=stride, skip=skip, reversible=reversible,
                        ncov_max=ncov_max)
     return _param_stage(data, res, stride=stride)

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -51,7 +51,7 @@ __all__ = ['featurizer',  # IO
            'save_trajs',
            'pca',  # transform
            'tica',
-           'nystroem_tica',
+           'tica_nystroem',
            'vamp',
            'covariance_lagged',
            'cluster_regspace',  # cluster
@@ -1415,7 +1415,7 @@ def vamp(data=None, lag=10, dim=None, scaling=None, right=True, ncov_max=float('
     return res
 
 
-def nystroem_tica(data, lag, max_columns,
+def tica_nystroem(data, lag, max_columns,
                   dim=-1, var_cutoff=0.95, epsilon=1e-6,
                   stride=1, skip=0, reversible=True, ncov_max=float('inf'),
                   initial_columns=None, nsel=1, neig=None):
@@ -1462,7 +1462,7 @@ def nystroem_tica(data, lag, max_columns,
 
     Returns
     -------
-    nystroem_tica : a :class:`NystroemTICA <pyemma.coordinates.transform.NystroemTICA>`
+    tica_nystroem : a :class:`NystroemTICA <pyemma.coordinates.transform.NystroemTICA>`
                     transformation object
         Object for sparse sampling time-lagged independent component (TICA) analysis.
         It contains TICA eigenvalues and eigenvectors, and the projection of

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -1416,7 +1416,7 @@ def vamp(data=None, lag=10, dim=None, scaling=None, right=True, ncov_max=float('
 
 def covariance_lagged(data=None, c00=True, c0t=True, ctt=False, remove_constant_mean=None, remove_data_mean=False,
                       reversible=False, bessel=True, lag=0, weights="empirical", stride=1, skip=0, chunksize=None,
-                      ncov_max=float('inf')):
+                      ncov_max=float('inf'), column_selection=None, diag_only=False):
     r"""Compute lagged covariances between time series. If data is available as an array of size (TxN), where T is the
     number of time steps and N the number of dimensions, this function can compute lagged covariances like
 
@@ -1468,6 +1468,10 @@ def covariance_lagged(data=None, c00=True, c0t=True, ctt=False, remove_constant_
     ncov_max : int, default=infinity
         limit the memory usage of the algorithm from [2]_ to an amount that corresponds
         to ncov_max additional copies of each correlation matrix
+    column_selection: ndarray(k, dtype=int) or None
+        Indices of those columns that are to be computed. If None, all columns are computed.
+    diag_only: bool
+        If True, the computation is restricted to the diagonal entries (autocorrelations) only.
 
     Returns
     -------
@@ -1504,7 +1508,8 @@ def covariance_lagged(data=None, c00=True, c0t=True, ctt=False, remove_constant_
     # chunksize is an estimation parameter for now.
     lc = LaggedCovariance(c00=c00, c0t=c0t, ctt=ctt, remove_constant_mean=remove_constant_mean,
                           remove_data_mean=remove_data_mean, reversible=reversible, bessel=bessel, lag=lag,
-                          weights=weights, stride=stride, skip=skip, ncov_max=ncov_max)
+                          weights=weights, stride=stride, skip=skip, ncov_max=ncov_max,
+                          column_selection=column_selection, diag_only=diag_only)
     if data is not None:
         lc.estimate(data, chunksize=chunksize)
     else:

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -1515,7 +1515,8 @@ def nystroem_tica(data, lag, max_columns,
                        stride=stride, skip=skip, reversible=reversible,
                        ncov_max=ncov_max,
                        initial_columns=initial_columns, nsel=nsel, neig=neig)
-    return _param_stage(data, res, stride=stride)
+    res.estimate(data, stride=stride)
+    return res
 
 
 def covariance_lagged(data=None, c00=True, c0t=True, ctt=False, remove_constant_mean=None, remove_data_mean=False,

--- a/pyemma/coordinates/estimation/covariance.py
+++ b/pyemma/coordinates/estimation/covariance.py
@@ -334,4 +334,4 @@ class LaggedCovariance(StreamingEstimator, SerializableMixIn):
         except AttributeError:
             pass
         self._estimated = False
-        self._logger.debug('Modified column selection: estimate() needed for this change to take effect')
+        self.logger.debug('Modified column selection: estimate() needed for this change to take effect')

--- a/pyemma/coordinates/estimation/covariance.py
+++ b/pyemma/coordinates/estimation/covariance.py
@@ -83,11 +83,15 @@ class LaggedCovariance(StreamingEstimator, SerializableMixIn):
          skip the first initial n frames per trajectory.
      chunksize : deprecated, default=NotImplemented
          The chunk size should now be set during estimation.
+     column_selection: ndarray(k, dtype=int) or None
+         Indices of those columns that are to be computed. If None, all columns are computed.
+     diag_only: bool
+         If True, the computation is restricted to the diagonal entries (autocorrelations) only.
 
      """
     def __init__(self, c00=True, c0t=False, ctt=False, remove_constant_mean=None, remove_data_mean=False, reversible=False,
                  bessel=True, sparse_mode='auto', modify_data=False, lag=0, weights=None, stride=1, skip=0,
-                 chunksize=NotImplemented, ncov_max=float('inf')):
+                 chunksize=NotImplemented, ncov_max=float('inf'), column_selection=None, diag_only=False):
         super(LaggedCovariance, self).__init__()
         if chunksize is not NotImplemented:
             import warnings
@@ -102,11 +106,18 @@ class LaggedCovariance(StreamingEstimator, SerializableMixIn):
             raise ValueError('Subtracting the data mean and a constant vector simultaneously is not supported.')
         if remove_constant_mean is not None:
             remove_constant_mean = ensure_float_vector(remove_constant_mean)
+        if column_selection is not None and diag_only:
+            raise ValueError('Computing only parts of the diagonal is not supported.')
+        if diag_only and sparse_mode is not 'dense':
+            if sparse_mode is 'sparse':
+                self.logger.warn('Computing diagonal entries only is not implemented for sparse mode. Switching to dense mode.')
+            sparse_mode = 'dense'
         self.set_params(c00=c00, c0t=c0t, ctt=ctt, remove_constant_mean=remove_constant_mean,
                         remove_data_mean=remove_data_mean, reversible=reversible,
                         sparse_mode=sparse_mode, modify_data=modify_data, lag=lag,
                         bessel=bessel,
-                        weights=weights, stride=stride, skip=skip, ncov_max=ncov_max)
+                        weights=weights, stride=stride, skip=skip, ncov_max=ncov_max,
+                        column_selection=column_selection, diag_only=diag_only)
 
         self._rc = None
 
@@ -153,7 +164,9 @@ class LaggedCovariance(StreamingEstimator, SerializableMixIn):
             self.logger.debug("using %s moments for %i chunks", nsave, n_chunks)
             self._rc = running_covar(xx=self.c00, xy=self.c0t, yy=self.ctt,
                                      remove_mean=self.remove_data_mean, symmetrize=self.reversible,
-                                     sparse_mode=self.sparse_mode, modify_data=self.modify_data, nsave=nsave)
+                                     sparse_mode=self.sparse_mode, modify_data=self.modify_data,
+                                     column_selection=self.column_selection, diag_only=self.diag_only,
+                                     nsave=nsave)
 
     def _estimate(self, iterable, partial_fit=False):
         indim = iterable.dimension()
@@ -307,3 +320,18 @@ class LaggedCovariance(StreamingEstimator, SerializableMixIn):
         if self.ctt:
             if self._rc.storage_YY.nsave <= ns:
                 self._rc.storage_YY.nsave = ns
+
+    @property
+    def column_selection(self):
+        return self._column_selection
+
+    @column_selection.setter
+    def column_selection(self, s):
+        self._column_selection = s
+        try:
+            if self._rc is not None:
+                self._rc.column_selection = s
+        except AttributeError:
+            pass
+        self._estimated = False
+        self._logger.debug('Modified column selection: estimate() needed for this change to take effect')

--- a/pyemma/coordinates/tests/test_covar_estimator.py
+++ b/pyemma/coordinates/tests/test_covar_estimator.py
@@ -42,6 +42,8 @@ class TestCovarEstimator(unittest.TestCase):
         cls.mean_const = mean_const
         # Chunksize:
         cls.chunksize = 500
+        # column subsets
+        cls.cols_2 = np.array([0])
 
         # moments of X and Y
         cls.w = np.shape(cls.X)[0]
@@ -158,12 +160,18 @@ class TestCovarEstimator(unittest.TestCase):
         cc = covariance_lagged(data=self.data, c0t=False, remove_data_mean=False, bessel=False, chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.mx_lag0)
         np.testing.assert_allclose(cc.C00_, self.Mxx_lag0)
+        cc.column_selection = self.cols_2
+        cc.estimate(self.data)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_lag0[:, self.cols_2])
 
     def test_XX_meanfree(self):
         # many passes
         cc = covariance_lagged(data=self.data, c0t=False, remove_data_mean=True, bessel=False, chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.mx_lag0)
         np.testing.assert_allclose(cc.C00_, self.Mxx0_lag0)
+        cc.column_selection = self.cols_2
+        cc.estimate(self.data)
+        np.testing.assert_allclose(cc.C00_, self.Mxx0_lag0[:, self.cols_2])
 
     def test_XX_weightobj_withmean(self):
         # many passes
@@ -171,6 +179,9 @@ class TestCovarEstimator(unittest.TestCase):
                                chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.mx_wobj_lag0)
         np.testing.assert_allclose(cc.C00_, self.Mxx_wobj_lag0)
+        cc.column_selection = self.cols_2
+        cc.estimate(self.data)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_wobj_lag0[:, self.cols_2])
 
     def test_XX_weightobj_meanfree(self):
         # many passes
@@ -178,6 +189,9 @@ class TestCovarEstimator(unittest.TestCase):
                                chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.mx_wobj_lag0)
         np.testing.assert_allclose(cc.C00_, self.Mxx0_wobj_lag0)
+        cc.column_selection = self.cols_2
+        cc.estimate(self.data)
+        np.testing.assert_allclose(cc.C00_, self.Mxx0_wobj_lag0[:, self.cols_2])
 
     def test_XXXY_withmean(self):
         # many passes
@@ -187,6 +201,10 @@ class TestCovarEstimator(unittest.TestCase):
         np.testing.assert_allclose(cc.mean_tau, self.my)
         np.testing.assert_allclose(cc.C00_, self.Mxx)
         np.testing.assert_allclose(cc.C0t_, self.Mxy)
+        cc.column_selection = self.cols_2
+        cc.estimate(self.data)
+        np.testing.assert_allclose(cc.C00_, self.Mxx[:, self.cols_2])
+        np.testing.assert_allclose(cc.C0t_, self.Mxy[:, self.cols_2])
 
     def test_XXXY_meanfree(self):
         # many passes
@@ -196,6 +214,10 @@ class TestCovarEstimator(unittest.TestCase):
         np.testing.assert_allclose(cc.mean_tau, self.my)
         np.testing.assert_allclose(cc.C00_, self.Mxx0)
         np.testing.assert_allclose(cc.C0t_, self.Mxy0)
+        cc.column_selection = self.cols_2
+        cc.estimate(self.data)
+        np.testing.assert_allclose(cc.C00_, self.Mxx0[:, self.cols_2])
+        np.testing.assert_allclose(cc.C0t_, self.Mxy0[:, self.cols_2])
 
     def test_XXXY_weightobj_withmean(self):
         # many passes
@@ -205,17 +227,23 @@ class TestCovarEstimator(unittest.TestCase):
         np.testing.assert_allclose(cc.mean_tau, self.my_wobj)
         np.testing.assert_allclose(cc.C00_, self.Mxx_wobj)
         np.testing.assert_allclose(cc.C0t_, self.Mxy_wobj)
+        cc.column_selection = self.cols_2
+        cc.estimate(self.data)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_wobj[:, self.cols_2])
+        np.testing.assert_allclose(cc.C0t_, self.Mxy_wobj[:, self.cols_2])
 
     def test_XXXY_weightobj_meanfree(self):
         # many passes
         cc = covariance_lagged(data=self.data, remove_data_mean=True, c0t=True, lag=self.lag, weights=self.wobj,
                                bessel=False, chunksize=self.chunksize)
-        #out = cc.weights.get_output()
-
         np.testing.assert_allclose(cc.mean, self.mx_wobj)
         np.testing.assert_allclose(cc.mean_tau, self.my_wobj)
         np.testing.assert_allclose(cc.C00_, self.Mxx0_wobj)
         np.testing.assert_allclose(cc.C0t_, self.Mxy0_wobj)
+        cc.column_selection = self.cols_2
+        cc.estimate(self.data)
+        np.testing.assert_allclose(cc.C00_, self.Mxx0_wobj[:, self.cols_2])
+        np.testing.assert_allclose(cc.C0t_, self.Mxy0_wobj[:, self.cols_2])
 
     def test_XXXY_sym_withmean(self):
         # many passes
@@ -224,6 +252,10 @@ class TestCovarEstimator(unittest.TestCase):
         np.testing.assert_allclose(cc.mean, self.m_sym)
         np.testing.assert_allclose(cc.C00_, self.Mxx_sym)
         np.testing.assert_allclose(cc.C0t_, self.Mxy_sym)
+        cc.column_selection = self.cols_2
+        cc.estimate(self.data)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_sym[:, self.cols_2])
+        np.testing.assert_allclose(cc.C0t_, self.Mxy_sym[:, self.cols_2])
 
     def test_XXXY_sym_meanfree(self):
         # many passes
@@ -232,6 +264,10 @@ class TestCovarEstimator(unittest.TestCase):
         np.testing.assert_allclose(cc.mean, self.m_sym)
         np.testing.assert_allclose(cc.C00_, self.Mxx0_sym)
         np.testing.assert_allclose(cc.C0t_, self.Mxy0_sym)
+        cc.column_selection = self.cols_2
+        cc.estimate(self.data)
+        np.testing.assert_allclose(cc.C00_, self.Mxx0_sym[:, self.cols_2])
+        np.testing.assert_allclose(cc.C0t_, self.Mxy0_sym[:, self.cols_2])
 
     def test_XXXY_weightobj_sym_withmean(self):
         # many passes
@@ -240,6 +276,10 @@ class TestCovarEstimator(unittest.TestCase):
         np.testing.assert_allclose(cc.mean, self.m_sym_wobj)
         np.testing.assert_allclose(cc.C00_, self.Mxx_sym_wobj)
         np.testing.assert_allclose(cc.C0t_, self.Mxy_sym_wobj)
+        cc.column_selection = self.cols_2
+        cc.estimate(self.data)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_sym_wobj[:, self.cols_2])
+        np.testing.assert_allclose(cc.C0t_, self.Mxy_sym_wobj[:, self.cols_2])
 
     def test_XXXY_weightobj_sym_meanfree(self):
         # many passes
@@ -248,18 +288,28 @@ class TestCovarEstimator(unittest.TestCase):
         np.testing.assert_allclose(cc.mean, self.m_sym_wobj)
         np.testing.assert_allclose(cc.C00_, self.Mxx0_sym_wobj)
         np.testing.assert_allclose(cc.C0t_, self.Mxy0_sym_wobj)
+        cc.column_selection = self.cols_2
+        cc.estimate(self.data)
+        np.testing.assert_allclose(cc.C00_, self.Mxx0_sym_wobj[:, self.cols_2])
+        np.testing.assert_allclose(cc.C0t_, self.Mxy0_sym_wobj[:, self.cols_2])
 
     def test_XX_meanconst(self):
         cc = covariance_lagged(data=self.data, c0t=False, remove_constant_mean=self.mean_const, bessel=False,
                                chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.mx_c_lag0)
         np.testing.assert_allclose(cc.C00_, self.Mxx_c_lag0)
+        cc.column_selection = self.cols_2
+        cc.estimate(self.data)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_c_lag0[:, self.cols_2])
 
     def test_XX_weighted_meanconst(self):
         cc = covariance_lagged(data=self.data, c0t=False, remove_constant_mean=self.mean_const, weights=self.wobj, bessel=False,
                                chunksize=self.chunksize)
         np.testing.assert_allclose(cc.mean, self.mx_c_wobj_lag0)
         np.testing.assert_allclose(cc.C00_, self.Mxx_c_wobj_lag0)
+        cc.column_selection = self.cols_2
+        cc.estimate(self.data)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_c_wobj_lag0[:, self.cols_2])
 
     def test_XY_meanconst(self):
         cc = covariance_lagged(data=self.data, remove_constant_mean=self.mean_const, c0t=True, lag=self.lag, bessel=False,
@@ -268,6 +318,10 @@ class TestCovarEstimator(unittest.TestCase):
         np.testing.assert_allclose(cc.mean_tau, self.my_c)
         np.testing.assert_allclose(cc.C00_, self.Mxx_c)
         np.testing.assert_allclose(cc.C0t_, self.Mxy_c)
+        cc.column_selection = self.cols_2
+        cc.estimate(self.data)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_c[:, self.cols_2])
+        np.testing.assert_allclose(cc.C0t_, self.Mxy_c[:, self.cols_2])
 
     def test_XY_weighted_meanconst(self):
         cc = covariance_lagged(data=self.data, remove_constant_mean=self.mean_const, c0t=True, weights=self.wobj, lag=self.lag,
@@ -276,6 +330,10 @@ class TestCovarEstimator(unittest.TestCase):
         np.testing.assert_allclose(cc.mean_tau, self.my_c_wobj)
         np.testing.assert_allclose(cc.C00_, self.Mxx_c_wobj)
         np.testing.assert_allclose(cc.C0t_, self.Mxy_c_wobj)
+        cc.column_selection = self.cols_2
+        cc.estimate(self.data)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_c_wobj[:, self.cols_2])
+        np.testing.assert_allclose(cc.C0t_, self.Mxy_c_wobj[:, self.cols_2])
 
     def test_XY_sym_meanconst(self):
         cc = covariance_lagged(data=self.data, remove_constant_mean=self.mean_const, c0t=True, reversible=True, lag=self.lag,
@@ -283,6 +341,10 @@ class TestCovarEstimator(unittest.TestCase):
         np.testing.assert_allclose(cc.mean, self.m_c_sym)
         np.testing.assert_allclose(cc.C00_, self.Mxx_c_sym)
         np.testing.assert_allclose(cc.C0t_, self.Mxy_c_sym)
+        cc.column_selection = self.cols_2
+        cc.estimate(self.data)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_c_sym[:, self.cols_2])
+        np.testing.assert_allclose(cc.C0t_, self.Mxy_c_sym[:, self.cols_2])
 
     def test_XY_sym_weighted_meanconst(self):
         cc = covariance_lagged(data=self.data, remove_constant_mean=self.mean_const, c0t=True, reversible=True, weights=self.wobj,
@@ -290,6 +352,10 @@ class TestCovarEstimator(unittest.TestCase):
         np.testing.assert_allclose(cc.mean, self.m_c_sym_wobj)
         np.testing.assert_allclose(cc.C00_, self.Mxx_c_sym_wobj)
         np.testing.assert_allclose(cc.C0t_, self.Mxy_c_sym_wobj)
+        cc.column_selection = self.cols_2
+        cc.estimate(self.data)
+        np.testing.assert_allclose(cc.C00_, self.Mxx_c_sym_wobj[:, self.cols_2])
+        np.testing.assert_allclose(cc.C0t_, self.Mxy_c_sym_wobj[:, self.cols_2])
 
 
 class TestCovarianceEstimatorGivenWeights(TestCovarEstimator):

--- a/pyemma/coordinates/tests/test_nystroem_tica.py
+++ b/pyemma/coordinates/tests/test_nystroem_tica.py
@@ -20,42 +20,50 @@ import unittest
 import numpy as np
 
 from pyemma.coordinates import tica, tica_nystroem
+from pyemma.coordinates.transform.nystroem_tica import oASIS_Nystroem
+
+import sys
+use_assert_warns = (sys.version_info >= (3, 4))
 
 
 class TestNystroemTICA_Simple(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.X_100 = np.random.rand(10000, 100)
-        cls.X_100_sparseconst = np.ones((10000, 100))
-        cls.X_100_sparseconst[:, :10] = cls.X_100[:, :10]
-        cls.data = cls.X_100_sparseconst
+        cls.data = np.ones((10000, 100))
+        cls.variable_columns = np.random.choice(100, 10, replace=False)
+        cls.data[:, cls.variable_columns] = np.random.rand(10000, 10)
+        # Start with one of the constant columns:
+        cls.initial_columns = np.setdiff1d(np.arange(cls.data.shape[1]), cls.variable_columns)[0:1]
         cls.tica_obj = tica(data=cls.data, lag=1)
 
-    def test_single(self):
-        t = tica_nystroem(data=self.data, lag=1, max_columns=11)
+    def _compare_tica(self, t):
         np.testing.assert_allclose(t._oasis.error, 0, rtol=1e-05, atol=1e-08)
         np.testing.assert_allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
         np.testing.assert_allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
         np.testing.assert_allclose(t.timescales, self.tica_obj.timescales)
+
+    def test_single(self):
+        t = tica_nystroem(data=self.data, lag=1, max_columns=11, initial_columns=self.initial_columns)
+        self._compare_tica(t)
 
     def test_single_issues_warning(self):
-        import sys
-        if sys.version_info >= (3, 4):
+        if use_assert_warns:
             with self.assertLogs(level='WARNING'):
-                t = tica_nystroem(data=self.data, lag=1, max_columns=11, initial_columns=np.array([0]))
+                t = tica_nystroem(data=self.data, lag=1, max_columns=12, initial_columns=self.initial_columns)
         else:
-            t = tica_nystroem(data=self.data, lag=1, max_columns=11, initial_columns=np.array([0]))
-        np.testing.assert_allclose(t._oasis.error, 0, rtol=1e-05, atol=1e-08)
-        np.testing.assert_allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
-        np.testing.assert_allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
-        np.testing.assert_allclose(t.timescales, self.tica_obj.timescales)
+            t = tica_nystroem(data=self.data, lag=1, max_columns=12, initial_columns=self.initial_columns)
+        self._compare_tica(t)
 
     def test_multiple(self):
-        t = tica_nystroem(data=self.data, lag=1, max_columns=10, nsel=3, initial_columns=np.array([0]))
-        np.testing.assert_allclose(t._oasis.error, 0, rtol=1e-05, atol=1e-08)
-        np.testing.assert_allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
-        np.testing.assert_allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
-        np.testing.assert_allclose(t.timescales, self.tica_obj.timescales)
+        t = tica_nystroem(data=self.data, lag=1, max_columns=11, nsel=3,
+                          initial_columns=self.initial_columns)
+        self._compare_tica(t)
+
+    def test_multiple_issues_warning(self):
+        if use_assert_warns:
+            with self.assertWarns(UserWarning):
+                tica_nystroem(data=np.random.rand(100, 10), lag=1, max_columns=11, nsel=3,
+                              initial_columns=np.random.choice(10, 2, replace=False))
 
 
 class TestNystroemTICA_DoubleWell(unittest.TestCase):
@@ -80,6 +88,80 @@ class TestNystroemTICA_DoubleWell(unittest.TestCase):
         np.testing.assert_allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
         np.testing.assert_allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
         assert np.all(np.abs(self.tica_obj.eigenvalues[:4] - t.eigenvalues[:4]) < 1e-3)
+
+
+class TestNystroemTICA_oASIS(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.X = np.ones((10000, 10))
+        cls.variable_columns = np.random.choice(10, 5, replace=False)
+        cls.X[:, cls.variable_columns] = np.random.randn(10000, 5)
+        cls.C0 = np.dot(cls.X.T, cls.X)
+        cls.d = np.diag(cls.C0)
+        cls.initial_columns = np.setdiff1d(np.arange(10), cls.variable_columns)[0:1]
+        cls.C0_k = cls.C0[:, cls.initial_columns]
+
+    def test_random(self):
+        oasis = oASIS_Nystroem(self.d, self.C0_k, self.initial_columns)
+        oasis.set_selection_strategy(strategy='random', nsel=1)
+        while oasis.k < 6:
+            newcol = oasis.select_columns()
+            c = self.C0[:, newcol]
+            added_columns = oasis.add_columns(c, newcol)
+            assert ((len(added_columns) > 0 and np.any(np.in1d(self.variable_columns, added_columns)))
+                   or (len(added_columns) == 0 and not np.all(np.in1d(self.variable_columns, newcol))))
+        assert oasis.select_columns() is None
+        np.testing.assert_allclose(oasis.error, 0, rtol=1e-08, atol=1e-10)
+
+    def _test_oasis_single(self, strategy):
+        oasis = oASIS_Nystroem(self.d, self.C0_k, self.initial_columns)
+        oasis.set_selection_strategy(strategy=strategy, nsel=1)
+        for _ in range(5):
+            newcol = oasis.select_columns()
+            c = self.C0[:, newcol]
+            assert oasis.add_columns(c, newcol) == newcol
+        assert oasis.select_columns() is None
+        np.testing.assert_allclose(oasis.error, 0, rtol=1e-08, atol=1e-10)
+        return oasis
+
+    def test_oasis(self):
+        oasis = self._test_oasis_single('oasis')
+        spectral_oasis = self._test_oasis_single('spectral-oasis')
+        assert np.all(np.equal(oasis.column_indices, spectral_oasis.column_indices))
+
+    def test_spectral_oasis_multiple(self):
+        oasis = oASIS_Nystroem(self.d, self.C0_k, self.initial_columns)
+        oasis.set_selection_strategy(strategy='spectral-oasis', nsel=5)
+        newcols = oasis.select_columns()
+        c = self.C0[:, newcols]
+        assert np.all(np.equal(oasis.add_columns(c, newcols), newcols))
+        assert oasis.select_columns() is None
+        np.testing.assert_allclose(oasis.error, 0, rtol=1e-08, atol=1e-10)
+
+    def test_initial_zero(self):
+        X = np.zeros((3, 3))
+        X[:, 2:3] = np.ones((3, 1))
+        C0 = np.dot(X.T, X)
+        initial_columns = np.array([0, 1])
+        oasis = oASIS_Nystroem(np.diag(C0), C0[:, initial_columns], initial_columns)
+        np.testing.assert_allclose(np.abs(oasis.error), np.array([0, 0, 3]))
+        np.testing.assert_allclose(oasis.approximate_matrix(), np.zeros((3, 3)))
+        for strategy in ['random', 'oasis', 'spectral-oasis']:
+            oasis.set_selection_strategy(strategy=strategy, nsel=1)
+            assert oasis.select_columns() == np.array([2])
+
+    def test_constant_evec(self):
+        U = np.vstack([1+np.random.randn(1, 4)*1e-6,
+                       np.array([1, -1, 0, 0]),
+                       np.array([0, 0, 1, -1])]).T
+        M = np.dot(U, np.dot(np.diag([1, 0.95, 0.7]), U.T))
+        oasis = oASIS_Nystroem(np.diag(M), M[:, 0:2], np.array([0, 1]))
+        from pyemma.coordinates.transform.nystroem_tica import SelectionStrategySpectralOasis
+        sel = SelectionStrategySpectralOasis(oasis, strategy='spectral-oasis')
+        evecs = oasis.approximate_eig()[1]
+        fixed_evecs = sel._fix_constant_evec(evecs)
+        assert np.all(fixed_evecs[:, 0] == 1)
+        assert evecs.shape == fixed_evecs.shape
 
 
 if __name__ == "__main__":

--- a/pyemma/coordinates/tests/test_nystroem_tica.py
+++ b/pyemma/coordinates/tests/test_nystroem_tica.py
@@ -1,0 +1,81 @@
+# This file is part of PyEMMA.
+#
+# Copyright (c) 2017 Computational Molecular Biology Group, Freie Universitaet Berlin (GER)
+#
+# PyEMMA is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+import unittest
+import numpy as np
+
+from pyemma.coordinates import tica, nystroem_tica
+
+
+class TestNystroemTICA_Simple(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.X_100 = np.random.rand(10000, 100)
+        cls.X_100_sparseconst = np.ones((10000, 100))
+        cls.X_100_sparseconst[:, :10] = cls.X_100[:, :10]
+        cls.data = cls.X_100_sparseconst
+        cls.tica_obj = tica(data=cls.data, lag=1)
+
+    def test_single(self):
+        t = nystroem_tica(data=self.data, lag=1, max_columns=11)
+        assert np.allclose(t._oasis.error, 0)
+        assert np.allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
+        assert np.allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
+        assert np.allclose(t.timescales, self.tica_obj.timescales)
+
+    def test_single_issues_warning(self):
+        t = nystroem_tica(data=self.data, lag=1, max_columns=11, initial_columns=np.array([0]))
+        assert np.allclose(t._oasis.error, 0)
+        assert np.allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
+        assert np.allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
+        assert np.allclose(t.timescales, self.tica_obj.timescales)
+
+    def test_multiple(self):
+        t = nystroem_tica(data=self.data, lag=1, max_columns=10, nsel=3, initial_columns=np.array([0]))
+        assert np.allclose(t._oasis.error, 0)
+        assert np.allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
+        assert np.allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
+        assert np.allclose(t.timescales, self.tica_obj.timescales)
+
+
+class TestNystroemTICA_DoubleWell(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        from pyemma.datasets import load_2well_discrete
+        dw = load_2well_discrete()
+        v = dw.dtraj_T100K_dt10[:10000]
+        cls.T = v.size
+        nstates = 100
+        b = np.linspace(-1, 1, nstates)
+        sigma = 0.15
+        cls.Z = np.zeros((cls.T, nstates))
+        for t in range(cls.T):
+            for j in range(nstates):
+                cls.Z[t, j] = np.exp(-(b[v[t]]-b[j])**2/(2*sigma**2))
+        cls.lag = 10
+        cls.tica_obj = tica(data=cls.Z, lag=cls.lag)
+
+    def test(self):
+        t = nystroem_tica(data=self.Z, lag=self.lag, max_columns=10, initial_columns=np.array([91]))
+        assert np.allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
+        assert np.allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
+        assert np.all(np.abs(self.tica_obj.eigenvalues[:4] - t.eigenvalues[:4]) < 1e-3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyemma/coordinates/tests/test_nystroem_tica.py
+++ b/pyemma/coordinates/tests/test_nystroem_tica.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import
 import unittest
 import numpy as np
 
-from pyemma.coordinates import tica, nystroem_tica
+from pyemma.coordinates import tica, tica_nystroem
 
 
 class TestNystroemTICA_Simple(unittest.TestCase):
@@ -32,7 +32,7 @@ class TestNystroemTICA_Simple(unittest.TestCase):
         cls.tica_obj = tica(data=cls.data, lag=1)
 
     def test_single(self):
-        t = nystroem_tica(data=self.data, lag=1, max_columns=11)
+        t = tica_nystroem(data=self.data, lag=1, max_columns=11)
         np.testing.assert_allclose(t._oasis.error, 0, rtol=1e-05, atol=1e-08)
         np.testing.assert_allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
         np.testing.assert_allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
@@ -42,16 +42,16 @@ class TestNystroemTICA_Simple(unittest.TestCase):
         import sys
         if sys.version_info >= (3, 4):
             with self.assertLogs(level='WARNING'):
-                t = nystroem_tica(data=self.data, lag=1, max_columns=11, initial_columns=np.array([0]))
+                t = tica_nystroem(data=self.data, lag=1, max_columns=11, initial_columns=np.array([0]))
         else:
-            t = nystroem_tica(data=self.data, lag=1, max_columns=11, initial_columns=np.array([0]))
+            t = tica_nystroem(data=self.data, lag=1, max_columns=11, initial_columns=np.array([0]))
         np.testing.assert_allclose(t._oasis.error, 0, rtol=1e-05, atol=1e-08)
         np.testing.assert_allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
         np.testing.assert_allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
         np.testing.assert_allclose(t.timescales, self.tica_obj.timescales)
 
     def test_multiple(self):
-        t = nystroem_tica(data=self.data, lag=1, max_columns=10, nsel=3, initial_columns=np.array([0]))
+        t = tica_nystroem(data=self.data, lag=1, max_columns=10, nsel=3, initial_columns=np.array([0]))
         np.testing.assert_allclose(t._oasis.error, 0, rtol=1e-05, atol=1e-08)
         np.testing.assert_allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
         np.testing.assert_allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
@@ -76,7 +76,7 @@ class TestNystroemTICA_DoubleWell(unittest.TestCase):
         cls.tica_obj = tica(data=cls.Z, lag=cls.lag)
 
     def test(self):
-        t = nystroem_tica(data=self.Z, lag=self.lag, max_columns=10, initial_columns=np.array([91]))
+        t = tica_nystroem(data=self.Z, lag=self.lag, max_columns=10, initial_columns=np.array([91]))
         np.testing.assert_allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
         np.testing.assert_allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
         assert np.all(np.abs(self.tica_obj.eigenvalues[:4] - t.eigenvalues[:4]) < 1e-3)

--- a/pyemma/coordinates/tests/test_nystroem_tica.py
+++ b/pyemma/coordinates/tests/test_nystroem_tica.py
@@ -33,15 +33,19 @@ class TestNystroemTICA_Simple(unittest.TestCase):
 
     def test_single(self):
         t = nystroem_tica(data=self.data, lag=1, max_columns=11)
-        np.testing.assert_allclose(t._oasis.error, 0)
+        np.testing.assert_allclose(t._oasis.error, 0, rtol=1e-05, atol=1e-08)
         np.testing.assert_allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
         np.testing.assert_allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
         np.testing.assert_allclose(t.timescales, self.tica_obj.timescales)
 
     def test_single_issues_warning(self):
-        with self.assertLogs(level='WARNING'):
+        import sys
+        if sys.version_info >= (3, 4):
+            with self.assertLogs(level='WARNING'):
+                t = nystroem_tica(data=self.data, lag=1, max_columns=11, initial_columns=np.array([0]))
+        else:
             t = nystroem_tica(data=self.data, lag=1, max_columns=11, initial_columns=np.array([0]))
-        np.testing.assert_allclose(t._oasis.error, 0)
+        np.testing.assert_allclose(t._oasis.error, 0, rtol=1e-05, atol=1e-08)
         np.testing.assert_allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
         np.testing.assert_allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
         np.testing.assert_allclose(t.timescales, self.tica_obj.timescales)

--- a/pyemma/coordinates/tests/test_nystroem_tica.py
+++ b/pyemma/coordinates/tests/test_nystroem_tica.py
@@ -33,24 +33,25 @@ class TestNystroemTICA_Simple(unittest.TestCase):
 
     def test_single(self):
         t = nystroem_tica(data=self.data, lag=1, max_columns=11)
-        assert np.allclose(t._oasis.error, 0)
-        assert np.allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
-        assert np.allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
-        assert np.allclose(t.timescales, self.tica_obj.timescales)
+        np.testing.assert_allclose(t._oasis.error, 0)
+        np.testing.assert_allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
+        np.testing.assert_allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
+        np.testing.assert_allclose(t.timescales, self.tica_obj.timescales)
 
     def test_single_issues_warning(self):
-        t = nystroem_tica(data=self.data, lag=1, max_columns=11, initial_columns=np.array([0]))
-        assert np.allclose(t._oasis.error, 0)
-        assert np.allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
-        assert np.allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
-        assert np.allclose(t.timescales, self.tica_obj.timescales)
+        with self.assertLogs(level='WARNING'):
+            t = nystroem_tica(data=self.data, lag=1, max_columns=11, initial_columns=np.array([0]))
+        np.testing.assert_allclose(t._oasis.error, 0)
+        np.testing.assert_allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
+        np.testing.assert_allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
+        np.testing.assert_allclose(t.timescales, self.tica_obj.timescales)
 
     def test_multiple(self):
         t = nystroem_tica(data=self.data, lag=1, max_columns=10, nsel=3, initial_columns=np.array([0]))
-        assert np.allclose(t._oasis.error, 0)
-        assert np.allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
-        assert np.allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
-        assert np.allclose(t.timescales, self.tica_obj.timescales)
+        np.testing.assert_allclose(t._oasis.error, 0, rtol=1e-05, atol=1e-08)
+        np.testing.assert_allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
+        np.testing.assert_allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
+        np.testing.assert_allclose(t.timescales, self.tica_obj.timescales)
 
 
 class TestNystroemTICA_DoubleWell(unittest.TestCase):
@@ -72,8 +73,8 @@ class TestNystroemTICA_DoubleWell(unittest.TestCase):
 
     def test(self):
         t = nystroem_tica(data=self.Z, lag=self.lag, max_columns=10, initial_columns=np.array([91]))
-        assert np.allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
-        assert np.allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
+        np.testing.assert_allclose(t.cov, self.tica_obj.cov[:, t.column_indices])
+        np.testing.assert_allclose(t.cov_tau, self.tica_obj.cov_tau[:, t.column_indices])
         assert np.all(np.abs(self.tica_obj.eigenvalues[:4] - t.eigenvalues[:4]) < 1e-3)
 
 

--- a/pyemma/coordinates/transform/__init__.py
+++ b/pyemma/coordinates/transform/__init__.py
@@ -35,4 +35,5 @@ transform - Transformation Utilities (:mod:`pyemma.coordinates.transform`)
 
 from .pca import *
 from .tica import *
+from .nystroem_tica import *
 from .vamp import *

--- a/pyemma/coordinates/transform/nystroem_tica.py
+++ b/pyemma/coordinates/transform/nystroem_tica.py
@@ -420,7 +420,7 @@ class oASIS_Nystroem:
 
     >>> # generate random time series
     >>> import numpy as np
-    >>> X = np.random.randn((10000,100))
+    >>> X = np.random.randn(10000, 100)
     >>> # compute full correlation matrix
     >>> C0 = np.dot(X.T, X)
 

--- a/pyemma/coordinates/transform/nystroem_tica.py
+++ b/pyemma/coordinates/transform/nystroem_tica.py
@@ -420,19 +420,23 @@ class oASIS_Nystroem:
 
     >>> # generate random time series
     >>> import numpy as np
-    >>> X = np.random.randn(10000, 100)
+    >>> from numpy.random import RandomState
+    >>> prng = RandomState(0)
+    >>> X = np.ones((10000, 10))
+    >>> X[:, :5] = prng.randn(10000, 5)
     >>> # compute full correlation matrix
     >>> C0 = np.dot(X.T, X)
 
-    We will compute the full correlation matrix as a reference, and start oASIS with 3 out of 100 columns:
+    We compute the full correlation matrix as a reference and start oASIS with 3 out of 10 columns:
 
     >>> # approximate correlation matrix
     >>> d = np.diag(C0)
-    >>> cols = [0,49,99]
-    >>> C0_k = C0[:,cols]
+    >>> cols = np.array([0, 4, 9])
+    >>> C0_k = C0[:, cols]
     >>> oasis = oASIS_Nystroem(np.diag(C0), C0_k, cols)
     >>> # show error of the current approximation
-    >>> print np.max(oasis.error)
+    >>> print('{:.2e}'.format(np.max(np.abs(oasis.error))))
+    1.00e+04
 
     Now we conduct the approximation. We ask oASIS which columns should be computed next, compute them with whichever
     algorithm applies, and update the oASIS approximation. This can be repeated until the error is small enough or
@@ -441,13 +445,15 @@ class oASIS_Nystroem:
     >>> # ask oASIS which column we should compute next
     >>> newcol = oasis.select_columns()
     >>> # recompute the new column yourself
-    >>> c = np.dot(X.T, X[:,newcol][:,None])
+    >>> c = np.dot(X.T, X[:, newcol])
     >>> # update oASIS
-    >>> oasis.add_column(c, newcol)
+    >>> oasis.add_columns(c, newcol)
+    array([1, 2, 3])
     >>> # take note of the new column index
-    >>> cols.append(newcol)
+    >>> cols = np.append(cols, newcol)
     >>> # show error of the current approximation
-    >>> print np.max(oasis.error)
+    >>> np.max(np.abs(oasis.error)) < 1e-10
+    True
 
     References
     ----------

--- a/pyemma/coordinates/transform/nystroem_tica.py
+++ b/pyemma/coordinates/transform/nystroem_tica.py
@@ -1,0 +1,891 @@
+# This file is part of PyEMMA.
+#
+# Copyright (c) 2017 Computational Molecular Biology Group, Freie Universitaet Berlin (GER)
+#
+# PyEMMA is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+
+import numpy as np
+from decorator import decorator
+
+from pyemma._base.model import Model
+from pyemma._ext.variational.solvers.direct import sort_by_norm, spd_inv_split, eig_corr
+from pyemma._ext.variational.util import ZeroRankError
+from pyemma.coordinates.data._base.transformer import StreamingEstimationTransformer
+from pyemma.coordinates.estimation.covariance import LaggedCovariance
+from pyemma.util.annotators import fix_docs
+from pyemma.util.reflection import get_default_args
+import warnings
+import copy
+
+__all__ = ['NystroemTICA']
+
+__author__ = 'litzinger'
+
+
+class NystroemTICAModel(Model):
+    def set_model_params(self, mean, cov, cov_tau, diag, column_indices):
+        self.mean = mean
+        self.cov = cov
+        self.cov_tau = cov_tau
+        self.diag = diag
+        self.column_indices = column_indices
+
+@decorator
+def _lazy_estimation(func, *args, **kw):
+    assert isinstance(args[0], NystroemTICA)
+    tica_obj = args[0]
+    if not tica_obj._estimated:
+        tica_obj._diagonalize()
+    return func(*args, **kw)
+
+
+@fix_docs
+class NystroemTICA(StreamingEstimationTransformer):
+    r""" Sparse sampling implementation of time-lagged independent component analysis (TICA)"""
+
+    def __init__(self, lag, max_columns, initial_columns=None, nsel=1, dim=-1,
+                 var_cutoff=0.95, epsilon=1e-6,
+                 stride=1, skip=0, reversible=True,
+                 ncov_max=float('inf')):
+        r""" Sparse sampling implementation [1]_ of time-lagged independent component analysis (TICA) [2]_, [3]_, [4]_.
+
+        Parameters
+        ----------
+        lag : int
+            lag time
+        max_columns : int
+            Maximum number of columns (features) to use in the approximation.
+        initial_columns : list, ndarray(k, dtype=int), int, or None, optional, default None
+            Columns used for an initial approximation. If a list or an 1-d ndarray
+            of integers is given, use these column indices. If an integer is given,
+            use that number of randomly selected indices. If None is given, use
+            one randomly selected column.
+        nsel : int, optional, default 1
+            Number of columns to select and add per iteration and pass through the data.
+            Larger values provide for better pass-efficiency.
+        dim : int, optional, default -1
+            Maximum number of significant independent components to use to reduce dimension of input data. -1 means
+            all numerically available dimensions (see epsilon) will be used unless reduced by var_cutoff.
+            Setting dim to a positive value is exclusive with var_cutoff.
+        var_cutoff : float in the range [0,1], optional, default 0.95
+            Determines the number of output dimensions by including dimensions until their cumulative kinetic variance
+            exceeds the fraction subspace_variance. var_cutoff=1.0 means all numerically available dimensions
+            (see epsilon) will be used, unless set by dim. Setting var_cutoff smaller than 1.0 is exclusive with dim.
+        epsilon : float, optional, default 1e-6
+            Eigenvalue norm cutoff. Eigenvalues of :math:`C_0` with norms <= epsilon will be
+            cut off. The remaining number of eigenvalues define the size
+            of the output.
+        stride: int, optional, default 1
+            Use only every stride-th time step. By default, every time step is used.
+        skip : int, optional, default 0
+            Skip the first initial n frames per trajectory.
+        reversible: bool, optional, default True
+            Symmetrize correlation matrices :math:`C_0`, :math:`C_{\tau}`.
+
+        Notes
+        -----
+        Perform a sparse approximation of time-lagged independent component analysis (TICA)
+        :class:`TICA <pyemma.coordinates.transform.TICA>`. The starting point is the
+        generalized eigenvalue problem
+
+        .. math:: C_{\tau} r_i = C_0 \lambda_i(\tau) r_i.
+
+        Instead of computing the full matrices involved in this problem, we conduct
+        a Nyström approximation [5]_ of the matrix :math:`C_0` by means of the
+        accelerated sequential incoherence selection (oASIS) algorithm [6]_ and,
+        in particular, its extension called spectral oASIS [1]_.
+
+        Iteratively, we select a small number of columns such that the resulting
+        Nyström approximation is sufficiently accurate. This selection represents
+        in turn a subset of important features, for which we obtain a generalized
+        eigenvalue problem similar to the one above, but much smaller in size.
+        Its generalized eigenvalues and eigenvectors provide an approximation
+        to those of the full TICA solution [1]_.
+
+        References
+        ----------
+        .. [1] upcoming paper
+        .. [2] Perez-Hernandez G, F Paul, T Giorgino, G De Fabritiis and F Noe. 2013.
+           Identification of slow molecular order parameters for Markov model construction
+           J. Chem. Phys. 139, 015102. doi:10.1063/1.4811489
+        .. [3] Schwantes C, V S Pande. 2013.
+           Improvements in Markov State Model Construction Reveal Many Non-Native Interactions in the Folding of NTL9
+           J. Chem. Theory. Comput. 9, 2000-2009. doi:10.1021/ct300878a
+        .. [4] L. Molgedey and H. G. Schuster. 1994.
+           Separation of a mixture of independent signals using time delayed correlations
+           Phys. Rev. Lett. 72, 3634.
+        .. [5] P. Drineas and M. W. Mahoney.
+           On the Nystrom method for approximating a Gram matrix for improved kernel-based learning.
+           Journal of Machine Learning Research, 6:2153-2175 (2005).
+        .. [6] Raajen Patel, Thomas A. Goldstein, Eva L. Dyer, Azalia Mirhoseini, Richard G. Baraniuk.
+           oASIS: Adaptive Column Sampling for Kernel Matrix Approximation.
+           arXiv: 1505.05208 [stat.ML].
+
+        """
+        default_var_cutoff = get_default_args(self.__init__)['var_cutoff']
+        if dim != -1 and var_cutoff != default_var_cutoff:
+            raise ValueError('Trying to set both the number of dimension and the subspace variance. Use either one or the other.')
+        super(NystroemTICA, self).__init__()
+
+        if dim > -1:
+            var_cutoff = 1.0
+
+        if initial_columns is None:
+            initial_columns = 1
+        if isinstance(initial_columns, int):
+            i = initial_columns
+            initial_columns = lambda N: np.random.choice(N, i, replace=False)
+
+        self._covar = LaggedCovariance(c00=True, c0t=True, ctt=False, remove_data_mean=True, reversible=reversible,
+                                       lag=lag, bessel=False, stride=stride, skip=skip, ncov_max=ncov_max)
+        self._diag = LaggedCovariance(c00=True, c0t=True, ctt=False, remove_data_mean=True, reversible=reversible,
+                                      lag=lag, bessel=False, stride=stride, skip=skip, ncov_max=ncov_max,
+                                      diag_only=True)
+        self._oasis = None
+
+        # empty dummy model instance
+        self._model = NystroemTICAModel()
+        self.set_params(lag=lag, max_columns=max_columns, initial_columns=initial_columns, nsel=nsel,
+                        dim=dim, var_cutoff=var_cutoff,
+                        epsilon=epsilon, reversible=reversible, stride=stride, skip=skip,
+                        ncov_max=ncov_max)
+
+    @property
+    def lag(self):
+        """ lag time of correlation matrix :math:`C_{\tau}` """
+        return self._lag
+
+    @lag.setter
+    def lag(self, new_tau):
+        self._lag = new_tau
+
+    def describe(self):
+        try:
+            dim = self.dimension()
+        except AttributeError:
+            dim = self.dim
+        return "[NystroemTICA, lag = %i; max. columns = %i; max. output dim. = %i]" % (self._lag, self._max_columns, dim)
+
+    def dimension(self):
+        """ output dimension """
+        if self.dim > -1:
+            return self.dim
+        d = None
+        if self.dim != -1 and not self._estimated:  # fixed parametrization
+            d = self.dim
+        elif self._estimated:  # parametrization finished. Dimension is known
+            dim = len(self.eigenvalues)
+            if self.var_cutoff < 1.0:  # if subspace_variance, reduce the output dimension if needed
+                dim = min(dim, np.searchsorted(self.cumvar, self.var_cutoff) + 1)
+            d = dim
+        elif self.var_cutoff == 1.0:  # We only know that all dimensions are wanted, so return input dim
+            d = self.data_producer.dimension()
+        else:  # We know nothing. Give up
+            raise RuntimeError('Requested dimension, but the dimension depends on the cumulative variance and the '
+                               'transformer has not yet been estimated. Call estimate() before.')
+        return d
+
+    @property
+    def mean(self):
+        """ mean of input features """
+        return self._model.mean
+
+    @mean.setter
+    def mean(self, value):
+        self._model.mean = value
+
+    def estimate(self, X, **kwargs):
+        r"""
+        Chunk-based parameterization of NystroemTICA.
+        Iterates over all data several times to select important columns and
+        estimate the mean, covariance and time-lagged covariance. Finally, the
+        small-scale generalized eigenvalue problem is solved to determine
+        the approximate independent components.
+        """
+        return super(NystroemTICA, self).estimate(X, **kwargs)
+
+    def _estimate(self, iterable, **kw):
+        indim = iterable.dimension()
+
+        if not self.dim <= indim:
+            raise RuntimeError("requested more output dimensions (%i) than dimension"
+                               " of input data (%i)" % (self.dim, indim))
+
+        if callable(self.initial_columns):
+            self.initial_columns = self.initial_columns(indim)
+        if not len(np.array(self.initial_columns).shape) == 1:
+            raise ValueError('initial_columns must be either None, an integer, a list, or a 1-d numpy array.')
+
+        self._diag.estimate(iterable, **kw)
+
+        self._covar.column_selection = self.initial_columns
+        self._covar.estimate(iterable, **kw)
+        self._model.update_model_params(cov_tau=self._covar.cov_tau)
+
+        self._oasis = oASIS_Nystroem(self._diag.cov, self._covar.cov, self.initial_columns)
+        self._oasis.set_selection_strategy(strategy='spectral-oasis', nsel=self.nsel)
+
+        while len(self._oasis.column_indices) < self.max_columns:
+            cols = self._oasis.select_columns()
+            if cols is None:
+                break
+            if len(cols) == 0:
+                self._logger.warning("oASIS iteration ended prematurely: No more columns to select.")
+                break
+            self._covar.column_selection = cols
+            self._covar.estimate(iterable, **kw)
+            self._model.update_model_params(cov_tau=np.concatenate((self._model.cov_tau, self._covar.cov_tau), axis=1))
+            self._oasis.add_columns(self._covar.cov, cols)
+
+        self._model.update_model_params(mean=self._covar.mean,
+                                        diag=self._diag.cov,
+                                        cov=self._oasis.Ck,
+                                        column_indices=self._oasis.column_indices)
+        self._diagonalize()
+
+        return self._model
+
+    def _transform_array(self, X):
+        r"""Projects the data onto the dominant independent components.
+
+        Parameters
+        ----------
+        X : ndarray(n, m)
+            the input data
+
+        Returns
+        -------
+        Y : ndarray(n,)
+            the projected data
+        """
+        X_meanfree = X - self.mean
+        Y = np.dot(X_meanfree, self.eigenvectors[:, 0:self.dimension()])
+
+        return Y.astype(self.output_type())
+
+    def _diagonalize(self):
+        # diagonalize with low rank approximation
+        self._logger.debug("Diagonalize Cov and Cov_tau.")
+        Wktau = self._model.cov_tau[self._model.column_indices, :].copy()
+        try:
+            eigenvalues, eigenvectors = eig_corr(self._oasis.Wk, Wktau, self.epsilon, sign_maxelement=True)
+        except ZeroRankError:
+            raise ZeroRankError('All input features are constant in all time steps. No dimension would be left after dimension reduction.')
+        self._logger.debug("Finished diagonalization.")
+
+        # compute cumulative variance
+        cumvar = np.cumsum(np.abs(eigenvalues) ** 2)
+        cumvar /= cumvar[-1]
+
+        self._model.update_model_params(cumvar=cumvar,
+                                        eigenvalues=eigenvalues,
+                                        eigenvectors=eigenvectors)
+
+        self._estimated = True
+
+    @property
+    @_lazy_estimation
+    def timescales(self):
+        r"""Implied timescales of the TICA transformation
+
+        For each :math:`i`-th eigenvalue, this returns
+
+        .. math::
+
+            t_i = -\frac{\tau}{\log(|\lambda_i|)}
+
+        where :math:`\tau` is the :py:obj:`lag` of the TICA object and :math:`\lambda_i` is the `i`-th
+        :py:obj:`eigenvalue <eigenvalues>` of the TICA object.
+
+        Returns
+        -------
+        timescales: 1D np.array
+            numpy array with the implied timescales. In principle, one should expect as many timescales as
+            input coordinates were available. However, less eigenvalues will be returned if the TICA matrices
+            were not full rank or :py:obj:`var_cutoff` was parsed
+        """
+        return -self.lag / np.log(np.abs(self.eigenvalues))
+
+    @property
+    def cov(self):
+        """ covariance matrix of input data. """
+        return self._model.cov
+
+    @cov.setter
+    def cov(self, value):
+        self._model.cov = value
+
+    @property
+    def cov_tau(self):
+        """ covariance matrix of time-lagged input data. """
+        return self._model.cov_tau
+
+    @cov_tau.setter
+    def cov_tau(self, value):
+        self._model.cov_tau = value
+
+    @property
+    def column_indices(self):
+        """ Indices of columns used in the approximation. """
+        return self._model.column_indices
+
+    @property
+    @_lazy_estimation
+    def eigenvalues(self):
+        r""" Eigenvalues of the TICA problem (usually denoted :math:`\lambda`)
+
+        Returns
+        -------
+        eigenvalues: 1D np.array
+        """
+        return self._model.eigenvalues
+
+    @property
+    @_lazy_estimation
+    def eigenvectors(self):
+        r""" Eigenvectors of the TICA problem, columnwise
+
+        Returns
+        -------
+        eigenvectors: (N,M) ndarray
+        """
+        return self._model.eigenvectors
+
+    @property
+    @_lazy_estimation
+    def cumvar(self):
+        r""" Cumulative sum of the the TICA eigenvalues
+
+        Returns
+        -------
+        cumvar: 1D np.array
+        """
+        return self._model.cumvar
+
+    def output_type(self):
+        # TODO: handle the case of conjugate pairs
+        if np.all(np.isreal(self.eigenvectors[:, 0:self.dimension()])) or \
+                np.allclose(np.imag(self.eigenvectors[:, 0:self.dimension()]), 0):
+            return super(NystroemTICA, self).output_type()
+        else:
+            return np.complex64
+
+
+class oASIS_Nystroem:
+    r""" Implements a sparse sampling method for very large symmetric matrices.
+
+    The aim of this method is to provide a low-rank approximation of a very large symmetric matrix
+    $C \in \mathbb{R}^{n \times n}$.
+    This method uses the Nystroem approximation [1]_ and the Accelerated Sequential Incoherent Selection (oASIS)
+    method [2]_ for selecting a small set of $m$ column vectors to achieve a sparse approximation of $C$.
+    Using an extended method called spectral oASIS [3]_, multiple columns can be selected at once,
+    thereby reducing the required number of passes through the data.
+
+    While the original basis set size can be very large (e.g. millions), $m$ is much smaller (e.g. hundreds or less).
+    The method never computes the large $n \times n$ matrices explicitly, but at most evaluates matrices of the
+    size $n \times m$.
+
+    Example
+    -------
+
+    In this example we attempt to approximate a correlation matrix from random data:
+
+    >>> # generate random time series
+    >>> import numpy as np
+    >>> X = np.random.randn((10000,100))
+    >>> # compute full correlation matrix
+    >>> C0 = np.dot(X.T, X)
+
+    We will compute the full correlation matrix as a reference, and start oASIS with 3 out of 100 columns:
+
+    >>> # approximate correlation matrix
+    >>> d = np.diag(C0)
+    >>> cols = [0,49,99]
+    >>> C0_k = C0[:,cols]
+    >>> oasis = oASIS_Nystroem(np.diag(C0), C0_k, cols)
+    >>> # show error of the current approximation
+    >>> print np.max(oasis.error)
+
+    Now we conduct the approximation. We ask oASIS which columns should be computed next, compute them with whichever
+    algorithm applies, and update the oASIS approximation. This can be repeated until the error is small enough or
+    until a certain number of columns is reached.
+
+    >>> # ask oASIS which column we should compute next
+    >>> newcol = oasis.select_columns()
+    >>> # recompute the new column yourself
+    >>> c = np.dot(X.T, X[:,newcol][:,None])
+    >>> # update oASIS
+    >>> oasis.add_column(c, newcol)
+    >>> # take note of the new column index
+    >>> cols.append(newcol)
+    >>> # show error of the current approximation
+    >>> print np.max(oasis.error)
+
+    References
+    ----------
+    .. [1] P. Drineas and M. W. Mahoney.
+       On the Nystrom method for approximating a Gram matrix for improved kernel-based learning.
+       Journal of Machine Learning Research, 6:2153-2175 (2005).
+    .. [2] Raajen Patel, Thomas A. Goldstein, Eva L. Dyer, Azalia Mirhoseini, Richard G. Baraniuk.
+       oASIS: Adaptive Column Sampling for Kernel Matrix Approximation.
+       arXiv: 1505.05208 [stat.ML].
+    .. [3] upcoming paper
+
+    """
+
+    def __init__(self, d, C_k, columns):
+        """
+        Initializes the oASIS_Nystroem method.
+
+        Parameters
+        ----------
+        d : ndarray((n,), dtype=float)
+            diagonal (autocorrelation) elements of :math:`A`
+        C_k : ndarray((n,k), dtype=float)
+            column matrix with the k selected columns of the spd matrix :math:`A`.
+        columns : ndarray((k,), dtype=int) or list of ints of size :math:`k`
+            array of selected column indices (such that formally :math:`A_k = \mathrm{A[:,columns]}` )
+
+        """
+        # store copy of diagonals
+        self._d = np.array(d)
+        # store copy of column submatrix
+        self._C_k = np.array(C_k)
+        # store copy of pre-selected columns
+        self._columns = np.array(columns)
+        # number of pre-selected columns
+        self._k = self._columns.shape[0]
+        # total size
+        self._n = self._C_k.shape[0]
+
+        self.update_inverse()
+
+        # update error
+        self._compute_error()
+
+        # set default selection strategy
+        self._selection_strategy = selection_strategy(oasis_obj=self, strategy='spectral-oasis', nsel=len(columns))
+
+    @property
+    def n(self):
+        """ Total number of rows (large matrix size) """
+        return self._n
+
+    @property
+    def k(self):
+        """ Current number of columns """
+        return self._k
+
+    @property
+    def Ck(self):
+        """ The submatrix of selected columns """
+        return self._C_k
+
+    @property
+    def Wk(self):
+        """ The block matrix selected by rows and columns """
+        return self._C_k[self._columns, :]
+
+    @property
+    def Wk_inv(self):
+        """ The inverse of the block matrix selected by rows and columns """
+        return self._W_k_inv
+
+    @property
+    def diag(self):
+        """ The diagonal """
+        return self._d
+
+    @property
+    def column_indices(self):
+        """ The selected column indices """
+        return np.array(self._columns)
+
+    def _compute_error(self):
+        """ Evaluate the absolute error of the Nystroem approximation for each column """
+        # evaluate error of Nystroem approx for each new column
+        # err_i = sum_j R_{k,ij} A_{k,ji} - d_i
+        self._err = np.sum(np.multiply(self._R_k,self._C_k.T),axis=0) - self._d
+
+    @property
+    def error(self):
+        """ Absolute error of the Nystroem approximation by column """
+        return self._err
+
+    def set_selection_strategy(self, strategy='spectral-oasis', nsel=1):
+        """ Defines the column selection strategy
+
+        Parameters
+        ----------
+        strategy : str
+            One of the following strategies to select new columns:
+            random : randomly choose from non-selected columns
+            oasis : maximal approximation error in the diagonal of :math:`A`
+            spectral-oasis : selects the nsel columns that are most distanced in the oASIS-error-scaled dominant eigenspace
+        nsel : int
+            number of columns to be selected in each round
+
+        """
+        self._selection_strategy = selection_strategy(self, strategy, nsel)
+
+    def select_columns(self):
+        """ Selects new columns of :math:`A` using the given selection strategy
+
+        Returns
+        -------
+        selected_columns : ndarray((ncols), dtype=int)
+            An array containing the selected column indices
+
+        """
+        return self._selection_strategy.select()
+
+    def update_inverse(self):
+        """ Recomputes W_k_inv and R_k given the current column selection
+
+        When computed, the block matrix inverse W_k_inv will be updated. This is useful when you want to compute
+        eigenvalues or get an approximation for the full matrix or individual columns.
+        Calling this function is not strictly necessary, but then you rely on the fact that the updates did not
+        accumulate large errors. That depends very much on how columns were added. Adding columns with very small
+        Schur complement causes accumulation of errors and is more likely to make it necessary to update the inverse.
+
+        """
+        # compute R_k and W_k_inv
+        Wk = self._C_k[self._columns, :]
+        self._W_k_inv = np.linalg.pinv(Wk)
+        self._R_k = np.dot(self._W_k_inv, self._C_k.T)
+
+    def add_column(self, col, icol, update_error=True):
+        """ Attempts to add a single column of :math:`A` to the Nystroem approximation and updates the local matrices
+
+        Parameters
+        ----------
+        col : ndarray((N,), dtype=float)
+            new column of :math:`A`
+        icol : int
+            index of new column within :math:`A`
+        update_error : bool, optional, default = True
+            If True, the absolute and relative approximation error will be updated after adding the column.
+            If False, then not.
+
+        Return
+        ------
+        success : bool
+            True if the new column was added to the approximation. False if not.
+
+        """
+        # copy column
+        col = copy.deepcopy(col)
+
+        # convenience access
+        k = self._k
+        d = self._d
+        R = self._R_k
+        Winv = self._W_k_inv
+
+        b_new = col[self._columns][:, None]
+        d_new = d[icol]
+        q_new = R[:, icol][:, None]
+
+        # calculate R_new
+        schur_complement = d_new - np.dot(b_new.T, q_new)  # Schur complement
+        if np.isclose(schur_complement, 0):
+            return False
+
+        # otherwise complete the update
+        s_new = 1./schur_complement
+        qC = np.dot(b_new.T, R)
+
+        # update Winv
+        Winv_new = np.zeros((k+1, k+1))
+        Winv_new[0:k, 0:k] = Winv+s_new*np.dot(q_new, q_new.T)
+        Winv_new[0:k, k] = -s_new*q_new[0:k, 0]
+        Winv_new[k, 0:k] = -s_new*q_new[0:k, 0].T
+        Winv_new[k, k] = s_new
+
+        R_new = np.vstack((R + s_new * np.dot(q_new, (qC - col.T)), s_new*(-qC + col.T)))
+
+        # forcing known structure on R_new
+        sel_new = np.append(self._columns, icol)
+        R_new[:, sel_new] = np.eye(k+1)
+
+        # update Winv
+        self._W_k_inv = Winv_new
+        # update R
+        self._R_k = R_new
+        # update C0_k
+        self._C_k = np.hstack((self._C_k, col[:, None]))
+        # update number of selected columns
+        self._k += 1
+        # add column to present selection
+        self._columns = np.append(self._columns, icol)
+
+        # update error
+        if update_error:
+            self._compute_error()
+
+        # exit with success
+        return True
+
+    def add_columns(self, C_k_new, columns_new):
+        r""" Attempts to adds a set of new columns of :math:`A` to the Nystroem approximation and updates the local matrices
+
+        Parameters
+        ----------
+        C_k_new : ndarray((N,k), dtype=float)
+            :math:`k` new columns of :math:`A`
+        columns_new : int
+            indices of new columns within :math:`A`, in the same order as the C_k_new columns
+
+        Return
+        ------
+        cols_added : ndarray of int
+            Columns that were added successfully. Columns are only added when their Schur complement exceeds 0,
+            which is normally true for columns that were not yet added, but the Schur complement may become 0 even
+            for new columns as a result of numerical cancellation errors.
+
+        """
+        added = []
+        for (i, c) in enumerate(columns_new):
+            if self.add_column(C_k_new[:, i], c, update_error=False):
+                added.append(c)
+        # update error only once
+        self._compute_error()
+        # return the columns that were successfully added
+        return np.array(added)
+
+    def approximate_matrix(self):
+        r""" Computes the Nystroem approximation of the matrix $A \in \mathbb{R}^{n \times n}$.
+
+        WARNING: This will attempt to construct a $n \times n$ matrix. The computation effort of doing this is
+        $O(m n^2)$, and the memory requirements can be huge for large $n$. So be sure you know what you are asking
+        for when calling this method.
+
+        """
+        C_approx = np.dot(self._C_k, self._R_k)
+        return C_approx
+
+    def approximate_column(self, i):
+        """ Computes the Nystroem approximation of column :math:`i` of matrix $A \in \mathbb{R}^{n \times n}$.
+
+        """
+        col_approx = np.dot(self._C_k, self._R_k[:, i])
+        return col_approx
+
+    def approximate_cholesky(self, epsilon=1e-6):
+        r""" Compute low-rank approximation to the Cholesky decomposition of target matrix.
+
+        The decomposition will be conducted while ensuring that the spectrum of `A_k^{-1}` is positive.
+
+        Parameters
+        ----------
+        epsilon : float, optional, default 1e-6
+            If truncate=True, this determines the cutoff for eigenvalue norms. If negative eigenvalues occur,
+            with larger norms than epsilon, the largest negative eigenvalue norm will be used instead of epsilon, i.e.
+            a band including all negative eigenvalues will be cut off.
+
+        Returns
+        -------
+        L : ndarray((n,m), dtype=float)
+            Cholesky matrix such that `A \approx L L^{\top}`. Number of columns :math:`m` is most at the number of columns
+            used in the Nystroem approximation, but may be smaller if truncate=True.
+
+        """
+        # compute the Eigenvalues of C0 using Schur factorization
+        Wk = self._C_k[self._columns, :]
+        L0 = spd_inv_split(Wk)
+        L = np.dot(self._C_k, L0)
+
+        return L
+
+    def approximate_eig(self, epsilon=1e-6):
+        """ Compute low-rank approximation of the eigenvalue decomposition of target matrix.
+
+        If spd is True, the decomposition will be conducted while ensuring that the spectrum of `A_k^{-1}` is positive.
+
+        Parameters
+        ----------
+        epsilon : float, optional, default 1e-6
+            If truncate=True, this determines the cutoff for eigenvalue norms. If negative eigenvalues occur,
+            with larger norms than epsilon, the largest negative eigenvalue norm will be used instead of epsilon, i.e.
+            a band including all negative eigenvalues will be cut off.
+
+        Returns
+        -------
+        s : ndarray((m,), dtype=float)
+            approximated eigenvalues. Number of eigenvalues returned is at most the number of columns used in the
+            Nystroem approximation, but may be smaller if truncate=True.
+
+        W : ndarray((n,m), dtype=float)
+            approximated eigenvectors in columns. Number of eigenvectors returned is at most the number of columns
+            used in the Nystroem approximation, but may be smaller if truncate=True.
+
+        """
+        L = self.approximate_cholesky(epsilon=epsilon)
+        LL = np.dot(L.T, L)
+        s, V = np.linalg.eigh(LL)
+        # sort
+        s, V = sort_by_norm(s, V)
+
+        # back-transform eigenvectors
+        Linv = np.linalg.pinv(L.T)
+        V = np.dot(Linv, V)
+
+        # normalize eigenvectors
+        ncol = V.shape[1]
+        for i in range(ncol):
+            V[:, i] /= np.sqrt(np.dot(V[:, i], V[:, i]))
+
+        return s, V
+
+
+class SelectionStrategy:
+    def __init__(self, oasis_obj, strategy, nsel):
+        """ Abstract selection strategy class
+
+        Parameters
+        ----------
+        oasis_obj : oASIS_Nystroem
+            The associated oASIS_Nystroem object.
+        strategy : str
+            One of the following strategies to select new columns:
+            random : randomly choose from non-selected columns
+            oasis : maximal approximation error in the diagonal of :math:`A`
+            spectral-oasis : selects the nsel columns that are most distance in the oASIS-error-scaled dominant eigenspace
+        nsel : int
+            number of columns to be selected in each round
+
+        """
+        self._oasis_obj = oasis_obj
+        self._strategy = strategy
+        self._nsel = nsel
+
+    @property
+    def strategy(self):
+        return self._strategy
+
+    @property
+    def nsel(self):
+        return self._nsel
+
+    def _check_nsel(self):
+        if self._nsel > self._oasis_obj._n - self._oasis_obj._k:
+            # less columns left than requested
+            ncols = self._oasis_obj._n - self._oasis_obj._k
+            warnings.warn('Requested more columns than are left to select. Returning only '+str(ncols)+' columns.')
+            return ncols
+        # nothing left to select?
+        if self._oasis_obj._n == self._oasis_obj._k:
+            warnings.warn('Requested more columns but there are none left. Returning None.')
+            return None
+        return self._nsel
+
+    def select(self):
+        """ Selects next column indexes according to defined strategy
+
+        Returns
+        -------
+        cols : ndarray((nsel,), dtype=int)
+            selected columns
+
+        """
+        err = self._oasis_obj.error
+        # check nsel
+        nsel = self._check_nsel()
+        if nsel is None:
+            return None
+        # go
+        return self._select(nsel, err)
+
+    def _select(self, nsel, err):
+        """ Override me to do selection """
+        pass
+
+
+class SelectionStrategyRandom(SelectionStrategy):
+    """ Selects nsel random columns not yet included in the approximation """
+    def _select(self, nsel, err):
+        # do select
+        sel = []
+        while len(sel) < nsel:
+            i = np.random.choice(self._oasis_obj._n)
+            if not (i in sel or i in self._oasis_obj._columns):
+                sel.append(i)
+        return np.array(sel, dtype=int)
+
+
+class SelectionStrategyOasis(SelectionStrategy):
+    """ Selects the nsel columns with the largest oASIS error """
+    def _select(self, nsel, err):
+        return np.argsort(np.abs(err))[::-1][:nsel]
+
+
+class SelectionStrategySpectralOasis(SelectionStrategy):
+    """ Selects the nsel columns that are most distanced in the oASIS-error-scaled dominant eigenspace """
+    def _select(self, nsel, err):
+        # if one column is wanted, then we take the one with the largest error
+        if nsel == 1:
+            return np.array([np.argmax(np.abs(err))])
+        # compute approximate eigenvectors
+        _, evec = self._oasis_obj.approximate_eig()
+        evec = self._fix_constant_evec(evec)
+        if self._neig is None:
+            neig = evec.shape[1]
+        else:
+            neig = min(self._neig, evec.shape[1])
+        # compute eigenvector-weighted error vectors
+        W = err[:, None] * evec[:, :neig]
+        # initialize selection
+        sel = np.zeros(nsel, dtype=int)
+        n = np.shape(W)[0]
+        # look for the most distant point from 0
+        d_to_0 = np.linalg.norm(W, axis=1)
+        sel[0] = np.argmax(d_to_0)
+        # append most distance point
+        for i in range(1, nsel):
+            d_to_i = d_to_0[:]
+            for k in range(nsel):
+                d_to_i = np.minimum(d_to_i, np.linalg.norm(W - W[sel[k], :], axis=1))
+            sel[i] = np.argmax(d_to_i)
+        return sel
+
+    def _fix_constant_evec(self, evecs):
+        # test if first vector is trying to approximate constant vector
+        evec0 = evecs[:, 0] / np.max(evecs[:, 0])  # make sure the vector has positive elements.
+        if np.min(evec0) > -1e-10:  # this looks like a constant eigenvector
+            evecs[:, 0] = 1  # make it really constant
+        else:  # we don't have it, so add it
+            evecs = np.hstack([np.ones((evecs.shape[0], 1)), evecs])
+        return evecs
+
+
+def selection_strategy(oasis_obj, strategy='spectral-oasis', nsel=1):
+    """ Factory for selection strategy object
+
+    Returns
+    -------
+    selstr : SelectionStrategy
+        Selection strategy object
+
+    """
+    strategy = strategy.lower()
+    if strategy == 'random':
+        return SelectionStrategyRandom(oasis_obj, strategy, nsel=nsel)
+    elif strategy == 'oasis':
+        return SelectionStrategyOasis(oasis_obj, strategy, nsel=nsel)
+    elif strategy == 'spectral-oasis':
+        return SelectionStrategySpectralOasis(oasis_obj, strategy, nsel=nsel)
+    else:
+        raise ValueError('Selected strategy is unknown: '+str(strategy))

--- a/pyemma/coordinates/transform/nystroem_tica.py
+++ b/pyemma/coordinates/transform/nystroem_tica.py
@@ -226,8 +226,12 @@ class NystroemTICA(StreamingEstimationTransformer):
         return super(NystroemTICA, self).estimate(X, **kwargs)
 
     def _estimate(self, iterable, **kw):
-        indim = iterable.dimension()
+        from pyemma.coordinates.data import DataInMemory
+        if not isinstance(iterable, DataInMemory):
+            self._logger.warning('Every iteration of the selection process involves streaming of all data and featurization. '+
+                                 'Depending on your setup, this might be inefficient.')
 
+        indim = iterable.dimension()
         if not self.dim <= indim:
             raise RuntimeError("requested more output dimensions (%i) than dimension"
                                " of input data (%i)" % (self.dim, indim))
@@ -251,7 +255,7 @@ class NystroemTICA(StreamingEstimationTransformer):
             if cols is None:
                 break
             if len(cols) == 0 or np.all(np.in1d(cols, self._oasis.column_indices)):
-                self._logger.warning("oASIS iteration ended prematurely: No more columns to select.")
+                self._logger.warning("Iteration ended prematurely: No more columns to select.")
                 break
             self._covar.column_selection = cols
             self._covar.estimate(iterable, **kw)


### PR DESCRIPTION
This introduces the NystroemTICA transformer that implements a sparse sampling variant of TICA based on a selection of column subsets of the relevant covariance matrices. To that end, additional arguments to coordinates.estimation.covariance, _ext.variational.estimators.moments, and _ext.variational.estimators.running_moments have been introduced that allow for the restriction of the covariance computation to the diagonal or a subset of columns, respectively. The tests have been extended to cover the new features.
