### PR TITLE
[plots1d] mask zero-counts in logscale feature histogram

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changelog
 
 - plots: added missing parameter ncontours=100 to plot_state_map() #1331
 - msm: Chapman Kolmogorov tests (CK-tests) are now computed using multiple processes by default. #1330
+- plots: maks zero-counts in logscale feature histograms. #1340
 -
 
 **Contributors**:

--- a/pyemma/plots/plots1d.py
+++ b/pyemma/plots/plots1d.py
@@ -97,7 +97,9 @@ def plot_feature_histograms(xyzall,
         if not ylog:
             y = hist / hist.max()
         else:
-            y = _np.log(hist) / _np.log(hist).max()
+            y = _np.zeros_like(hist) + _np.NaN
+            pos_idx = hist > 0
+            y[pos_idx] = _np.log(hist[pos_idx]) / _np.log(hist[pos_idx]).max()
         ax.fill_between(edges[:-1], y + h + hist_offset, y2=h + hist_offset, **kwargs)
         ax.axhline(y=h + hist_offset, xmin=0, xmax=1, color='k', linewidth=.2)
     ax.set_ylim(hist_offset, h + hist_offset + 1)


### PR DESCRIPTION
contributes to
https://github.com/markovmodel/pyemma_tutorials/issues/100