### PR TITLE
Make left singular functions the default in VAMP

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -17,13 +17,16 @@ Changelog
   the count matrix. :pr:`1343`
 - plots: fix vmin, vmax keyword arguments for plot_contour(). :pr:`1376`
 - coordinates: forcefully enable checking of coordinates data streaming for invalid (not initialized) data. :pr:`1384`
-- coordinates: for sake of faster strided MD data reading, we now require a version of MDTraj >= 1.9.2:pr:`1391` 
-
+- coordinates: for sake of faster strided MD data reading, we now require a version of MDTraj >= 1.9.2 :pr:`1391` 
+- coordinates: VAMP: changed default projection vector from right to left, since only the left singular functions induce
+  a kinetic map wrt. the conventional forward propagator, while the right singular functions induce
+  a kinetic map wrt. the backward propagator. :pr:`1394`
 
 
 **Contributors**:
 
 - :user:`marscher`
+- :user:`fabian-paul`
 
 
 2.5.4 (07-20-2018)

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -1291,9 +1291,9 @@ def vamp(data=None, lag=10, dim=None, scaling=None, right=False, ncov_max=float(
 
           * None: no scaling will be applied, variance of the order parameters is 1
           * 'kinetic map' or 'km': order parameters are scaled by singular value.
-            Only the left singular functions induce a kinetic map.
-            Therefore scaling='km' is only effective if `right` is False.
-      right : boolean
+            Only the left singular functions induce a kinetic map wrt the
+            conventional forward propagator. The right singular functions induce
+            a kinetic map wrt the backward propagator.      right : boolean
           Whether to compute the right singular functions.
           If `right==True`, `get_output()` will return the right singular
           functions. Otherwise, `get_output()` will return the left singular
@@ -1315,6 +1315,14 @@ def vamp(data=None, lag=10, dim=None, scaling=None, right=False, ncov_max=float(
       ncov_max : int, default=infinity
           limit the memory usage of the algorithm from [3]_ to an amount that corresponds
           to ncov_max additional copies of each correlation matrix
+
+      Returns
+      -------
+      vamp : a :class:`VAMP <pyemma.coordinates.transform.VAMP>` transformation object
+         It contains the definitions of singular functions and singular values and
+         can be used to project input data to the dominant VAMP components, predict
+         expectations and time-lagged covariances and perform a Chapman-Kolmogorov
+         test.
 
       Notes
       -----

--- a/pyemma/coordinates/api.py
+++ b/pyemma/coordinates/api.py
@@ -1267,7 +1267,7 @@ def tica(data=None, lag=10, dim=-1, var_cutoff=0.95, kinetic_map=True, commute_m
     return res
 
 
-def vamp(data=None, lag=10, dim=None, scaling=None, right=True, ncov_max=float('inf'),
+def vamp(data=None, lag=10, dim=None, scaling=None, right=False, ncov_max=float('inf'),
          stride=1, skip=0, chunksize=None):
     r""" Variational approach for Markov processes (VAMP) [1]_.
 

--- a/pyemma/coordinates/tests/test_vamp.py
+++ b/pyemma/coordinates/tests/test_vamp.py
@@ -260,8 +260,8 @@ class TestVAMPModel(unittest.TestCase):
         assert error < 0.05
 
     def test_CK_covariances_against_MSM(self):
-        obs = np.eye(3) # observe every state
-        sta = np.eye(3) # restrict p0 to every state
+        obs = np.eye(3)  # observe every state
+        sta = np.eye(3)  # restrict p0 to every state
         cktest = self.vamp.cktest(observables=obs, statistics=sta, mlags=4, show_progress=True)
         pred = cktest.predictions[1:]
         est = cktest.estimates[1:]
@@ -286,7 +286,6 @@ class TestVAMPModel(unittest.TestCase):
         s1 = self.vamp.score(score_method='VAMP1')
         np.testing.assert_allclose(s1, Nnuc)
 
-        # TODO: check why this is not equal
         sE = self.vamp.score(score_method='VAMPE')
         np.testing.assert_allclose(sE, NFro)  # see paper appendix H.2
 
@@ -323,7 +322,7 @@ class TestVAMPModel(unittest.TestCase):
 class TestVAMPWithEdgeCaseData(unittest.TestCase):
     def test_1D_data(self):
         x = np.random.randn(10, 1)
-        vamp = pyemma_api_vamp([x], 1)  # just test that this doesn't raise
+        vamp = pyemma_api_vamp([x], 1, right=True)  # just test that this doesn't raise
         # Doing VAMP with 1-D data is just centering and normalizing the data.
         assert_allclose_ignore_phase(vamp.get_output()[0], (x - np.mean(x[1:, 0])) / np.std(x[1:, 0]))
 

--- a/pyemma/coordinates/transform/vamp.py
+++ b/pyemma/coordinates/transform/vamp.py
@@ -401,8 +401,9 @@ class VAMP(StreamingEstimationTransformer, SerializableMixIn):
 
               * None: no scaling will be applied, variance of the order parameters is 1
               * 'kinetic map' or 'km': order parameters are scaled by singular value.
-                Only the left singular functions induce a kinetic map.
-                Therefore scaling='km' is only effective if `right` is False.
+                Only the left singular functions induce a kinetic map wrt the
+                conventional forward propagator. The right singular functions induce
+                a kinetic map wrt the backward propagator.
           right : boolean
               Whether to compute the right singular functions.
               If `right==True`, `get_output()` will return the right singular

--- a/pyemma/coordinates/transform/vamp.py
+++ b/pyemma/coordinates/transform/vamp.py
@@ -294,7 +294,8 @@ class VAMPModel(Model, SerializableMixIn):
 
         # scale vectors
         if self.scaling is not None:
-            U *= s[np.newaxis, 0:m]
+            U *= s[np.newaxis, 0:m]  # scaled left singular functions induce a kinetic map
+            V *= s[np.newaxis, 0:m]  # scaled right singular functions induce a kinetic map wrt. backward propagator
 
         self._U = U
         self._V = V
@@ -376,7 +377,7 @@ class VAMP(StreamingEstimationTransformer, SerializableMixIn):
     def describe(self):
         return "[VAMP, lag = %i; max. output dim. = %s]" % (self._lag, str(self.dim))
 
-    def __init__(self, lag, dim=None, scaling=None, right=True, epsilon=1e-6,
+    def __init__(self, lag, dim=None, scaling=None, right=False, epsilon=1e-6,
                  stride=1, skip=0, ncov_max=float('inf')):
         r""" Variational approach for Markov processes (VAMP) [1]_.
 


### PR DESCRIPTION
Make left singular functions the default in VAMP. Also added kinetic map scaling of the right singular functions if the user wants it.