### PR TITLE
Vamp fix varcut cutoff

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -15,9 +15,7 @@ build:
    - CIRCLE_TEST_REPORTS
    - OMP_NUM_THREADS
    - PYEMMA_NJOBS
-  script: python setup.py install --single-version-externally-managed --record record.txt
-  # workaround for bpo-24935, the compiler jinja2 template sets CC, but LDSHARED is not being set accordingly by distutils.sysconfig.
-  script: LDSHARED="$CC -shared" python setup.py install --single-version-externally-managed --record record.txt # [linux]
+  script: pip install .  --ignore-dependencies
 
 requirements:
   build:
@@ -34,8 +32,7 @@ requirements:
     - python
     - scipy
     - setuptools
-    # use build flags (eg. CFLAGS etc) from conda-forge
-    #- toolchain
+    - pip
     - pybind11
 
   run:
@@ -45,7 +42,6 @@ requirements:
     - intel-openmp # [osx]
     - matplotlib
     - mdtraj >=1.8
-    - mock # TODO: remove when py3k only.
     - msmtools >=1.2
     - {{ pin_compatible('numpy') }}
     - pathos
@@ -54,9 +50,7 @@ requirements:
     - pyyaml
     - scipy
     - setuptools
-    - six >=1.10
     - tqdm
-    - progress_reporter >=2
 
 test:
   source_files:

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
    - CIRCLE_TEST_REPORTS
    - OMP_NUM_THREADS
    - PYEMMA_NJOBS
-  script: pip install .  --ignore-dependencies
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
 
 requirements:
   build:

--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 2.5.5 (??-??-????)
 ------------------
 
-This version only supports Python 3.
+For now all future versions will only support Python 3. :pr:`1395`
 
 **New features**:
 
@@ -23,6 +23,7 @@ This version only supports Python 3.
 - coordinates: VAMP: changed default projection vector from right to left, since only the left singular functions induce
   a kinetic map wrt. the conventional forward propagator, while the right singular functions induce
   a kinetic map wrt. the backward propagator. :pr:`1394`
+- coordinates: VAMP: fixed variance cutoff to really include as many dimensions to meet subspace variance criterion. :pr:`1397`
 
 
 **Contributors**:

--- a/pyemma/__init__.py
+++ b/pyemma/__init__.py
@@ -44,7 +44,7 @@ def _version_check(current, testing=False):
 
     Can be disabled by setting config.check_version = False.
 
-    >>> from mock import patch
+    >>> from unittest.mock import patch
     >>> import warnings, pyemma
     >>> with warnings.catch_warnings(record=True) as cw, patch('pyemma.version', '0.1'):
     ...     warnings.simplefilter('always', UserWarning)

