### PR TITLE
HMM submodel fix

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -18,6 +18,7 @@ Changelog
 - plots: fixed minor bug in plot_network (state_labels=None would not work). #1306
 - plots: refactored plots2d to remove inappropriate pylab/gca() usage, allow more figure construction control #1317
 - plots: refactored plots1d to remove inappropriate pylab/gca() usage #1317
+- msm: fixed inconsistent submodel behavior in HMSM and BayesianHMSM. #1323
 
 
 2.5.2 (04-10-2018)

--- a/pyemma/msm/estimators/bayesian_hmsm.py
+++ b/pyemma/msm/estimators/bayesian_hmsm.py
@@ -327,16 +327,20 @@ class BayesianHMSM(_MaximumLikelihoodHMSM, _SampledHMSM, ProgressReporterMixin):
 
         # return submodel (will return self if all None)
         return self.submodel(states=states_subset, obs=observe_subset,
-                             mincount_connectivity=self.mincount_connectivity)
+                             mincount_connectivity=self.mincount_connectivity,
+                             inplace=True)
 
-    def submodel(self, states=None, obs=None, mincount_connectivity='1/n'):
+    def submodel(self, states=None, obs=None, mincount_connectivity='1/n', inplace=False):
         # call submodel on MaximumLikelihoodHMSM
-        _MaximumLikelihoodHMSM.submodel(self, states=states, obs=obs, mincount_connectivity=mincount_connectivity)
+
+        submodel_estimator = _MaximumLikelihoodHMSM.submodel(self, states=states, obs=obs,
+                                                             mincount_connectivity=mincount_connectivity,
+                                                             inplace=inplace)
         # if samples set, also reduce them
         if hasattr(self, 'samples') and self.samples is not None:
-            subsamples = [sample.submodel(states=self.active_set, obs=self.observable_set)
+            subsamples = [sample.submodel(states=submodel_estimator.active_set, obs=submodel_estimator.observable_set)
                           for sample in self.samples]
-            self.update_model_params(samples=subsamples)
+            submodel_estimator.update_model_params(samples=subsamples)
 
         # return
-        return self
+        return submodel_estimator

--- a/pyemma/msm/estimators/maximum_likelihood_hmsm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_hmsm.py
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import absolute_import
-from six.moves import range
 from pyemma.util.annotators import alias, aliased, fix_docs
 
 import numpy as _np
@@ -276,9 +275,9 @@ class MaximumLikelihoodHMSM(_Estimator, _HMSM):
             states_subset = 'populous-strong'
 
         # return submodel (will return self if all None)
-        self._internal_submodel_call = True
         return self.submodel(states=states_subset, obs=observe_subset,
-                             mincount_connectivity=self.mincount_connectivity)
+                             mincount_connectivity=self.mincount_connectivity,
+                             inplace=True)
 
     @property
     def msm_init(self):
@@ -365,7 +364,7 @@ class MaximumLikelihoodHMSM(_Estimator, _HMSM):
     # Submodel functions using estimation information (counts)
     ################################################################################
 
