### PR TITLE
Fix connected sets for Bayesian MSMs

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -1,6 +1,24 @@
 Changelog
 =========
 
+2.5.5 (??-??-????)
+------------------
+
+**New features**:
+
+-
+
+**Fixes:
+
+- msm: fix connected sets for Bayesian MSMs in case the mincount connectivity (ergodic cutoff) parameter truncated
+  the count matrix. #1343
+
+
+**Contributors**:
+
+- @marscher
+
+
 2.5.4 (07-20-2018)
 ------------------
 

--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -1015,9 +1015,7 @@ class MaximumLikelihoodMSM(_MSMEstimator):
         npi = pi.shape[0]
         # pi has to be defined on all states visited by the trajectories
         if nC > npi:
-            errstr = """There are visited states for which no stationary
-            probability is given"""
-            raise ValueError(errstr)
+            raise ValueError('There are visited states for which no stationary probability is given')
         # Reduce pi to the visited set
         pi_visited = pi[0:nC]
         # Find visited states with positive stationary probabilities"""
@@ -1120,7 +1118,7 @@ class MaximumLikelihoodMSM(_MSMEstimator):
         # Done. We set our own model parameters, so this estimator is
         # equal to the estimated model.
         self._dtrajs_full = dtrajs
-        self._connected_sets = msmest.connected_sets(self._C_full)
+        self._connected_sets = dtrajstats.connected_sets
         self.set_model_params(P=P, pi=statdist_active, reversible=self.reversible,
                               dt_model=self.timestep_traj.get_scaled(self.lag))
 


### PR DESCRIPTION
These sets were not computed on the same count matrix as the one used to compute the active set.
    
This had lead to differences between the largest connected set and
the shape of P and pi. When the ergodic cutoff kicked out low populated
states in during count matrix estimation, the connected sets were estimated
on a wrong measure, because it used the full count matrix instead of the truncated one.
