### PR TITLE
Unpickle unversioned classes

### DIFF
--- a/pyemma/_base/serialization/serialization.py
+++ b/pyemma/_base/serialization/serialization.py
@@ -405,6 +405,17 @@ class SerializableMixIn(object):
 
     def __setstate__(self, state):
         # handle exceptions here, because they will be sucked up by pickle and silently fail...
+        if 'pyemma_version' not in state:
+            import warnings
+            msg = ('Trying to restore an un-versioned PyEMMA model/estimator (%s) via pickling. '
+                   'This is not officially supported. Please handle the object with great caution.'
+                   % self.__class__.__name__)
+            warnings.warn(msg, category=UserWarning)
+            if hasattr(self, 'logger'):
+                self.logger.warn(msg)
+            for k, v in state.items():
+                setattr(self, k, v)
+            return
         try:
             assert state
             # we need to set the model prior extra fields from _serializable_fields, because the model often contains

--- a/pyemma/_base/serialization/serialization.py
+++ b/pyemma/_base/serialization/serialization.py
@@ -408,7 +408,8 @@ class SerializableMixIn(object):
         if 'pyemma_version' not in state:
             import warnings
             msg = ('Trying to restore an un-versioned PyEMMA model/estimator (%s) via pickling. '
-                   'This is not officially supported. Please handle the object with great caution.'
+                   'This is not officially supported. Please handle the object with great caution. '
+                   'To avoid this please use model.save() and pyemma.load() in the future.'
                    % self.__class__.__name__)
             warnings.warn(msg, category=UserWarning)
             if hasattr(self, 'logger'):

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -1477,12 +1477,12 @@ def tica_nystroem(max_columns, data=None, lag=10,
     .. math:: C_{\tau} r_i = C_0 \lambda_i(\tau) r_i.
 
     Instead of computing the full matrices involved in this problem, we conduct
-    a Nyström approximation [5]_ of the matrix :math:`C_0` by means of the
+    a Nystroemm approximation [5]_ of the matrix :math:`C_0` by means of the
     accelerated sequential incoherence selection (oASIS) algorithm [6]_ and,
     in particular, its extension called spectral oASIS [1]_.
 
     Iteratively, we select a small number of columns such that the resulting
-    Nyström approximation is sufficiently accurate. This selection represents
+    Nystroem approximation is sufficiently accurate. This selection represents
     in turn a subset of important features, for which we obtain a generalized
     eigenvalue problem similar to the one above, but much smaller in size.
     Its generalized eigenvalues and eigenvectors provide an approximation
@@ -1490,7 +1490,7 @@ def tica_nystroem(max_columns, data=None, lag=10,
 
     References
     ----------
-    .. [1] F. Litzinger, L. Boninsegna, H. Wu, F. Nüske, R. Patel, R. Baraniuk, F. Noé, and C. Clementi.
+    .. [1] F. Litzinger, L. Boninsegna, H. Wu, F. Nueske, R. Patel, R. Baraniuk, F. Noe, and C. Clementi.
        Rapid calculation of molecular kinetics using compressed sensing (2018). (submitted)
     .. [2] Perez-Hernandez G, F Paul, T Giorgino, G De Fabritiis and F Noe. 2013.
        Identification of slow molecular order parameters for Markov model construction


### PR DESCRIPTION
Allow for unpickling un-versioned objects.

This prints a big fat warning, that it is unsupported,
and should be treated with great caution.