### PR TITLE
Update types.py

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,4 @@ Stephan Doerr
 Simon Olsson
 Brooke Husic
 Tim Hempel
+Sander Roet

--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -14,7 +14,8 @@ Changelog
 - serialization: fixed bug in function which checked for h5 serialization options.
 - :code:`n_jobs` is handled consistently, allows only for :code:`None` or positive integers and when
   determined from hardware, falls back to logical number of cpus. :pr:`1488`
-
+- import from :code:`collections.abc` instead of base :code:`collections`
+  :pr:`1503`
 
 2.5.7 (9-24-2019)
 -----------------

--- a/pyemma/util/types.py
+++ b/pyemma/util/types.py
@@ -140,7 +140,7 @@ def is_string(s):
     return isinstance(s, str)
 
 def is_iterable(I):
-    return isinstance(I, collections.Iterable)
+    return isinstance(I, collections.abc.Iterable)
 
 def is_list(S):
     # FIXME: name states check for list, but checks for tuple __and__ list. Thats confusing.


### PR DESCRIPTION
A test for a downstream project is showing the following `DeprecationWarning`:
```python
/home/sroet/miniconda3/envs/python3/lib/python3.9/site-packages/pyemma/util/types.py:143: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    return isinstance(I, collections.Iterable)
```
This fixes that Deprectation warning


Thanks for submitting a PR, your contribution is really appreciated!

Here's a quick checklist that should be present in PRs:

- [NA] Make sure to include one or more tests for your change
- [x] Add yourself to `AUTHORS`
- [x] Add a new entry to the `doc/source/CHANGELOG` (choose any open position to avoid merge conflicts with other PRs).
      Decide whether your change is a fix or a new feature.
