### PR TITLE
[coordinates/source] do not probe h5 file for mdtraj.HDF5TrajectoryFile

### DIFF
--- a/pyemma/coordinates/data/feature_reader.py
+++ b/pyemma/coordinates/data/feature_reader.py
@@ -22,7 +22,7 @@ import mdtraj
 import numpy as np
 
 from pyemma._base.serialization.serialization import SerializableMixIn
-from pyemma.coordinates.data._base.datasource import DataSourceIterator, DataSource, EncapsulatedIterator
+from pyemma.coordinates.data._base.datasource import DataSource, EncapsulatedIterator
 from pyemma.coordinates.data._base.random_accessible import RandomAccessStrategy
 from pyemma.coordinates.data.featurization.featurizer import MDFeaturizer
 from pyemma.coordinates.data.util.traj_info_cache import TrajInfo
@@ -133,7 +133,7 @@ class FeatureReader(DataSource, SerializableMixIn):
             length = len(fh)
             frame = fh.read(1)[0]
             ndim = np.shape(frame)[1]
-            offsets = fh.offsets if hasattr(fh, 'offsets') else []
+            offsets = fh.offsets if hasattr(fh, 'offsets') else ()
 
         return TrajInfo(ndim, length, offsets)
 

--- a/pyemma/coordinates/tests/test_readers.py
+++ b/pyemma/coordinates/tests/test_readers.py
@@ -123,7 +123,7 @@ class TestReaders(six.with_metaclass(GenerateTestMatrix, unittest.TestCase)):
                     'xtc',
                     'trr',
                     'dcd',
-                    'h5',
+                    'h5',  # pyemma H5Reader
                     'csv',
                     )
     # transform data or not (identity does not change the data, but pushes it through a StreamingTransformer).
@@ -178,6 +178,16 @@ class TestReaders(six.with_metaclass(GenerateTestMatrix, unittest.TestCase)):
     @classmethod
     def teardown_class(cls):
         shutil.rmtree(cls.tempdir, ignore_errors=True)
+
+    # H5Reader does not need a topology (and gets only selected in case we do not pass it).
+    def setUp(self):
+        if 'h5' in self._testMethodName:
+            self.pdb_file_bak = self.pdb_file
+            self.pdb_file = None
+
+    def tearDown(self):
+        if 'h5' in self._testMethodName:
+            self.pdb_file = self.pdb_file_bak
 
     def _test_lagged_reader(self, file_format, stride, skip, chunksize, lag):
         trajs = self.test_trajs[file_format]


### PR DESCRIPTION
The exception triggering and catching was too broad/unspecific to be
triggered in certain cases.

Now we just check, if the user wants to read MD data by checking if
either a topology or a featurizer has been given.