### PR TITLE
[vamp] use gesvd as lapack method to solve the svd problem.

### DIFF
--- a/pyemma/coordinates/transform/vamp.py
+++ b/pyemma/coordinates/transform/vamp.py
@@ -275,13 +275,11 @@ class VAMPModel(Model, SerializableMixIn):
               singular value. Note that only the left singular functions
               induce a kinetic map.
         """
-
         L0, self._rank0 = spd_inv_sqrt(self.C00, epsilon=self.epsilon, return_rank=True)
         Lt, self._rankt = spd_inv_sqrt(self.Ctt, epsilon=self.epsilon, return_rank=True)
-        # TODO: rethink this. Why is A still living in the full-rank space?
         A = L0.T.dot(self.C0t).dot(Lt)
-
-        Uprime, s, Vprimeh = np.linalg.svd(A, compute_uv=True)
+        from scipy.linalg import svd
+        Uprime, s, Vprimeh = svd(A, compute_uv=True, lapack_driver='gesvd')
         self._singular_values = s
 
         self._L0 = L0

--- a/pyemma/plots/networks.py
+++ b/pyemma/plots/networks.py
@@ -65,8 +65,8 @@ class NetworkPlot(object):
         >>> F = msm.tpt(msm.markov_model(P), [2], [3])
 
         now plot the gross flux
-        >>> NetworkPlot(F.gross_flux).plot_network() # doctest:+ELLIPSIS
-        <matplotlib.figure.Figure...
+        >>> NetworkPlot(F.gross_flux).plot_network() # doctest: +ELLIPSIS
+        <...Figure...
 
         """
 
@@ -411,7 +411,7 @@ def plot_markov_model(
     ...              [0.0,  0.2, 0.0,  0.8,  0.0],
     ...              [0.0,  0.02, 0.02, 0.0,  0.96]])
     >>> plot_markov_model(P) # doctest:+ELLIPSIS
-    (<matplotlib.figure.Figure..., array...)
+    (<...Figure..., array...)
 
     """
     from msmtools import analysis as msmana
@@ -538,7 +538,7 @@ def plot_flux(
     to 1 (avoid printing many zeros). Now we visualize the flux:
 
     >>> plot_flux(F) # doctest:+ELLIPSIS
-    (<matplotlib.figure.Figure..., array...)
+    (<...Figure..., array...)
 
     """
     from matplotlib import pylab as plt
@@ -668,7 +668,7 @@ def plot_network(
     to 1 (avoid printing many zeros). Now we visualize the flux:
 
     >>> plot_network(P) # doctest:+ELLIPSIS
-    (<matplotlib.figure.Figure..., array...)
+    (<...Figure..., array...)
 
     """
     plot = NetworkPlot(weights, pos=pos, xpos=xpos, ypos=ypos, ax=ax)


### PR DESCRIPTION
There had been some numerical issues with small epsilons, by using
the gesvd method, these examples work as well. The svd raised a not converged error,
when using the default numpy.linalg.svd.

thanks @clonker for his great help

https://github.com/ContinuumIO/anaconda-issues/issues/695