### PR TITLE
Fix quadwell default params

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -12,6 +12,7 @@ Changelog
 **Fixes**:
 
 - msm: Chapman Kolmogorov validator ensures there are no side effects on the tested model. #1255
+- datasets: Fix default values for kT to ensure integrator produces sane values. #1272, #1275
 
 
 2.5.1 (02-17-2018)

--- a/pyemma/datasets/api.py
+++ b/pyemma/datasets/api.py
@@ -135,7 +135,7 @@ def get_quadwell_data(ntraj=10, nstep=10000, x0=0., nskip=1, dt=0.01, kT=1.0, ma
         number of integrator steps
     dt: float, default=0.01
         time step size
-    kT: float, default=10.0
+    kT: float, default=1.0
         temperature factor
     mass: float, default=1.0
         mass
@@ -149,5 +149,11 @@ def get_quadwell_data(ntraj=10, nstep=10000, x0=0., nskip=1, dt=0.01, kT=1.0, ma
     """
     from .potentials import PrinzModel
     pw = PrinzModel(dt, kT, mass=mass, damping=damping)
-    trajs = [pw.sample(x0, nstep, nskip=nskip) for _ in range(ntraj)]
+    import warnings
+    import numpy as np
+    with warnings.catch_warnings(record=True) as w:
+        trajs = [pw.sample(x0, nstep, nskip=nskip) for _ in range(ntraj)]
+        if not np.all(tuple(np.isfinite(x) for x in trajs)):
+            raise RuntimeError('integrator detected invalid values in output. If you used a high temperature value (kT),'
+                               ' try decreasing the integration time step dt.')
     return trajs

--- a/pyemma/datasets/api.py
+++ b/pyemma/datasets/api.py
@@ -120,11 +120,13 @@ def get_multi_temperature_data(kt0=1.0, kt1=5.0, length0=10000, length1=10000, n
     return mt_data
 
 
-def get_quadwell_data(nstep=10000, x0=0., nskip=1, dt=0.01, kT=10.0, mass=1.0, damping=1.0):
+def get_quadwell_data(ntraj=10, nstep=10000, x0=0., nskip=1, dt=0.01, kT=1.0, mass=1.0, damping=1.0):
     r""" Performs a Brownian dynamics simulation in the Prinz potential (quad well).
 
     Parameters
     ----------
+    ntraj: int, default=10
+        how many realizations will be computed
     nstep: int, default=10000
         number of time steps
     x0: float, default 0
@@ -135,11 +137,17 @@ def get_quadwell_data(nstep=10000, x0=0., nskip=1, dt=0.01, kT=10.0, mass=1.0, d
         time step size
     kT: float, default=10.0
         temperature factor
-    mass: float, default=1
+    mass: float, default=1.0
         mass
-    damping: float, default=1
+    damping: float, default=1.0
         damping factor of integrator
+
+    Returns
+    -------
+    trajectories : list of ndarray
+        realizations of the the brownian diffusion in the quadwell potential.
     """
     from .potentials import PrinzModel
     pw = PrinzModel(dt, kT, mass=mass, damping=damping)
-    return pw.sample(x0, nstep, nskip=nskip)
+    trajs = [pw.sample(x0, nstep, nskip=nskip) for _ in range(ntraj)]
+    return trajs

--- a/pyemma/datasets/api.py
+++ b/pyemma/datasets/api.py
@@ -120,7 +120,7 @@ def get_multi_temperature_data(kt0=1.0, kt1=5.0, length0=10000, length1=10000, n
     return mt_data
 
 
-def get_quadwell_data(ntraj=10, nstep=10000, x0=0., nskip=1, dt=0.01, kT=1.0, mass=1.0, damping=1.0):
+def get_quadwell_data(ntraj=10, nstep=10000, x0=0., nskip=1, dt=0.001, kT=1.0, mass=1.0, damping=1.0):
     r""" Performs a Brownian dynamics simulation in the Prinz potential (quad well).
 
     Parameters
@@ -133,7 +133,7 @@ def get_quadwell_data(ntraj=10, nstep=10000, x0=0., nskip=1, dt=0.01, kT=1.0, ma
         starting point for sampling
     nskip: int, default=1
         number of integrator steps
-    dt: float, default=0.01
+    dt: float, default=0.001
         time step size
     kT: float, default=1.0
         temperature factor

--- a/pyemma/datasets/tests/test_datasets.py
+++ b/pyemma/datasets/tests/test_datasets.py
@@ -20,6 +20,7 @@ from pyemma.datasets import get_multi_temperature_data
 from pyemma.thermo import estimate_umbrella_sampling
 from pyemma.thermo import estimate_multi_temperature
 from numpy.testing import assert_allclose
+import unittest
 
 
 def test_umbrella_sampling_data():
@@ -82,6 +83,14 @@ def test_multi_temperature_data():
     assert_allclose(pi, [0.3, 0.7], rtol=0.25, atol=0.1)
 
 
-def test_prinz_potential():
-    from pyemma.datasets import get_quadwell_data
-    get_quadwell_data()
+class TestPrinzPotential(unittest.TestCase):
+
+    def test_prinz_potential(self):
+        from pyemma.datasets import get_quadwell_data
+        import numpy as np
+
+        d = get_quadwell_data(ntraj=1, nstep=int(1e5))
+        assert np.all(np.isfinite(x) for x in d)
+
+        with self.assertRaises(RuntimeError):
+            get_quadwell_data(ntraj=1, dt=1, kT=100)


### PR DESCRIPTION
the used default values for kT and dt were not sane, eg. yielded NaN in the output.

Now the output is being checked internally and a user-friendly error message is being passed.