### PR TITLE
[plots] fixed vmin, vmax kwarg pass to subsequent function call

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -12,6 +12,8 @@ Changelog
 
 - msm: fix connected sets for Bayesian MSMs in case the mincount connectivity (ergodic cutoff) parameter truncated
   the count matrix. #1343
+- plots: fix vmin, vmax keyword arguments for plot_contour(). #1376
+
 
 
 **Contributors**:

--- a/pyemma/plots/plots2d.py
+++ b/pyemma/plots/plots2d.py
@@ -810,7 +810,7 @@ def plot_contour(
         z = _np.ma.masked_where(counts.T <= 0, z)
     return plot_map(
         x, y, z, ax=ax, cmap=cmap,
-        ncontours=ncontours, vmin=None, vmax=None, levels=levels,
+        ncontours=ncontours, vmin=vmin, vmax=vmax, levels=levels,
         cbar=cbar, cax=cax, cbar_label=cbar_label,
         cbar_orientation=cbar_orientation, norm=norm,
         **kwargs)


### PR DESCRIPTION
Keyword arguments `vmin` and `vmax` were processed but not passed from `pyemma.plots.plot_contour()` to its internal call of `pyemma.plots.plot_map()`. 