### PR TITLE
Allow zorder in plots2d

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -6,11 +6,13 @@ Changelog
 
 **New features**:
 
+- plots: allow zorder parameter via **kwargs in plot_density(), plot_free_energy(), plot_contour(), and plot_state_map()
 -
 
 **Fixes**:
 
 - plots: added missing parameter ncontours=100 to plot_state_map()
+-
 
 **Contributors**:
 

--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -13,13 +13,14 @@ Changelog
 
 - plots: added missing parameter ncontours=100 to plot_state_map() #1331
 - msm: Chapman Kolmogorov tests (CK-tests) are now computed using multiple processes by default. #1330
+- plots: fixed ill-scaled circles in plot_flux #1336
 -
 
 **Contributors**:
 
 - @chwehmeyer
 - @marscher
-
+- @thempel
 
 2.5.3 (06-28-2018)
 ------------------

--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -13,14 +13,13 @@ Changelog
 
 - plots: added missing parameter ncontours=100 to plot_state_map() #1331
 - msm: Chapman Kolmogorov tests (CK-tests) are now computed using multiple processes by default. #1330
-- plots: fixed ill-scaled circles in plot_flux #1336
 -
 
 **Contributors**:
 
 - @chwehmeyer
 - @marscher
-- @thempel
+
 
 2.5.3 (06-28-2018)
 ------------------

--- a/pyemma/plots/networks.py
+++ b/pyemma/plots/networks.py
@@ -157,20 +157,14 @@ class NetworkPlot(object):
         # number of nodes
         n = len(self.pos)
         # get bounds and pad figure
-        if self.ax is None:
-            xmin = _np.min(self.pos[:, 0])
-            xmax = _np.max(self.pos[:, 0])
-        else:
-            xmin, xmax = self.ax.get_xlim()
+        xmin = _np.min(self.pos[:, 0])
+        xmax = _np.max(self.pos[:, 0])
         Dx = xmax - xmin
         xmin -= Dx * figpadding
         xmax += Dx * figpadding
         Dx *= 1 + figpadding
-        if self.ax is None:
-            ymin = _np.min(self.pos[:, 1])
-            ymax = _np.max(self.pos[:, 1])
-        else:
-            ymin, ymax = self.ax.get_ylim()
+        ymin = _np.min(self.pos[:, 1])
+        ymax = _np.max(self.pos[:, 1])
         Dy = ymax - ymin
         ymin -= Dy * figpadding
         ymax += Dy * figpadding
@@ -192,9 +186,10 @@ class NetworkPlot(object):
             figsize = (Dx / Dy * max_height, max_height)
         if self.ax is None:
             logger.debug("creating new figure")
-            fig, self.ax = _plt.subplots(figsize=figsize)
+            fig = _plt.figure(None, figsize=figsize)
+            self.ax = fig.add_subplot(111)
         else:
-            fig = self.ax.get_figure()
+            fig = self.ax.figure
             window_extend = self.ax.get_window_extent()
             axes_ratio = window_extend.height / window_extend.width
             data_ratio = (ymax - ymin) / (xmax - xmin)
@@ -584,7 +579,7 @@ def plot_network(
     weights, pos=None, xpos=None, ypos=None, state_sizes=None, state_scale=1.0,
     state_colors='#ff5500', state_labels='auto', arrow_scale=1.0, arrow_curvature=1.0,
     arrow_labels='weights', arrow_label_format='%2.e', max_width=12, max_height=12, figpadding=0.2,
-    show_frame=False, xticks=False, yticks=False, ax=None,
+    attribute_to_plot='net_flux', show_frame=False, xticks=False, yticks=False, ax=None,
     **textkwargs):
     r"""Network representation of given matrix
 

--- a/pyemma/plots/networks.py
+++ b/pyemma/plots/networks.py
@@ -157,14 +157,20 @@ class NetworkPlot(object):
         # number of nodes
         n = len(self.pos)
         # get bounds and pad figure
-        xmin = _np.min(self.pos[:, 0])
-        xmax = _np.max(self.pos[:, 0])
+        if self.ax is None:
+            xmin = _np.min(self.pos[:, 0])
+            xmax = _np.max(self.pos[:, 0])
+        else:
+            xmin, xmax = self.ax.get_xlim()
         Dx = xmax - xmin
         xmin -= Dx * figpadding
         xmax += Dx * figpadding
         Dx *= 1 + figpadding
-        ymin = _np.min(self.pos[:, 1])
-        ymax = _np.max(self.pos[:, 1])
+        if self.ax is None:
+            ymin = _np.min(self.pos[:, 1])
+            ymax = _np.max(self.pos[:, 1])
+        else:
+            ymin, ymax = self.ax.get_ylim()
         Dy = ymax - ymin
         ymin -= Dy * figpadding
         ymax += Dy * figpadding
@@ -186,10 +192,9 @@ class NetworkPlot(object):
             figsize = (Dx / Dy * max_height, max_height)
         if self.ax is None:
             logger.debug("creating new figure")
-            fig = _plt.figure(None, figsize=figsize)
-            self.ax = fig.add_subplot(111)
+            fig, self.ax = _plt.subplots(figsize=figsize)
         else:
-            fig = self.ax.figure
+            fig = self.ax.get_figure()
             window_extend = self.ax.get_window_extent()
             axes_ratio = window_extend.height / window_extend.width
             data_ratio = (ymax - ymin) / (xmax - xmin)
@@ -579,7 +584,7 @@ def plot_network(
     weights, pos=None, xpos=None, ypos=None, state_sizes=None, state_scale=1.0,
     state_colors='#ff5500', state_labels='auto', arrow_scale=1.0, arrow_curvature=1.0,
     arrow_labels='weights', arrow_label_format='%2.e', max_width=12, max_height=12, figpadding=0.2,
-    attribute_to_plot='net_flux', show_frame=False, xticks=False, yticks=False, ax=None,
+    show_frame=False, xticks=False, yticks=False, ax=None,
     **textkwargs):
     r"""Network representation of given matrix
 

