### PR TITLE
Use int instead of numpy.int

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,3 +25,4 @@ Stephan Doerr
 Simon Olsson
 Brooke Husic
 Tim Hempel
+Sander Roet

--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -14,7 +14,8 @@ Changelog
 - serialization: fixed bug in function which checked for h5 serialization options.
 - :code:`n_jobs` is handled consistently, allows only for :code:`None` or positive integers and when
   determined from hardware, falls back to logical number of cpus. :pr:`1488`
-
+- Use :code:`int` instead of :code:`numpy.int` to solve :code:`numpy` 1.20
+  DeprecationWarning :pr:`1504`
 
 2.5.7 (9-24-2019)
 -----------------

--- a/pyemma/coordinates/data/featurization/featurizer.py
+++ b/pyemma/coordinates/data/featurization/featurizer.py
@@ -237,7 +237,7 @@ class MDFeaturizer(SerializableMixIn, Loggable):
         """ensure pairs are valid (shapes, all atom indices available?, etc.)
         """
 
-        pair_inds = np.array(pair_inds).astype(dtype=np.int, casting='safe')
+        pair_inds = np.array(pair_inds).astype(dtype=int, casting='safe')
 
         if pair_inds.ndim != 2:
             raise ValueError("pair indices has to be a matrix.")


### PR DESCRIPTION
A test on a downstream project was showing Deprecation warnings from this code:

```
/home/sroet/miniconda3/envs/python3/lib/python3.9/site-packages/pyemma/coordinates/data/featurization/featurizer.py:240: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    pair_inds = np.array(pair_inds).astype(dtype=np.int, casting='safe')
```

This PR solves that warning with the most common solution (just use the unaliased `int`) 

- [NA] Make sure to include one or more tests for your change
- [X] Add yourself to `AUTHORS`
- [X] Add a new entry to the `doc/source/CHANGELOG` (choose any open position to avoid merge conflicts with other PRs).
      Decide whether your change is a fix or a new feature.
