### PR TITLE
more reliable SVD implementation for VAMP, part 2

### DIFF
--- a/pyemma/_ext/variational/solvers/direct.py
+++ b/pyemma/_ext/variational/solvers/direct.py
@@ -38,6 +38,21 @@ def spd_eig(W, epsilon=1e-10, method='QR', canonical_signs=False):
 
     Removes all negligible eigenvalues
 
+    Parameters
+    ----------
+    W : ndarray((n, n), dtype=float)
+        Symmetric positive-definite (spd) matrix.
+    epsilon : float
+        Truncation parameter. Eigenvalues with norms smaller than this cutoff will
+        be removed.
+    method : str
+        Method to perform the decomposition of :math:`W` before inverting. Options are:
+
+        * 'QR': QR-based robust eigenvalue decomposition of W
+        * 'schur': Schur decomposition of W
+    canonical_signs : boolean, default = False
+        Fix signs in V, s. t. the largest element of in every row of V is positive.
+
     Returns
     -------
     s : ndarray(k)
@@ -45,7 +60,6 @@ def spd_eig(W, epsilon=1e-10, method='QR', canonical_signs=False):
 
     V : ndarray(n, k)
         k leading eigenvectors
-
     """
     # check input
     assert _np.allclose(W.T, W), 'W is not a symmetric matrix'
@@ -87,11 +101,12 @@ def spd_eig(W, epsilon=1e-10, method='QR', canonical_signs=False):
     return sm, Vm
 
 
-def spd_inv(W, epsilon=1e-10, method='QR', canonical_signs=False):
+def spd_inv(W, epsilon=1e-10, method='QR'):
     """
     Compute matrix inverse of symmetric positive-definite matrix :math:`W`.
 
-    by first reducing W to a low-rank approximation that is truly spd.
+    by first reducing W to a low-rank approximation that is truly spd
+    (Moore-Penrose inverse).
 
     Parameters
     ----------
@@ -106,26 +121,26 @@ def spd_inv(W, epsilon=1e-10, method='QR', canonical_signs=False):
         * 'QR': QR-based robust eigenvalue decomposition of W
         * 'schur': Schur decomposition of W
 
-     canonical_signs : boolean, default = False
-        Fix signs in L, s. t. the largest element of in every row of L is positive.
-
     Returns
     -------
     L : ndarray((n, r))
-        Matrix :math:`L` from the decomposition :math:`W^{-1} = L L^T`.
+        the Moore-Penrose inverse of the symmetric positive-definite matrix :math:`W`
 
     """
     if (_np.shape(W)[0] == 1):
+        if W[0,0] < epsilon:
+            raise _ZeroRankError(
+                'All eigenvalues are smaller than %g, rank reduction would discard all dimensions.' % epsilon)
         Winv = 1./W[0,0]
     else:
-        sm, Vm = spd_eig(W, epsilon=epsilon, method=method, canonical_signs=canonical_signs)
+        sm, Vm = spd_eig(W, epsilon=epsilon, method=method)
         Winv = _np.dot(Vm, _np.diag(1.0 / sm)).dot(Vm.T)
 
     # return split
     return Winv
 
 
-def spd_inv_sqrt(W, epsilon=1e-10, method='QR', canonical_signs=False, return_rank=False):
+def spd_inv_sqrt(W, epsilon=1e-10, method='QR', return_rank=False):
     """
     Computes :math:`W^{-1/2}` of symmetric positive-definite matrix :math:`W`.
 
