### PR TITLE
[msm] remove dead code

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+image: Visual Studio 2015
+platform: x64
 environment:
   global:
     PYTHONHASHSEED: "0"
@@ -12,17 +14,20 @@ environment:
       NUMPY: "" # numpy unpinned
 
 install:
+  - cmd: '"%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" %PLATFORM%'
+  - ps: if ($env:PLATFORM -eq "x64") { $env:CONDA = "$env:CONDA-x64" }
   - "SET PATH=%MINICONDA_PYTHON%;%MINICONDA_PYTHON%\\Scripts;%PATH%;"
-
-  - conda config --set always_yes true
+  - conda config --set always_yes true --set changeps1 no
+  - conda config --add channels conda-forge
+  - conda update -q conda
   - conda install -q conda-build=3
 
 build: false # Not a C# project, build stuff at the test step instead.
 
 test_script:
   # run testsuite and upload test results to AppVeyor; return exit code of testsuite
-  - setenv /release /x64
-  - conda build -c conda-forge -q devtools/conda-recipe %CONDA_NPY%"
+  # - setenv /release /x64
+  - conda build -q devtools/conda-recipe %CONDA_NPY%"
 
 on_finish:
   # upload test results to AppVeyor

--- a/pyemma/msm/estimators/_dtraj_stats.py
+++ b/pyemma/msm/estimators/_dtraj_stats.py
@@ -338,7 +338,7 @@ class DiscreteTrajectoryStats(object):
         self._assert_counted_at_lag()
         return self._lag
 
-    def count_matrix(self, connected_set=None, subset=None, effective=False):
+    def count_matrix(self, connected_set=None, subset=None):
         r"""The count matrix
 
         Parameters
@@ -348,16 +348,6 @@ class DiscreteTrajectoryStats(object):
             This parameter is exclusive with subset.
         subset : array-like of int or None, optional, default=None
             subset of states to compute the count matrix on. This parameter is exclusive with subset.
-        effective : bool, optional, default=False
-            Statistically uncorrelated transition counts within the active set of states.
-
-            You can use this count matrix for any kind of estimation, in particular it is meant to give reasonable
-            error bars in uncertainty measurements (error perturbation or Gibbs sampling of the posterior).
-
-            The effective count matrix is obtained by dividing the sliding-window count matrix by the lag time. This
-            can be shown to provide a likelihood that is the geometrical average over shifted subsamples of the trajectory,
-            :math:`(s_1,\:s_{\tau+1},\:...),\:(s_2,\:t_{\tau+2},\:...),` etc. This geometrical average converges to the
-            correct likelihood in the statistical limit [1]_.
 
         References
         ----------
@@ -377,10 +367,6 @@ class DiscreteTrajectoryStats(object):
         else: # full matrix wanted
             C = self._C
 
-        # effective count matrix wanted?
-        if effective:
-            C /= float(self._lag)
-
         return C
 
     @alias('hist_lagged')
@@ -397,11 +383,11 @@ class DiscreteTrajectoryStats(object):
         return h.sum()
 
     @property
-    def count_matrix_largest(self, effective=False):
+    def count_matrix_largest(self):
         """The count matrix on the largest connected set
 
         """
-        return self.count_matrix(connected_set=0, effective=effective)
+        return self.count_matrix(connected_set=0)
 
     @property
     def largest_connected_set(self):


### PR DESCRIPTION
effective count matrix estimation conducted with statistical
inefficiencies, not by dividing by lag time. this part of
the code is not used at all. removed. thx @clonker 