-    def submodel(self, states=None, obs=None, mincount_connectivity='1/n'):
+    def submodel(self, states=None, obs=None, mincount_connectivity='1/n', inplace=False):
         """Returns a HMM with restricted state space
 
         Parameters
@@ -388,6 +387,9 @@ class MaximumLikelihoodHMSM(_Estimator, _HMSM):
             Counts lower than that will count zero in the connectivity check and
             may thus separate the resulting transition matrix. Default value:
             1/nstates.
+        inplace : Bool
+            if True, submodel is estimated in-place, overwriting the original
+            estimator and possibly discarding information. Default value: False
 
         Returns
         -------
@@ -410,13 +412,11 @@ class MaximumLikelihoodHMSM(_Estimator, _HMSM):
         S = _tmatrix_disconnected.connected_sets(self.count_matrix,
                                                  mincount_connectivity=mincount_connectivity,
                                                  strong=True)
-        if hasattr(self, '_internal_submodel_call') and self._internal_submodel_call:
+        if inplace:
             submodel_estimator = self
         else:
             from copy import deepcopy
             submodel_estimator = deepcopy(self)
-
-        self._internal_submodel_call = False
 
         if len(S) > 1:
             # keep only non-negligible transitions

--- a/pyemma/msm/models/msm.py
+++ b/pyemma/msm/models/msm.py
@@ -156,7 +156,10 @@ class MSM(_Model, SerializableMixIn):
         if id(self) == id(other):
             return True
         if self.P is not None and other.P is not None:
-            P_equal = _np.allclose(self.P, other.P)
+            if self.P.shape != other.P.shape:
+                P_equal = False
+            else:
+                P_equal = _np.allclose(self.P, other.P)
         else:
             P_equal = True
         return (P_equal and

--- a/pyemma/msm/tests/test_bayesian_hmsm.py
+++ b/pyemma/msm/tests/test_bayesian_hmsm.py
@@ -20,8 +20,7 @@ from __future__ import absolute_import
 import unittest
 import numpy as np
 from pyemma.msm import bayesian_hidden_markov_model
-from os.path import abspath, join
-from os import pardir
+
 
 class TestBHMM(unittest.TestCase):
 
@@ -302,6 +301,23 @@ class TestBHMM(unittest.TestCase):
         # test consistency
         assert np.all(L <= mean)
         assert np.all(R >= mean)
+
+    def test_submodel_simple(self):
+        # sanity check for submodel;
+        # call should not alter self
+        from copy import deepcopy
+        dtrj = np.random.randint(0, 2, size=100)
+        dtrj[np.random.randint(0, dtrj.shape[0], 3)] = 2
+        h = bayesian_hidden_markov_model(dtrj, 3, 2)
+        h_original = deepcopy(h)
+
+        hs = h.submodel_largest(mincount_connectivity=5)
+
+        self.assertTrue(h == h_original)
+
+        self.assertEqual(hs.timescales().shape[0], 1)
+        self.assertEqual(hs.pi.shape[0], 2)
+        self.assertEqual(hs.transition_matrix.shape, (2, 2))
 
     # TODO: these tests can be made compact because they are almost the same. can define general functions for testing
     # TODO: samples and stats, only need to implement consistency check individually.

--- a/pyemma/msm/tests/test_hmsm.py
+++ b/pyemma/msm/tests/test_hmsm.py
@@ -431,11 +431,27 @@ class TestMLHMM(unittest.TestCase):
         assert np.abs(k2 - ksum) < 1e-4
 
     def test_cktest_simple(self):
-        import pyemma
         dtraj = np.random.randint(0, 10, 100)
-        oom = pyemma.msm.estimate_markov_model(dtraj, 1)
+        oom = msm.estimate_markov_model(dtraj, 1)
         hmm = oom.coarse_grain(2)
         hmm.cktest()
+
+    def test_submodel_simple(self):
+        # sanity check for submodel;
+        # call should not alter self
+        from copy import deepcopy
+        dtrj = np.random.randint(0, 2, size=100)
+        dtrj[np.random.randint(0, dtrj.shape[0], 3)] = 2
+        h = msm.estimate_hidden_markov_model(dtrj, 3, 2)
+        h_original = deepcopy(h)
+
+        hs = h.submodel_largest(mincount_connectivity=5)
+
+        self.assertTrue(h == h_original)
+
+        self.assertEqual(hs.timescales().shape[0], 1)
+        self.assertEqual(hs.pi.shape[0], 2)
+        self.assertEqual(hs.transition_matrix.shape, (2, 2))
 
 
 class TestHMMSpecialCases(unittest.TestCase):


### PR DESCRIPTION
Calling the `submodel()` function of a (Bayesian) HMM would not only return a sub-model but indeed overwrite the HMM instance directly. This makes sense when used within `_estimate()`, but not if a user wants to have an actual submodel. The PR submodels and returns a copy of `self` in these cases.