### PR TITLE
Progress bar effective counting

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 
 **New features**:
 
--
+- msm: for Bayesian MSMs we show an optional progress bar for the counting computation. #1344
 
 **Fixes:
 

--- a/pyemma/msm/estimators/bayesian_hmsm.py
+++ b/pyemma/msm/estimators/bayesian_hmsm.py
@@ -227,8 +227,8 @@ class BayesianHMSM(_MaximumLikelihoodHMSM, _SampledHMSM, ProgressReporterMixin):
 
                 if _np.setxor1d(_np.concatenate(dtrajs_lagged_strided),
                                  _np.concatenate(self.init_hmsm._dtrajs_lagged)).size != 0:
-                    raise UserWarning('Choice of stride has excluded a different set of microstates than in ' +
-                                      'init_hmsm. Set of observed microstates in time-lagged strided trajectories ' +
+                    raise UserWarning('Choice of stride has excluded a different set of microstates than in '
+                                      'init_hmsm. Set of observed microstates in time-lagged strided trajectories '
                                       'must match to the one used for init_hmsm estimation.')
 
                 self._dtrajs_full = dtrajs
@@ -255,11 +255,12 @@ class BayesianHMSM(_MaximumLikelihoodHMSM, _SampledHMSM, ProgressReporterMixin):
         # check if we have a valid initial model
         import msmtools.estimation as msmest
         if self.reversible and not msmest.is_connected(self.count_matrix):
-            raise NotImplementedError('Encountered disconnected count matrix:\n ' + str(self.count_matrix)
-                                      + 'with reversible Bayesian HMM sampler using lag=' + str(self.lag)
-                                      + ' and stride=' + str(self.stride) + '. Consider using shorter lag, '
-                                      + 'or shorter stride (to use more of the data), '
-                                      + 'or using a lower value for mincount_connectivity.')
+            raise NotImplementedError('Encountered disconnected count matrix:\n{count_matrix} '
+                                      'with reversible Bayesian HMM sampler using lag={lag}'
+                                      ' and stride={stride}. Consider using shorter lag, '
+                                      'or shorter stride (to use more of the data), '
+                                      'or using a lower value for mincount_connectivity.'
+                                      .format(count_matrix=self.count_matrix, lag=self.lag, stride=self.stride))
 
         # here we blow up the output matrix (if needed) to the FULL state space because we want to use dtrajs in the
         # Bayesian HMM sampler. This is just an initialization.

--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -187,8 +187,9 @@ class _MSMEstimator(_Estimator, _MSM):
                                     'Consider using sparse=True.'.format(nstates=dtrajstats.nstates))
 
         # count lagged
+        show_progress = getattr(self, 'show_progress', False)
         dtrajstats.count_lagged(self.lag, count_mode=self.count_mode,
-                                mincount_connectivity=self.mincount_connectivity)
+                                mincount_connectivity=self.mincount_connectivity, show_progress=show_progress)
 
         # for other statistics
         return dtrajstats


### PR DESCRIPTION
Use multiple jobs for computing the statistical inefficiency (slowest operation in BMSM estimation). Added progress bars for this computation - can be turned of the usual way (estimator setting).
Depends on msmtools 1.2.3 (optionally).