### PR TITLE
Fix periodic width initialization in umbrella sampling

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,3 +26,4 @@ Simon Olsson
 Brooke Husic
 Tim Hempel
 Sander Roet
+Sebastian Falkner

--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -18,6 +18,7 @@ Changelog
   :pr:`1503`
 - Use :code:`int` instead of :code:`numpy.int` to solve :code:`numpy` 1.20
   DeprecationWarning :pr:`1504`
+- Umbrella sampling: fix periodic width initialization :pr:`1522`
 
 2.5.7 (9-24-2019)
 -----------------

--- a/pyemma/thermo/util/util.py
+++ b/pyemma/thermo/util/util.py
@@ -270,7 +270,7 @@ def get_umbrella_sampling_data(
     if width is None:
         width = _np.zeros(shape=(umbrella_centers.shape[1],), dtype=_np.float64)
     else:
-        width = _np.asarray(
+        width = _np.fromiter(
             map(lambda w: w if w is not None and w > 0.0 else 0.0, width),
             dtype=_np.float64)
     if width.shape[0] != umbrella_centers.shape[1]:


### PR DESCRIPTION
Running pyemma.thermo.estimate_umbrella_sampling with periodicity in a dimension leads to the error:

```
~/anaconda3/envs/pytorch/lib/python3.9/site-packages/pyemma/thermo/util/util.py in get_umbrella_sampling_data(us_trajs, us_centers, us_force_constants, md_trajs, kT, width)
    271         width = _np.zeros(shape=(umbrella_centers.shape[1],), dtype=_np.float64)
    272     else:
--> 273         width = _np.asarray(
    274             map(lambda w: w if w is not None and w > 0.0 else 0.0, width),
    275             dtype=_np.float64)

TypeError: float() argument must be a string or a number, not 'map'

```

np.asarray can't construct an array from an iterator anymore, np.fromiter should fix the problem.


- [ ] Make sure to include one or more tests for your change
- [x] Add yourself to `AUTHORS`
- [x] Add a new entry to the `doc/source/CHANGELOG` (choose any open position to avoid merge conflicts with other PRs).
      Decide whether your change is a fix or a new feature.