@@ -144,20 +159,20 @@ def spd_inv_sqrt(W, epsilon=1e-10, method='QR', canonical_signs=False, return_ra
         * 'QR': QR-based robust eigenvalue decomposition of W
         * 'schur': Schur decomposition of W
 
-     canonical_signs : boolean, default = False
-        Fix signs in L, s. t. the largest element of in every row of L is positive.
-
     Returns
     -------
     L : ndarray((n, r))
-        Matrix :math:`L` from the decomposition :math:`W^{-1} = L L^T`.
+        :math:`W^{-1/2}` after reduction of W to a low-rank spd matrix
 
     """
     if _np.shape(W)[0] == 1:
+        if W[0,0] < epsilon:
+            raise _ZeroRankError(
+                'All eigenvalues are smaller than %g, rank reduction would discard all dimensions.' % epsilon)
         Winv = 1./_np.sqrt(W[0, 0])
         sm = _np.ones(1)
     else:
-        sm, Vm = spd_eig(W, epsilon=epsilon, method=method, canonical_signs=canonical_signs)
+        sm, Vm = spd_eig(W, epsilon=epsilon, method=method)
         Winv = _np.dot(Vm, _np.diag(1.0 / _np.sqrt(sm))).dot(Vm.T)
 
     # return split
@@ -196,6 +211,9 @@ def spd_inv_split(W, epsilon=1e-10, method='QR', canonical_signs=False):
 
     """
     if (_np.shape(W)[0] == 1):
+        if W[0,0] < epsilon:
+            raise _ZeroRankError(
+                'All eigenvalues are smaller than %g, rank reduction would discard all dimensions.' % epsilon)
         L = 1./_np.sqrt(W[0,0])
     else:
         sm, Vm = spd_eig(W, epsilon=epsilon, method=method, canonical_signs=canonical_signs)

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -1276,7 +1276,7 @@ def vamp(data=None, lag=10, dim=None, scaling=None, right=True, ncov_max=float('
           Number of dimensions to keep:
 
           * if dim is not set (None) all available ranks are kept:
-              `n_components == min(n_samples, n_features)`
+              `n_components == min(n_samples, n_uncorrelated_features)`
           * if dim is an integer >= 1, this number specifies the number
             of dimensions to keep.
           * if dim is a float with ``0 < dim < 1``, select the number
@@ -1287,7 +1287,7 @@ def vamp(data=None, lag=10, dim=None, scaling=None, right=True, ncov_max=float('
           Scaling to be applied to the VAMP order parameters upon transformation
 
           * None: no scaling will be applied, variance of the order parameters is 1
-          * 'kinetic map' or 'km': order parameters are scaled by singular value
+          * 'kinetic map' or 'km': order parameters are scaled by singular value.
             Only the left singular functions induce a kinetic map.
             Therefore scaling='km' is only effective if `right` is False.
       right : boolean
@@ -1302,9 +1302,9 @@ def vamp(data=None, lag=10, dim=None, scaling=None, right=True, ncov_max=float('
           the left singular functions. The remaining frames might
           possibly be interpreted as some extrapolation.
       epsilon : float
-          singular value cutoff. Singular values of :math:`C0` with
-          norms <= epsilon will be cut off. The remaining number of
-          singular values define the size of the output.
+          eigenvalue cutoff. Eigenvalues of :math:`C_{00}` and :math:`C_{11}`
+          with norms <= epsilon will be cut off. The remaining number of
+          eigenvalues together with the value of `dim` define the size of the output.
       stride: int, optional, default = 1
           Use only every stride-th time step. By default, every time step is used.
       skip : int, default=0

--- a/pyemma/coordinates/tests/test_vamp.py
+++ b/pyemma/coordinates/tests/test_vamp.py
@@ -328,9 +328,9 @@ class TestVAMPWithEdgeCaseData(unittest.TestCase):
 
     def test_const_data(self):
         from pyemma._ext.variational.util import ZeroRankError
-        with np.testing.assert_raises(ZeroRankError):
+        with self.assertRaises(ZeroRankError):
             pyemma_api_vamp([np.ones((10, 2))], 1)
-        with np.testing.assert_raises(ZeroRankError):
+        with self.assertRaises(ZeroRankError):
             pyemma_api_vamp([np.ones(10)] ,1)
 
 

--- a/pyemma/coordinates/tests/test_vamp.py
+++ b/pyemma/coordinates/tests/test_vamp.py
@@ -319,5 +319,20 @@ class TestVAMPModel(unittest.TestCase):
         assert v.default_chunksize == v._FALLBACK_CHUNKSIZE
 
 
+class TestVAMPWithEdgeCaseData(unittest.TestCase):
+    def test_1D_data(self):
+        x = np.random.randn(10, 1)
+        vamp = pyemma_api_vamp([x], 1)  # just test that this doesn't raise
+        # Doing VAMP with 1-D data is just centering and normalizing the data.
+        assert_allclose_ignore_phase(vamp.get_output()[0], (x - np.mean(x[1:, 0])) / np.std(x[1:, 0]))
+
+    def test_const_data(self):
+        from pyemma._ext.variational.util import ZeroRankError
+        with np.testing.assert_raises(ZeroRankError):
+            pyemma_api_vamp([np.ones((10, 2))], 1)
+        with np.testing.assert_raises(ZeroRankError):
+            pyemma_api_vamp([np.ones(10)] ,1)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/pyemma/coordinates/transform/vamp.py
+++ b/pyemma/coordinates/transform/vamp.py
@@ -26,7 +26,7 @@ from pyemma._base.model import Model
 from pyemma._base.serialization.serialization import SerializableMixIn
 from pyemma.util.annotators import fix_docs
 from pyemma.util.types import ensure_ndarray_or_None, ensure_ndarray
-from pyemma._ext.variational.solvers.direct import spd_inv_sqrt, spd_eig
+from pyemma._ext.variational.solvers.direct import spd_inv_sqrt, spd_inv_split
 from pyemma.coordinates.estimation.covariance import LaggedCovariance
 from pyemma.coordinates.data._base.transformer import StreamingEstimationTransformer
 from pyemma.msm.estimators.lagged_model_validators import LaggedModelValidator
@@ -275,22 +275,22 @@ class VAMPModel(Model, SerializableMixIn):
               singular value. Note that only the left singular functions
               induce a kinetic map.
         """
-        lambda0, QT0 = spd_eig(self.C00, epsilon=self.epsilon)
-        self._rank0 = lambda0.shape[0]
-        lambda1, QT1 = spd_eig(self.Ctt, epsilon=self.epsilon)
-        self._rankt = lambda1.shape[0]
+        L0 = spd_inv_split(self.C00, epsilon=self.epsilon)
+        self._rank0 = L0.shape[1] if L0.ndim == 2 else 1
+        Lt = spd_inv_split(self.Ctt, epsilon=self.epsilon)
+        self._rankt = Lt.shape[1] if Lt.ndim == 2 else 1
 
-        W = np.diag(lambda0**-0.5).dot(QT0.T).dot(self.C0t).dot(QT1).dot(np.diag(lambda1**-0.5))
+        W = np.dot(L0.T, self.C0t).dot(Lt)
         from scipy.linalg import svd
         A, s, BT = svd(W, compute_uv=True, lapack_driver='gesvd')
 
         self._singular_values = s
 
-        # don't pass any values calling this method again!!!
+        # don't pass any values in the argument list that call _diagonalize again!!!
         m = VAMPModel._dimension(self._rank0, self._rankt, self.dim, self._singular_values)
 
-        U = QT0.dot(np.diag(lambda0 ** -0.5).dot(A[:, :m]))
-        V = QT1.dot(np.diag(lambda1 ** -0.5).dot(BT[:m, :].T))
+        U = np.dot(L0, A[:, :m])
+        V = np.dot(Lt, BT[:m, :].T)
 
         # scale vectors
         if self.scaling is not None:
@@ -388,7 +388,7 @@ class VAMP(StreamingEstimationTransformer, SerializableMixIn):
               Number of dimensions to keep:
 
               * if dim is not set (None) all available ranks are kept:
-                  `n_components == min(n_samples, n_features)`
+                  `n_components == min(n_samples, n_uncorrelated_features)`
               * if dim is an integer >= 1, this number specifies the number
                 of dimensions to keep.
               * if dim is a float with ``0 < dim < 1``, select the number
@@ -399,7 +399,7 @@ class VAMP(StreamingEstimationTransformer, SerializableMixIn):
               Scaling to be applied to the VAMP order parameters upon transformation
 
               * None: no scaling will be applied, variance of the order parameters is 1
-              * 'kinetic map' or 'km': order parameters are scaled by singular value
+              * 'kinetic map' or 'km': order parameters are scaled by singular value.
                 Only the left singular functions induce a kinetic map.
                 Therefore scaling='km' is only effective if `right` is False.
           right : boolean
@@ -414,9 +414,9 @@ class VAMP(StreamingEstimationTransformer, SerializableMixIn):
               the left singular functions. The remaining frames might
               possibly be interpreted as some extrapolation.
           epsilon : float
-              singular value cutoff. Singular values of :math:`C0` with
-              norms <= epsilon will be cut off. The remaining number of
-              singular values define the size of the output.
+              eigenvalue cutoff. Eigenvalues of :math:`C_{00}` and :math:`C_{11}`
+              with norms <= epsilon will be cut off. The remaining number of
+              eigenvalues together with the value of `dim` define the size of the output.
           stride: int, optional, default = 1
               Use only every stride-th time step. By default, every time step is used.
           skip : int, default=0


### PR DESCRIPTION
Hi all, 
while correcting the SVD implementation, I found a couple of issues that I correct here.
There already existed code for the reliable SVD (spd_inv_split), I just didn't understand it. Now that I've understood, I have changed _diagonalize() again. The changes in this PR are purely organizational. The actual SVD algorithm is unchanged. (We still do the SVD if C01 in the small space.)