### PR TITLE
[config] forcefully enable coordinates_check_output

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - scipy
     - setuptools
     # use build flags (eg. CFLAGS etc) from conda-forge
-    - toolchain
+    #- toolchain
     - pybind11
 
   run:

--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -15,6 +15,7 @@ Changelog
 - msm: fix connected sets for Bayesian MSMs in case the mincount connectivity (ergodic cutoff) parameter truncated
   the count matrix. #1343
 - plots: fix vmin, vmax keyword arguments for plot_contour(). #1376
+- coordinates: forcefully enable checking of coordinates data streaming for invalid (not initialized) data. #1384
 
 
 

--- a/pyemma/coordinates/tests/test_readers.py
+++ b/pyemma/coordinates/tests/test_readers.py
@@ -45,6 +45,7 @@ class GenerateTestMatrix(type):
                 vals_str = '_'.join((str(v) if not isinstance(v, np.ndarray) else 'array' for v in param_set.values()))
                 assert '[' not in vals_str, 'this char makes pytest think it has to extract parameters out of the testname.'
                 out_name = '{}_{}'.format(test[1:], vals_str)
+                func.__qualname__ = 'TestReaders.{}'.format(out_name)
                 new_test_methods[out_name] = func
 
         attr.update(new_test_methods)

--- a/pyemma/util/_config.py
+++ b/pyemma/util/_config.py
@@ -339,15 +339,19 @@ class Config(object):
         self._conf_values.set('pyemma', 'show_config_notification', str(val))
 
     @property
-    @_cached
     def coordinates_check_output(self):
-        """ Enabling this option will check for invalid output (NaN, Inf) in pyemma.coordinates """
-        return self._conf_values.getboolean('pyemma', 'coordinates_check_output')
+        """ Enabling this option will check for invalid output (NaN, Inf) in pyemma.coordinates.
+
+        Notes
+        -----
+        This setting is on by default by PyEMMA version 2.5.5
+        """
+        return True
 
     @coordinates_check_output.setter
-    @_invalidate_cache
-    def coordinates_check_output(self, val):
-        self._conf_values.set('pyemma', 'coordinates_check_output', str(val))
+    def coordinates_check_output(self, _):
+        import warnings
+        warnings.warn('{d} disabling output checking has been disabled for very good reasons. {d}'.format(d=u'\U00002620'))
 
     @property
     @_cached

--- a/pyemma/util/_config.py
+++ b/pyemma/util/_config.py
@@ -350,8 +350,9 @@ class Config(object):
 
     @coordinates_check_output.setter
     def coordinates_check_output(self, _):
-        import warnings
-        warnings.warn('{d} disabling output checking has been disabled for very good reasons. {d}'.format(d=u'\U00002620'))
+        import warnings, sys
+        warnings.warn('{d}Changing the setting for output checking has been disabled for very good reasons.{d}'
+                      .format(d=u' \U00002620 ' if sys.version_info[0] == 3 else ''))
 
     @property
     @_cached

--- a/setup_util.py
+++ b/setup_util.py
@@ -210,5 +210,5 @@ class get_pybind_include(object):
     def __str__(self):
         result = self.search_pybind11_headers()
         if not result:
-            raise RuntimeError()
+            raise RuntimeError('pybind11 headers not found')
         return result


### PR DESCRIPTION
If there is a bug in mdtraj, it is much easier to hunt it down,
when this setting is not a user choice. The performance impact is
minimal.