--- a/pyemma/_base/estimator.py
+++ b/pyemma/_base/estimator.py
@@ -311,8 +311,7 @@ def estimate_param_scan(estimator, X, param_sets, evaluate=None, evaluate_args=N
     if logger_available:
         logger = estimators[0].logger
     if progress_reporter is None:
-        from mock import MagicMock
-        # TODO: replace with nullcontext from util once merged
+        from unittest.mock import MagicMock
         ctx = progress_reporter = MagicMock()
         callback = None
     else:

--- a/pyemma/coordinates/clustering/tests/test_assign.py
+++ b/pyemma/coordinates/clustering/tests/test_assign.py
@@ -20,7 +20,7 @@ import os
 import unittest
 from contextlib import contextmanager
 
-from mock import patch
+from unittest.mock import patch
 from pyemma.util.files import TemporaryDirectory
 from logging import getLogger
 

--- a/pyemma/coordinates/tests/test_random_access_stride.py
+++ b/pyemma/coordinates/tests/test_random_access_stride.py
@@ -469,7 +469,7 @@ class TestRandomAccessStride(TestCase):
         for ext in savable_formats_mdtra_18:
             traj = create_traj(length=n, dir=self.tmpdir, format=ext)[0]
 
-            from mock import patch
+            from unittest.mock import patch
             # temporarily overwrite the memory cutoff with a smaller value, to trigger the switch to RA stride.
             with patch('pyemma.coordinates.util.patches.iterload.MEMORY_CUTOFF', n_bytes - 1):
                 r = coor.source(traj, top=get_top())

--- a/pyemma/coordinates/tests/test_traj_info_cache.py
+++ b/pyemma/coordinates/tests/test_traj_info_cache.py
@@ -27,7 +27,7 @@ import os
 import tempfile
 import unittest
 
-import mock
+from unittest import mock
 
 from pyemma.coordinates import api
 from pyemma.coordinates.data.feature_reader import FeatureReader

--- a/pyemma/coordinates/tests/test_vamp.py
+++ b/pyemma/coordinates/tests/test_vamp.py
@@ -237,6 +237,17 @@ class TestVAMPModel(unittest.TestCase):
             np.testing.assert_allclose(np.diag(p), np.diag(r), atol=1E-6)
             np.testing.assert_allclose(np.abs(p), np.abs(r), atol=1E-6)
 
+        cumsum_Tsym = np.cumsum(S[1:] ** 2)
+        cumsum_Tsym /= cumsum_Tsym[-1]
+        np.testing.assert_allclose(self.vamp.cumvar, cumsum_Tsym)
+
+    def test_cumvar_variance_cutoff(self):
+        for d in (0.2, 0.5, 0.8, 0.9, 1.0):
+            self.vamp.dim = d
+            special_cumvar = np.asarray([0] + self.vamp.cumvar.tolist())
+            self.assertLessEqual(d, special_cumvar[self.vamp.dimension()],)
+            self.assertLessEqual(special_cumvar[self.vamp.dimension() - 1], d)
+
     def test_CK_expectation_against_MSM(self):
         obs = np.eye(3) # observe every state
         cktest = self.vamp.cktest(observables=obs, statistics=None, mlags=4)

--- a/pyemma/coordinates/transform/vamp.py
+++ b/pyemma/coordinates/transform/vamp.py
@@ -131,7 +131,7 @@ class VAMPModel(Model, SerializableMixIn):
         if dim is None or (isinstance(dim, float) and dim == 1.0):
             return min(rank0, rankt)
         if isinstance(dim, float):
-            return np.count_nonzero(VAMPModel._cumvar(singular_values) >= dim)
+            return np.searchsorted(VAMPModel._cumvar(singular_values), dim) + 1
         else:
             return np.min([rank0, rankt, dim])
 

--- a/pyemma/msm/tests/test_estimator.py
+++ b/pyemma/msm/tests/test_estimator.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
 import unittest
-import mock
+from unittest import mock
 from pyemma import msm
 from functools import wraps
 

--- a/pyemma/util/tests/test_config.py
+++ b/pyemma/util/tests/test_config.py
@@ -171,7 +171,7 @@ class TestConfig(unittest.TestCase):
     def test_mute_progress(self):
         """ switch mute on shall turn off progress bars"""
         from pyemma._base.progress import ProgressReporterMixin
-        import mock
+        from unittest import mock
         rp = ProgressReporterMixin()
 
         self.config_inst.mute = True

--- a/pyemma/util/tests/test_log.py
+++ b/pyemma/util/tests/test_log.py
@@ -27,7 +27,7 @@ import logging
 
 from pyemma.util import log
 from pyemma.util import config
-import mock
+from unittest import mock
 
 
 class TestNonWriteableLogFile(unittest.TestCase):


### PR DESCRIPTION
The variance cutoff yielded bogus results like:
``` python
for d in (0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.99, 1.0):
    vamp_dists.dim = d
    print('var cutoff:', d, 'dimensions:', vamp_dists.dimension() )
```
```
var cutoff: 0.5 dimensions: 159
var cutoff: 0.6 dimensions: 145
var cutoff: 0.7 dimensions: 129
var cutoff: 0.8 dimensions: 109
var cutoff: 0.9 dimensions: 82
var cutoff: 0.95 dimensions: 62
var cutoff: 0.99 dimensions: 37
var cutoff: 1.0 dimensions: 210
```

also removed references to mock and six.