### PR TITLE
Use spawn() for multiprocessing instead of fork()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -27,3 +27,4 @@ Brooke Husic
 Tim Hempel
 Sander Roet
 Sebastian Falkner
+Finn Krein

--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -19,7 +19,8 @@ Changelog
 - Use :code:`int` instead of :code:`numpy.int` to solve :code:`numpy` 1.20
   DeprecationWarning :pr:`1504`
 - Umbrella sampling: fix periodic width initialization :pr:`1522`
-- Solve 2 code:`SyntaxWarnings: "is" with a literal.` in utils/reader_utils.py :pr:`1530` 
+- Solve 2 code:`SyntaxWarnings: "is" with a literal.` in utils/reader_utils.py :pr:`1530`
+- Use spawn() for multiprocessing on linux instead of fork(), fixes worker processes sometimes going into idle for n_jobs>1 :pr:`1565`
 
 2.5.7 (9-24-2019)
 -----------------

--- a/pyemma/_base/estimator.py
+++ b/pyemma/_base/estimator.py
@@ -22,6 +22,9 @@ import inspect
 import sys
 import os
 
+from platform import system
+from multiprocess import get_context
+
 from threadpoolctl import threadpool_limits
 
 from pyemma._ext.sklearn.base import BaseEstimator as _BaseEstimator
@@ -339,8 +342,10 @@ def estimate_param_scan(estimator, X, param_sets, evaluate=None, evaluate_args=N
                       limit_threads)
                      for estimator, param_set in zip(estimators, param_sets))
 
-        from multiprocess import get_context
-        pool = get_context("spawn").Pool(processes=n_jobs)
+        if system() == "Linux":
+            pool = get_context("spawn").Pool(processes=n_jobs)
+        else:
+            pool = get_context().Pool(processes=n_jobs)
         args = list(task_iter)
 
         from contextlib import closing

--- a/pyemma/_base/estimator.py
+++ b/pyemma/_base/estimator.py
@@ -339,8 +339,8 @@ def estimate_param_scan(estimator, X, param_sets, evaluate=None, evaluate_args=N
                       limit_threads)
                      for estimator, param_set in zip(estimators, param_sets))
 
-        from pathos.multiprocessing import Pool
-        pool = Pool(processes=n_jobs)
+        from multiprocess import get_context
+        pool = get_context("spawn").Pool(processes=n_jobs)
         args = list(task_iter)
 
         from contextlib import closing


### PR DESCRIPTION
This PR changes the multiprocessing method used for the pool in `estimate_param_scan`.

### The issue
The reason for this PR is the following issue:
When using pyemma with n_jobs>1 and OpenBLAS I observed the worker processes getting stuck in lapack calls,
idling forever.  When using netlib blas or n_jobs=1 this problem did not occur.

This is likely due to OpenMP not supporting use in the main process AND forked processes, as explained [here](https://bisqwit.iki.fi/story/howto/openmp/).

### The fix
Setting the multiprocess start method to `spawn` for the pool fixes this issue.

### This is a breaking change
Using spawn requires guarding the main process with
```python
if __name__ == "__main__":
    #code 
```
For scripts this is best practice, but this PR would still break scripts which do not do this.

Common interactive contexts such as IPython or jupyter-notebook do this automatically and do not
require an explicit `if __name__ == "__main__":` statement.

### Checklist
- [ ] Make sure to include one or more tests for your change
- [x] Add yourself to `AUTHORS`
- [ ] Add a new entry to the `doc/source/CHANGELOG` (choose any open position to avoid merge conflicts with other PRs).
      Decide whether your change is a fix or a new feature.
