### PR TITLE
No pkg resources outside tests, fix indexing in fragmented traj reader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
 - source devtools/ci/travis/install_miniconda.sh
 
 script:
-- conda build -q devtools/conda-recipe
+- conda build -q devtools/conda-recipe -c conda-forge
 
 after_script:
 - bash <(curl -s https://codecov.io/bash) -f $HOME/coverage.xml -e CONDA_PY

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,14 +20,13 @@ install:
   - "SET PATH=%MINICONDA_PYTHON%;%MINICONDA_PYTHON%\\Scripts;%PATH%;"
 
   - conda config --set always_yes true
-  - conda config --add channels conda-forge
   - conda install -q conda-build=3
 
 build: false # Not a C# project, build stuff at the test step instead.
 
 test_script:
   # run testsuite and upload test results to AppVeyor; return exit code of testsuite
-  - "%CMD_IN_ENV% conda build -q devtools/conda-recipe %CONDA_NPY%"
+  - "%CMD_IN_ENV% conda build -c conda-forge -q devtools/conda-recipe %CONDA_NPY%"
 
 on_finish:
   # upload test results to AppVeyor

--- a/devtools/ci/travis/install_miniconda.sh
+++ b/devtools/ci/travis/install_miniconda.sh
@@ -25,8 +25,8 @@ else # if it does not exist, we need to install miniconda
         --set quiet yes \
         --set auto_update_conda false \
         --system # important to write to system cfg, otherwise we loose the changes upon cache reloading.
-    conda config --system --add channels conda-forge
-    conda install conda
+    #conda config --system --add channels conda-forge
+    #conda install conda
 fi
 
 # we want to have an up to date conda-build.

--- a/pyemma/coordinates/data/fragmented_trajectory_reader.py
+++ b/pyemma/coordinates/data/fragmented_trajectory_reader.py
@@ -192,7 +192,7 @@ class _FragmentedTrajectoryIterator(object):
         assert ifrag < len(self._readers)
         offset = self._cumulative_lengths[ifrag - 1] if ifrag > 0 else 0
         frag_inds = fragment_indices[ifrag]
-        ra = self.ra_indices[frag_inds] - offset
+        ra = self.ra_indices[tuple(frag_inds)] - offset
         indices = np.zeros((len(ra), 2), dtype=int)
         indices[:, 1] = ra.squeeze()
         return indices

--- a/pyemma/msm/estimators/_OOM_MSM.py
+++ b/pyemma/msm/estimators/_OOM_MSM.py
@@ -287,6 +287,8 @@ def equilibrium_transition_matrix(Xi, omega, sigma, reversible=True, return_lcc=
     lcc : ndarray(M,)
         the largest connected set of the transition matrix.
     """
+    import msmtools.estimation as me
+
     # Compute equilibrium transition matrix:
     Ct_Eq = np.einsum('j,jkl,lmn,n->km', omega, Xi, Xi, sigma)
     # Remove negative entries:

--- a/pyemma/msm/estimators/_OOM_MSM.py
+++ b/pyemma/msm/estimators/_OOM_MSM.py
@@ -2,7 +2,6 @@ import numpy as np
 import scipy.linalg as scl
 import scipy.sparse
 from pyemma.util.linalg import _sort_by_norm
-import msmtools.estimation as me
 
 __all__ = ['bootstrapping_count_matrix', 'bootstrapping_dtrajs', 'twostep_count_matrix', 'rank_decision',
            'oom_components', 'equilibrium_transition_matrix']
@@ -213,6 +212,7 @@ def oom_components(Ct, C2t, rank_ind=None, lcc=None, tol_one=1e-2):
     l : ndarray(M,)
         eigenvalues from OOM
     """
+    import msmtools.estimation as me
     # Decompose count matrix by SVD:
     if lcc is not None:
         Ct_svd = me.largest_connected_submatrix(Ct, lcc=lcc)

--- a/pyemma/msm/estimators/maximum_likelihood_hmsm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_hmsm.py
@@ -20,7 +20,6 @@ from __future__ import absolute_import
 from pyemma.util.annotators import alias, aliased, fix_docs
 
 import numpy as _np
-import msmtools.estimation as msmest
 from pyemma.msm.models.hmsm import HMSM as _HMSM
 
 from pyemma._base.estimator import Estimator as _Estimator
@@ -257,6 +256,7 @@ class MaximumLikelihoodHMSM(_Estimator, _HMSM):
 
         # TODO: it can happen that we loose states due to striding. Should we lift the output probabilities afterwards?
         # parametrize self
+        import msmtools.estimation as msmest
         self._dtrajs_full = dtrajs
         self._dtrajs_lagged = dtrajs_lagged_strided
         self._nstates_obs_full = msmest.number_of_states(dtrajs)

--- a/pyemma/util/_config.py
+++ b/pyemma/util/_config.py
@@ -26,8 +26,6 @@ import warnings
 from pyemma.util.files import mkdir_p
 from pyemma.util.exceptions import ConfigDirectoryException
 
-import pkg_resources
-
 
 # indicate error during reading
 class ReadConfigException(Exception):
@@ -183,12 +181,15 @@ class Config(object):
     @property
     def default_config_file(self):
         """ default config file living in PyEMMA package """
-        return pkg_resources.resource_filename('pyemma', Config.DEFAULT_CONFIG_FILE_NAME)
-
+        import os.path as p
+        import pyemma
+        return p.join(pyemma.__path__[0], Config.DEFAULT_CONFIG_FILE_NAME)
     @property
     def default_logging_file(self):
         """ default logging configuration"""
-        return pkg_resources.resource_filename('pyemma', Config.DEFAULT_LOGGING_FILE_NAME)
+        import os.path as p
+        import pyemma
+        return p.join(pyemma.__path__[0], Config.DEFAULT_LOGGING_FILE_NAME)
 
     def keys(self):
         """ valid configuration keys"""


### PR DESCRIPTION
pkg_resources does a local hard drive scan in site-packages which slows the import of pyemma down by 300 ms on my system. We are now using it only in tests to obtain resource paths.