--- a/pyemma/plots/plots2d.py
+++ b/pyemma/plots/plots2d.py
@@ -240,7 +240,7 @@ def _prune_kwargs(kwargs):
     """
     allowed_keys = [
         'corner_mask', 'alpha', 'locator', 'extend', 'xunits',
-        'yunits', 'antialiased', 'nchunk', 'hatches']
+        'yunits', 'antialiased', 'nchunk', 'hatches', 'zorder']
     ignored = [key for key in kwargs.keys() if key not in allowed_keys]
     for key in ignored:
         _warn(
@@ -333,6 +333,9 @@ def plot_map(
         If None, no hatching will be added to the contour. Hatching
         is supported in the PostScript, PDF, SVG and Agg backends
         only.
+    zorder : float
+        Set the zorder for the artist. Artists with lower zorder
+        values are drawn first.
 
     Returns
     -------
@@ -464,6 +467,9 @@ def plot_density(
         If None, no hatching will be added to the contour. Hatching
         is supported in the PostScript, PDF, SVG and Agg backends
         only.
+    zorder : float
+        Set the zorder for the artist. Artists with lower zorder
+        values are drawn first.
 
     Returns
     -------
@@ -607,6 +613,9 @@ def plot_free_energy(
         If None, no hatching will be added to the contour. Hatching
         is supported in the PostScript, PDF, SVG and Agg backends
         only.
+    zorder : float
+        Set the zorder for the artist. Artists with lower zorder
+        values are drawn first.
 
     Returns
     -------
@@ -751,6 +760,9 @@ def plot_contour(
         If None, no hatching will be added to the contour. Hatching
         is supported in the PostScript, PDF, SVG and Agg backends
         only.
+    zorder : float
+        Set the zorder for the artist. Artists with lower zorder
+        values are drawn first.
 
     Returns
     -------
@@ -863,6 +875,9 @@ def plot_state_map(
         If None, no hatching will be added to the contour. Hatching
         is supported in the PostScript, PDF, SVG and Agg backends
         only.
+    zorder : float
+        Set the zorder for the artist. Artists with lower zorder
+        values are drawn first.
 
     Returns
     -------

--- a/pyemma/plots/tests/test_plots2d.py
+++ b/pyemma/plots/tests/test_plots2d.py
@@ -62,6 +62,9 @@ class TestPlots2d(unittest.TestCase):
             self.data[:, 0], self.data[:, 1], alpha=True)
         plt.close(fig)
         fig, ax, misc = plot_density(
+            self.data[:, 0], self.data[:, 1], zorder=-1)
+        plt.close(fig)
+        fig, ax, misc = plot_density(
             self.data[:, 0], self.data[:, 1],
             this_should_raise_a_UserWarning=True)
         plt.close(fig)
@@ -95,4 +98,8 @@ class TestPlots2d(unittest.TestCase):
     def test_plot_state_map(self):
         fig, ax, misc = plot_state_map(
             self.data[:, 0], self.data[:, 1], self.data[:,0])
+        plt.close(fig)
+        fig, ax, misc = plot_state_map(
+            self.data[:, 0], self.data[:, 1], self.data[:,0],
+            zorder=0.5)
         plt.close(fig)


### PR DESCRIPTION
With this, we can pass the `zorder` parameter to the `pyemma.plots.plots2d` functions as requested in #1334.