### PR TITLE
[msm/its] added 'only_timescales' option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       - run: conda config --add channels conda-forge
       - run: conda config --set always_yes true
       - run: conda config --set quiet true
-      - run: conda install conda-build
+      - run: conda install conda-build -c defaults
       - run: mkdir workspace
       - run: conda build devtools/conda-recipe --python=3.6 --no-test --output-folder workspace
       - persist_to_workspace:
@@ -42,7 +42,7 @@ jobs:
       - run: conda config --add channels conda-forge
       - run: conda config --set always_yes true
       - run: conda config --set quiet true
-      - run: conda install conda-build
+      - run: conda install conda-build -c defaults
       - run: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
       - attach_workspace:
           at: workspace

--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -7,8 +7,10 @@ Changelog
 **New features**:
 
 - msm: for Bayesian MSMs we show an optional progress bar for the counting computation. #1344
+- msm: ImpliedTimescales allow to only store timescales and its samples for the purpose of saving memory. #1377
 
-**Fixes:
+
+**Fixes**:
 
 - msm: fix connected sets for Bayesian MSMs in case the mincount connectivity (ergodic cutoff) parameter truncated
   the count matrix. #1343

--- a/pyemma/_base/estimator.py
+++ b/pyemma/_base/estimator.py
@@ -313,14 +313,15 @@ def estimate_param_scan(estimator, X, param_sets, evaluate=None, evaluate_args=N
         logger = estimators[0].logger
     if progress_reporter is None:
         from mock import MagicMock
+        # TODO: replace with nullcontext from util once merged
         ctx = progress_reporter = MagicMock()
         callback = None
     else:
         ctx = progress_reporter._progress_context('param-scan')
         callback = lambda _: progress_reporter._progress_update(1, stage='param-scan')
 
-    progress_reporter._progress_register(len(estimators), stage='param-scan',
-                                         description="estimating %s" % str(estimator.__class__.__name__))
+        progress_reporter._progress_register(len(estimators), stage='param-scan',
+                                             description="estimating %s" % str(estimator.__class__.__name__))
 
     # TODO: test on win, osx
     if n_jobs > 1 and os.name == 'posix':
@@ -363,7 +364,8 @@ def estimate_param_scan(estimator, X, param_sets, evaluate=None, evaluate_args=N
             for estimator, param_set in zip(estimators, param_sets):
                 res.append(_estimate_param_scan_worker(estimator, param_set, X,
                                                        evaluate, evaluate_args, failfast, return_exceptions))
-                progress_reporter._progress_update(1, stage='param-scan')
+                if progress_reporter is not None:
+                    progress_reporter._progress_update(1, stage='param-scan')
 
     # done
     if return_estimators:

--- a/pyemma/msm/api.py
+++ b/pyemma/msm/api.py
@@ -61,7 +61,8 @@ __all__ = ['markov_model',
 # TODO: show_progress is not documented
 @shortcut('its')
 def timescales_msm(dtrajs, lags=None, nits=None, reversible=True, connected=True, weights='empirical',
-                   errors=None, nsamples=50, n_jobs=None, show_progress=True, mincount_connectivity='1/n'):
+                   errors=None, nsamples=50, n_jobs=None, show_progress=True, mincount_connectivity='1/n',
+                   only_timescales=False):
     # format data
     r""" Implied timescales from Markov state models estimated at a series of lag times.
 
@@ -124,6 +125,11 @@ def timescales_msm(dtrajs, lags=None, nits=None, reversible=True, connected=True
         Counts lower than that will count zero in the connectivity check and
         may thus separate the resulting transition matrix. The default
         evaluates to 1/nstates.
+
+    only_timescales: bool, default=False
+        If you are only interested in the timescales and its samples,
+        you can consider turning this on in order to save memory. This can be
+        useful to avoid blowing up memory with BayesianMSM and lots of samples.
 
     Returns
     -------
@@ -218,13 +224,13 @@ def timescales_msm(dtrajs, lags=None, nits=None, reversible=True, connected=True
         estimator = _Bayes_MSM(reversible=reversible, connectivity=connectivity,
                                nsamples=nsamples, show_progress=show_progress)
     else:
-        raise NotImplementedError('Error estimation method'+errors+'currently not implemented')
+        raise NotImplementedError('Error estimation method {errors} currently not implemented'.format(errors=errors))
 
     if hasattr(estimator, 'mincount_connectivity'):
         estimator.mincount_connectivity = mincount_connectivity
     # go
     itsobj = _ImpliedTimescales(estimator, lags=lags, nits=nits, n_jobs=n_jobs,
-                                show_progress=show_progress)
+                                show_progress=show_progress, only_timescales=only_timescales)
     itsobj.estimate(dtrajs)
     return itsobj
 

--- a/pyemma/msm/estimators/implied_timescales.py
+++ b/pyemma/msm/estimators/implied_timescales.py
@@ -77,6 +77,23 @@ def _hash_dtrajs(dtraj_list):
     return x
 
 
+class _DummyModel(object):
+    """ Used to encapsulate timescales and its samples in case we do not want to store the whole thing"""
+    __serialize_version = 0
+
+    def __init__(self, lag, timescales, ts_samples=None):
+        self.lag = lag
+        self._timescales = timescales
+        self._ts_samples = ts_samples
+
+    def timescales(self):
+        return self._timescales
+
+    def sample_f(self, arg):  # duck-type SampledModel
+        assert arg == 'timescales'
+        return self._ts_samples
+
+
 # TODO: build a generic implied timescales estimate in _base, and make this a subclass (for dtrajs)
 # TODO: Timescales should be assigned by similar eigenvectors rather than by order
 # TODO: when requesting too long lagtimes, throw a warning and exclude lagtime from calculation, but compute the rest
@@ -109,7 +126,7 @@ class ImpliedTimescales(Estimator, NJobsMixIn, SerializableMixIn):
 
     """
     def __init__(self, estimator, lags=None, nits=None, n_jobs=None,
-                 show_progress=True):
+                 show_progress=True, only_timescales=False):
         # initialize
         self.estimator = get_estimator(estimator)
         self.nits = nits
@@ -125,6 +142,8 @@ class ImpliedTimescales(Estimator, NJobsMixIn, SerializableMixIn):
         self._its_samples = None
         # fingerprint of the last estimate input.
         self._last_dtrajs_input_hash = None
+
+        self.only_timescales = only_timescales
 
     def estimate(self, X, **params):
         """
@@ -202,13 +221,33 @@ class ImpliedTimescales(Estimator, NJobsMixIn, SerializableMixIn):
         # run estimation on all lag times
         pg = ProgressReporter()
         with pg.context():
-            models, estimators = estimate_param_scan(self.estimator, dtrajs, param_sets, failfast=False,
+            if not self.only_timescales:
+                models, estimators = estimate_param_scan(self.estimator, dtrajs, param_sets, failfast=False,
                                                      return_estimators=True, n_jobs=self.n_jobs,
                                                      progress_reporter=pg, return_exceptions=True)
-        self._estimators = estimators
+                self._estimators = estimators
+            else:
+                evaluate = ['timescales']
+                evaluate_args = [[self.nits]]
+                if self._estimator_produces_samples():
+                    evaluate.append('sample_f')
+                    evaluate_args.append('timescales')
+                results = estimate_param_scan(self.estimator, dtrajs, param_sets, failfast=False,
+                                              return_estimators=False, n_jobs=self.n_jobs,
+                                              evaluate=evaluate,
+                                              evaluate_args=evaluate_args,
+                                              progress_reporter=pg, return_exceptions=True, )
 
-        self._postprocess_results(models)
+                if self._estimator_produces_samples():
+                    models = [_DummyModel(lag, ts, ts_sample) for lag, (ts, ts_sample) in zip(lags, results)]
+                else:
+                    models = [_DummyModel(lag, ts, None, ) for lag, ts in zip(lags, results)]
+            self._postprocess_results(models)
+
         return self
+
+    def _estimator_produces_samples(self):
+        return hasattr(self.estimator, 'sample_f')
 
     def _postprocess_results(self, models):
         ### PROCESS RESULTS
@@ -268,7 +307,7 @@ class ImpliedTimescales(Estimator, NJobsMixIn, SerializableMixIn):
             computed_all = False
 
         # timescales samples if available
-        if isinstance(models[0], SampledModel):
+        if self._estimator_produces_samples():
             # samples
             timescales_samples = [m.sample_f('timescales') for m in models]
             nsamples = np.shape(timescales_samples[0])[0]
@@ -507,6 +546,8 @@ class ImpliedTimescales(Estimator, NJobsMixIn, SerializableMixIn):
         r"""Returns the estimators for all lagtimes.
 
         """
+        if self.only_timescales:
+            raise RuntimeError('You requested only to save timescales and its samples upon estimation')
         return [self._estimators[i] for i in self._successful_lag_indexes]
 
     @property
@@ -514,6 +555,8 @@ class ImpliedTimescales(Estimator, NJobsMixIn, SerializableMixIn):
         r"""Returns the models for all lagtimes.
 
         """
+        if self.only_timescales:
+            raise RuntimeError('You requested only to save timescales and its samples upon estimation')
         return [self._models[i] for i in self._successful_lag_indexes]
 
     @property

--- a/pyemma/msm/tests/test_its.py
+++ b/pyemma/msm/tests/test_its.py
@@ -29,6 +29,8 @@ import unittest
 import numpy as np
 from pyemma import msm
 from msmtools.analysis import timescales
+
+from pyemma.msm import ImpliedTimescales
 from pyemma.msm.api import timescales_msm
 
 
@@ -215,6 +217,33 @@ class TestITS_MSM(unittest.TestCase):
         with self.assertRaises(RuntimeError) as e:
             timescales_msm(dtraj_disconnected, lags=[1, 2, 3, 4, 5])
         self.assertIn('negative row index', e.exception.args[0])
+
+    def test_no_return_estimators_samples(self):
+        lags = [1, 2, 3, 10, 20]
+        nstates = 10
+        nits = 3
+        its = timescales_msm(dtrajs=np.random.randint(0, nstates, size=1000), lags=lags,
+                             only_timescales=True, nits=nits, nsamples=2, errors='bayes')
+        with self.assertRaises(RuntimeError):
+            its.estimators
+        with self.assertRaises(RuntimeError):
+            its.models
+        assert isinstance(its.timescales, np.ndarray)
+        assert its.timescales.shape == (len(lags), nstates - 1 if nstates == nits else nits)
+        assert its.samples_available
+
+    def test_no_return_estimators(self):
+        lags = [1, 2, 3, 10, 20]
+        nstates = 10
+        nits = 3
+        its = timescales_msm(dtrajs=np.random.randint(0, nstates, size=1000), lags=lags,
+                             only_timescales=True, nits=nits)
+        with self.assertRaises(RuntimeError):
+            its.estimators
+        with self.assertRaises(RuntimeError):
+            its.models
+        assert isinstance(its.timescales, np.ndarray)
+        assert its.timescales.shape == (len(lags), nstates - 1 if nstates == nits else nits)
 
 
 class TestITS_AllEstimators(unittest.TestCase):

--- a/pyemma/msm/tests/test_msm_serialization.py
+++ b/pyemma/msm/tests/test_msm_serialization.py
@@ -37,7 +37,7 @@ class TestMSMSerialization(unittest.TestCase):
         # coarse-grain microstates to two metastable states
         cg = np.zeros(100, dtype=int)
         cg[50:] = 1
-        obs_macro = cg[cls.obs_micro]
+        cls.obs_macro = cg[cls.obs_micro]
         # hidden states
         cls.nstates = 2
         # samples
@@ -46,9 +46,8 @@ class TestMSMSerialization(unittest.TestCase):
         cls.lag = 100
 
         cls.msm = datasets.load_2well_discrete().msm
-        cls.bmsm_rev = bayesian_markov_model(obs_macro, cls.lag,
+        cls.bmsm_rev = bayesian_markov_model(cls.obs_macro, cls.lag,
                                              reversible=True, nsamples=cls.nsamples)
-        cls.oom = pyemma.msm.estimate_markov_model(obs_macro, cls.lag, weights='oom')
 
     def setUp(self):
         self.f = tempfile.mktemp()
@@ -226,6 +225,18 @@ class TestMSMSerialization(unittest.TestCase):
         np.testing.assert_equal(restored.timescales, its.timescales)
         np.testing.assert_equal(restored.sample_mean, its.sample_mean)
 
+    def test_its_sampled_only_ts(self):
+        lags = [1, 3]
+        its = pyemma.msm.timescales_msm(self.obs_micro, lags=lags, errors='bayes', nsamples=2, only_timescales=True)
+
+        its.save(self.f)
+        restored = load(self.f)
+
+        self.assertEqual(restored.estimator.get_params(deep=False), its.estimator.get_params(deep=False))
+        np.testing.assert_equal(restored.lags, its.lags)
+        np.testing.assert_equal(restored.timescales, its.timescales)
+        np.testing.assert_equal(restored.sample_mean, its.sample_mean)
+
     def test_cktest(self):
         ck = self.bmsm_rev.cktest(nsets=2, mlags=[1, 3])
 
@@ -239,14 +250,16 @@ class TestMSMSerialization(unittest.TestCase):
         np.testing.assert_equal(restored.estimates_conf, ck.estimates_conf)
 
     def test_oom(self):
-        self.oom.save(self.f)
+        oom = pyemma.msm.estimate_markov_model(self.obs_macro, self.lag, weights='oom')
+
+        oom.save(self.f)
 
         restored = load(self.f)
-        np.testing.assert_equal(self.oom.eigenvalues_OOM, restored.eigenvalues_OOM)
-        np.testing.assert_equal(self.oom.timescales_OOM, restored.timescales_OOM)
-        np.testing.assert_equal(self.oom.OOM_rank, restored.OOM_rank)
-        np.testing.assert_equal(self.oom.OOM_omega, restored.OOM_omega)
-        np.testing.assert_equal(self.oom.OOM_sigma, restored.OOM_sigma)
+        np.testing.assert_equal(oom.eigenvalues_OOM, restored.eigenvalues_OOM)
+        np.testing.assert_equal(oom.timescales_OOM, restored.timescales_OOM)
+        np.testing.assert_equal(oom.OOM_rank, restored.OOM_rank)
+        np.testing.assert_equal(oom.OOM_omega, restored.OOM_omega)
+        np.testing.assert_equal(oom.OOM_sigma, restored.OOM_sigma)
 
     def test_ml_msm_sparse(self):
         from pyemma.util.contexts import numpy_random_seed

--- a/pyemma/plots/tests/test_its.py
+++ b/pyemma/plots/tests/test_its.py
@@ -26,9 +26,10 @@ from __future__ import absolute_import
 import unittest
 import numpy as np
 
-from pyemma.msm import its, MaximumLikelihoodMSM, ImpliedTimescales
+from pyemma.msm import MaximumLikelihoodMSM, ImpliedTimescales
 from pyemma.plots import plot_implied_timescales
 from msmtools.generation import generate_traj
+
 
 class TestItsPlot(unittest.TestCase):
 
@@ -41,10 +42,10 @@ class TestItsPlot(unittest.TestCase):
                       ])
         # bogus its object
         lags = [1, 2, 3, 5, 10]
-        dtraj = generate_traj(P, 1000)
-        estimator = MaximumLikelihoodMSM(dt_traj='10 ps')
-        cls.its = ImpliedTimescales(estimator=estimator)
-        cls.its.estimate(dtraj, lags=lags)
+        cls.dtraj = generate_traj(P, 1000)
+        cls.estimator = MaximumLikelihoodMSM(dt_traj='10 ps')
+        cls.its = ImpliedTimescales(estimator=cls.estimator)
+        cls.its.estimate(cls.dtraj, lags=lags)
 
         cls.refs = cls.its.timescales[-1]
         return cls
@@ -56,8 +57,20 @@ class TestItsPlot(unittest.TestCase):
     def test_nits(self):
         plot_implied_timescales(self.its,
                                 refs=self.refs, nits=2)
+
     def test_process(self):
-        plot_implied_timescales(self.its, refs=self.refs, process=[1,2], dt=0.01, units='ns')
+        plot_implied_timescales(self.its, refs=self.refs, process=[1, 2], dt=0.01, units='ns')
+
+    def test_its_estimated_with_only_ts(self):
+        its = ImpliedTimescales(estimator=self.estimator, lags=[1, 2, 3], only_timescales=True)
+        its.estimate(self.dtraj)
+        plot_implied_timescales(its)
+
+    def test_its_estimated_with_only_ts_samples(self):
+        from pyemma.msm import BayesianMSM
+        its = ImpliedTimescales(estimator=BayesianMSM(nsamples=2), lags=[1, 2, 3], only_timescales=True)
+        its.estimate(self.dtraj)
+        plot_implied_timescales(its)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Avoid blowing up memory, if one estimates ITS with BMSM and lots of
states and or samples.