### PR TITLE
Add new tutorial

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,8 @@
 [submodule "pybind11"]
 	path = pybind11
 	url = https://github.com/pybind/pybind11
+
+[submodule "doc/tutorials"]
+	path = doc/tutorials
+	url = https://github.com/markovmodel/pyemma_tutorials
+

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,8 +2,6 @@
 #
 
 SHELL := /bin/bash
-PYVER = 2.7
-PYTHON = python$(PYVER)
 
 # You can set these variables from the command line.
 SPHINXOPTS    = -j8 -v
@@ -40,14 +38,13 @@ html:
 	@echo
 	@echo "Build finished. The HTML pages are in build/html."
 
-source/generated:
+out_dir:
 	mkdir -p source/generated
 
-ipython-rst: source/generated
-	@$(eval notebooks:= $$(shell python grep_active_notebooks.py))
+ipython-rst: out_dir
 	cd source/generated
 	pwd
-	set -x; for nb in $(notebooks); do $(NBCONVERT_CMD) $$nb || true; done
+	exec $(NBCONVERT_CMD)
 	@echo "Conversion finished."
 
 latex:

--- a/doc/grep_active_notebooks.py
+++ b/doc/grep_active_notebooks.py
@@ -1,22 +1,31 @@
 # finds the notebooks referenced in ipython.rst and gets the paths to these notebooks
 import re
 import os
+from glob import glob
 
-
-notebooks = []
+_notebooks = []
 with open('source/ipython.rst') as fh:
     for line in fh:
         match = re.match('\s+generated\/(.+)', line)
         if match:
-            notebooks.append('{}.ipynb'.format(match.group(1)))
+            _notebooks.append('{}.ipynb'.format(match.group(1)))
 
 
 notebooks_paths = []
+# legacy tutorials
 for root, dirs, files in os.walk('../pyemma-ipython'):
     for f in files:
-        if f in notebooks:
+        if f in _notebooks:
             notebooks_paths.append(os.path.join(root, f))
 
-assert len(notebooks) == len(notebooks_paths)
-for n in notebooks_paths:
-    print(n)
+# live coms tutorials.
+tutorial_nbs =  sorted(glob('tutorials/notebooks/*.ipynb'))
+assert tutorial_nbs
+
+notebooks_paths += tutorial_nbs
+notebooks_paths = [notebooks_paths[12]]
+
+if __name__ == '__main__':
+    #assert len(_notebooks) == len(notebooks_paths)
+    for n in notebooks_paths:
+        print(n)

--- a/doc/jupyter_nbconvert_config.py
+++ b/doc/jupyter_nbconvert_config.py
@@ -1,4 +1,8 @@
 # Configuration file for jupyter-nbconvert.
+from glob import glob
+
+from doc import grep_active_notebooks
+
 c = get_config()
 #------------------------------------------------------------------------------
 # Configurable configuration
@@ -72,9 +76,10 @@ c.NbConvertApp.export_format = 'rst'
 # read a single notebook from stdin.
 # c.NbConvertApp.from_stdin = False
 
-# List of notebooks to convert. Wildcards are supported. Filenames passed
+# List of _notebooks to convert. Wildcards are supported. Filenames passed
 # positionally will be added to the list.
-# c.NbConvertApp.notebooks = []
+c.NbConvertApp.notebooks = grep_active_notebooks.notebooks_paths
+print('notebooks in nbconvert config:', c.NbConvertApp.notebooks)
 
 # overwrite base name use for output files. can only be used when converting one
 # notebook at a time.
@@ -118,12 +123,15 @@ c.NbConvertApp.export_format = 'rst'
 # List of preprocessors available by default, by name, namespace,  instance, or
 # type.
 # c.Exporter.default_preprocessors = ['nbconvert.preprocessors.ClearOutputPreprocessor', 'nbconvert.preprocessors.ExecutePreprocessor', 'nbconvert.preprocessors.coalesce_streams', 'nbconvert.preprocessors.SVG2PDFPreprocessor', 'nbconvert.preprocessors.CSSHTMLHeaderPreprocessor', 'nbconvert.preprocessors.LatexPreprocessor', 'nbconvert.preprocessors.HighlightMagicsPreprocessor', 'nbconvert.preprocessors.ExtractOutputPreprocessor']
+# we need to make sure this filter is executed first, to avoid SyntaxError exceptions due to solution stubs.
+c.Exporter.default_preprocessors.insert(0, 'nbconvert_filter.RemoveSolutionStubs')
 
 # Extension of the file that should be written to disk
 # c.Exporter.file_extension = '.txt'
 
 # List of preprocessors, by name or namespace, to enable.
-c.Exporter.preprocessors = ['nbconvert_filter.RemoveWidgetNotice']
+c.Exporter.preprocessors = ['nbconvert_filter.RewriteNotebookLinks',
+                            'nbconvert_filter.RemoveWidgetNotice']
 
 #------------------------------------------------------------------------------
 # TemplateExporter configuration
@@ -389,7 +397,8 @@ c.ExecutePreprocessor.timeout = -1
 
 # List of the files that the notebook references.  Files will be  included with
 # written output.
-# c.WriterBase.files = []
+c.WriterBase.files = []
+c.WriterBase.files += glob('tutorials/_notebooks/static/*')
 
 #------------------------------------------------------------------------------
 # DebugWriter configuration

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -82,7 +82,7 @@ Tutorials
 .. toctree::
    :maxdepth: 2
 
-   ipython
+   tutorial
 
 Development
 ===========

--- a/doc/source/ipython.rst
+++ b/doc/source/ipython.rst
@@ -1,10 +1,10 @@
- .. _ref-notebooks:
+ .. _ref-notebooks_legacy:
 
-==========================
-Jupyter Notebook Tutorials
-==========================
 
-These Jupyter (http://jupyter.org), former IPython notebooks show the usage of
+Legacy Jupyter Notebook Tutorials
+=================================
+
+These Jupyter (http://jupyter.org) notebooks show the usage of
 the PyEMMA API in action and also describe the workflow of Markov model
 building.
 

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -1,0 +1,37 @@
+ .. _ref-notebooks:
+
+
+Jupyter notebook tutorials
+==========================
+
+By means of three different application examples, these notebooks give an overview of following methods:
+
+   * Featurization and MD trajectory input
+   * Time-lagged independent component analysis (TICA)
+   * Clustering
+   * Markov state model (MSM) estimation and validation
+   * Computing Metastable states and structures, coarse-grained MSMs
+   * Hidden Markov Models (HMM)
+   * Transition Path Theory (TPT)
+
+These tutorials are part of a (not yet published) LiveCOMS journal article and are up to date with the state of the
+released version of PyEMMA. You can file issues and pull requests for the contents of both the article and the
+jupyter notebooks `here <https://github.com/markovmodel/PyEMMA_tutorials>`_.
+
+
+.. toctree::
+   :maxdepth: 1
+
+   generated/00-pentapeptide-showcase
+   generated/01-data-io-and-featurization
+   generated/02-dimension-reduction-and-discretization
+   generated/03-msm-estimation-and-validation
+   generated/04-msm-analysis
+   generated/05-pcca-tpt
+   generated/06-expectations-and-observables
+   generated/07-hidden-markov-state-models
+   generated/08-common-problems
+
+
+The legacy tutorials (prior version 2.5.5) covering similar aspects and advanced topics can be found here :doc:`ipython`
+


### PR DESCRIPTION
We now include the livecoms tutorials by default in the first heading order of the documentation. The old (legacy) tutorials are linked there for convenience. 

I did not manage to convince the convert the image html tags to include static pictures to markdown.


Fixes #1356 

