### PR TITLE
plots.plot_markov_model minor fix

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -15,7 +15,7 @@ Changelog
 - msm: fixed minor bug in ImpliedTimescales, where all models got recomputed for extended lag time array. #1294
 - msm: fixed serialization of BayesianHMSM, if initialized with a ML-HMSM. #1283
 - base: require at least tqdm >= 4.23, because of an API change. #1292, #1293
-
+- plots: fixed minor bug in plot_network (state_labels=None would not work). #1306
 
 2.5.2 (04-10-2018)
 ------------------

--- a/pyemma/plots/networks.py
+++ b/pyemma/plots/networks.py
@@ -207,7 +207,9 @@ class NetworkPlot(object):
         # show or suppress frame
         self.ax.set_frame_on(show_frame)
         # set node labels
-        if isinstance(state_labels, str) and state_labels == 'auto':
+        if state_labels is None:
+            pass
+        elif isinstance(state_labels, str) and state_labels == 'auto':
             state_labels = [str(i) for i in _np.arange(n)]
         else:
             if len(state_labels) != n:
@@ -253,8 +255,8 @@ class NetworkPlot(object):
             circles.append(c)
             self.ax.add_artist(c)
             # add annotation
-            self.ax.text(
-                self.pos[i][0], self.pos[i][1], state_labels[i], zorder=3, **textkwargs)
+            if state_labels is not None:
+                self.ax.text(self.pos[i][0], self.pos[i][1], state_labels[i], zorder=3, **textkwargs)
 
         assert len(circles) == n, "%i != %i" % (len(circles), n)
 


### PR DESCRIPTION
`pyemma.plots.plot_markov_model(P, state_labels=None)` would raise a 
```python
TypeError: object of type 'NoneType' has no len()
``` 
because this case was not handled properly in the `plot_network()` function. 