### PR TITLE
Dtraj stats allow parallel no pg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       - run: conda config --add channels conda-forge
       - run: conda config --set always_yes true
       - run: conda config --set quiet true
-      - run: conda install conda-build
+      - run: conda install conda-build -c defaults
       - run: mkdir workspace
       - run: conda build devtools/conda-recipe --python=3.6 --no-test --output-folder workspace
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run: conda config --add channels conda-forge
       - run: conda config --set always_yes true
       - run: conda config --set quiet true
-      - run: conda install conda-build
+      - run: conda install conda-build -c defaults
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
       - attach_workspace:
           at: workspace

--- a/pyemma/_ext/variational/estimators/moments.py
+++ b/pyemma/_ext/variational/estimators/moments.py
@@ -891,7 +891,7 @@ def moments_block(X, Y, remove_mean=False, modify_data=False,
     w : float
         statistical weight of this estimation
     s : [ndarray (M), ndarray (M)]
-        list of two elements with s[0]=sx and s[0]=sy
+        list of two elements with s[0]=sx and s[1]=sy
     C : [[ndarray(M,M), ndarray(M,N)], [ndarray(N,M),ndarray(N,N)]]
         list of two lists with two elements.
         C[0,0] = Cxx, C[0,1] = Cxy, C[1,0] = Cyx, C[1,1] = Cyy
@@ -971,7 +971,7 @@ def moments_block(X, Y, remove_mean=False, modify_data=False,
                   xsum=sy_centered, xconst=yconst, ysum=sy_centered, yconst=yconst,
                   diag_only=diag_only)
 
-    return w, [sx, sy], [[Cxx, Cxy], [Cyx, Cyy]]
+    return w, (sx, sy), ((Cxx, Cxy), (Cyx, Cyy))
 
 
 def covar(X, remove_mean=False, modify_data=False, weights=None, sparse_mode='auto', sparse_tol=0.0):

--- a/pyemma/coordinates/clustering/kmeans.py
+++ b/pyemma/coordinates/clustering/kmeans.py
@@ -31,21 +31,15 @@ import random
 import tempfile
 
 from pyemma._base.progress.reporter import ProgressReporterMixin
-from pyemma._base.serialization.serialization import SerializableMixIn
 from pyemma.coordinates.clustering.interface import AbstractClustering
 from pyemma.util.annotators import fix_docs
 from pyemma.util.units import bytes_to_string
 
-from pyemma.util.contexts import random_seed
+from pyemma.util.contexts import random_seed, nullcontext
 import numpy as np
 
 
 __all__ = ['KmeansClustering', 'MiniBatchKmeansClustering']
-
-
-@contextmanager
-def _dummy():
-    yield
 
 
 @fix_docs
@@ -206,7 +200,7 @@ class KmeansClustering(AbstractClustering, ProgressReporterMixin):
 
     def _estimate(self, iterable, **kw):
         self._init_estimate()
-        ctx = _dummy() if 'data' not in self._progress_registered_stages else self._progress_context(stage='data')
+        ctx = nullcontext() if 'data' not in self._progress_registered_stages else self._progress_context(stage='data')
         # collect the data only if, we have not done this previously (eg. keep_data=True)
         # or the centers are not initialized.
         if not self._check_resume_iteration() or not self._in_memory_chunks_set:
@@ -321,7 +315,7 @@ class KmeansClustering(AbstractClustering, ProgressReporterMixin):
                 context = self._progress_context(stage=0)
             else:
                 callback = None
-                context = _dummy()
+                context = nullcontext()
             with context:
                 self.clustercenters = self._inst.init_centers_KMpp(self._in_memory_chunks, self.fixed_seed, self.n_jobs,
                                                                    callback)

--- a/pyemma/msm/estimators/_dtraj_stats.py
+++ b/pyemma/msm/estimators/_dtraj_stats.py
@@ -191,7 +191,7 @@ class DiscreteTrajectoryStats(object):
         S = msmest.connected_sets(Cconn, directed=strong)
         return S
 
-    def count_lagged(self, lag, count_mode='sliding', mincount_connectivity='1/n', show_progress=True, n_jobs=None):
+    def count_lagged(self, lag, count_mode='sliding', mincount_connectivity='1/n', show_progress=True, n_jobs=None, name=''):
         r""" Counts transitions at given lag time
 
         Parameters
@@ -245,7 +245,7 @@ class DiscreteTrajectoryStats(object):
                     pg = ProgressReporter()
                     # this is a fast operation
                     C_temp = msmest.count_matrix(self._dtrajs, lag, sliding=True)
-                    pg.register(C_temp.nnz, 'compute stat. inefficiencies', stage=0)
+                    pg.register(C_temp.nnz, '{}: compute stat. inefficiencies'.format(name), stage=0)
                     del C_temp
                     kw['callback'] = pg.update
                     ctx = pg.context(stage=0)

--- a/pyemma/msm/estimators/bayesian_msm.py
+++ b/pyemma/msm/estimators/bayesian_msm.py
@@ -18,9 +18,8 @@
 
 from __future__ import absolute_import
 
-
-
-from pyemma._base.progress import ProgressReporterMixin
+from pyemma._base.parallel import NJobsMixIn as _NJobsMixIn
+from pyemma._base.progress import ProgressReporterMixin as _ProgressReporterMixin
 from pyemma.msm.estimators.maximum_likelihood_msm import MaximumLikelihoodMSM as _MLMSM
 from pyemma.msm.models.msm import MSM as _MSM
 from pyemma.msm.models.msm_sampled import SampledMSM as _SampledMSM
@@ -31,7 +30,7 @@ __author__ = 'noe'
 
 
 @fix_docs
-class BayesianMSM(_MLMSM, _SampledMSM, ProgressReporterMixin):
+class BayesianMSM(_MLMSM, _SampledMSM, _ProgressReporterMixin, _NJobsMixIn):
     r"""Bayesian Markov state model estimator"""
     __serialize_version = 0
 
@@ -192,8 +191,8 @@ class BayesianMSM(_MLMSM, _SampledMSM, ProgressReporterMixin):
             tsampler = tmatrix_sampler(self.count_matrix_active, reversible=self.reversible,
                                        mu=statdist_active, nsteps=self.nsteps)
 
-        if self.show_progress and self.nstates >= 1000:
-            self._progress_register(self.nsamples, 'Sampling MSMs', stage=0)
+        if self.show_progress: #and self.nstates >= 1000:
+            self._progress_register(self.nsamples, '{}: Sampling MSMs'.format(self.name), stage=0)
             call_back = lambda: self._progress_update(1)
         else:
             call_back = None

--- a/pyemma/msm/estimators/maximum_likelihood_msm.py
+++ b/pyemma/msm/estimators/maximum_likelihood_msm.py
@@ -187,9 +187,11 @@ class _MSMEstimator(_Estimator, _MSM):
                                     'Consider using sparse=True.'.format(nstates=dtrajstats.nstates))
 
         # count lagged
-        show_progress = getattr(self, 'show_progress', False)
         dtrajstats.count_lagged(self.lag, count_mode=self.count_mode,
-                                mincount_connectivity=self.mincount_connectivity, show_progress=show_progress)
+                                mincount_connectivity=self.mincount_connectivity,
+                                n_jobs=getattr(self, 'n_jobs', None),
+                                show_progress=getattr(self, 'show_progress', False),
+                                name=self.name)
 
         # for other statistics
         return dtrajstats

--- a/pyemma/util/contexts.py
+++ b/pyemma/util/contexts.py
@@ -137,3 +137,19 @@ class Capturing(list):
         self.extend(self._stringio.getvalue().splitlines())
         del self._stringio  # free up some memory
         setattr(sys, self._which, self._stream)
+
+
+class nullcontext(object):
+    """Context manager that does no additional processing.
+    Used as a stand-in for a normal context manager, when a particular
+    block of code is only sometimes used with a normal context manager:
+    cm = optional_cm if condition else nullcontext()
+    with cm:
+        # Perform operation, using optional_cm if condition is True
+    """
+    def __init__(self, enter_result=None):
+        self.enter_result = enter_result
+    def __enter__(self):
+        return self.enter_result
+    def __exit__(self, *excinfo):
+        pass


### PR DESCRIPTION
* fix ci
* allow bmsm to set njobs for effective cmatrix estimation.
* added null_context (backport python 3.7)