### PR TITLE
Substitute uses of numpy.bool with numpy.bool_

### DIFF
--- a/doc/source/CHANGELOG.rst
+++ b/doc/source/CHANGELOG.rst
@@ -21,6 +21,7 @@ Changelog
 - Umbrella sampling: fix periodic width initialization :pr:`1522`
 - Solve 2 code:`SyntaxWarnings: "is" with a literal.` in utils/reader_utils.py :pr:`1530`
 - Use spawn() for multiprocessing on linux instead of fork(), fixes worker processes sometimes going into idle for n_jobs>1 :pr:`1565`
+- Replace usage of :code:`numpy.bool` with :code:`numpy.bool_` to remain compatible with numpy>=1.20
 
 2.5.7 (9-24-2019)
 -----------------

--- a/pyemma/_ext/variational/estimators/covar_c/covartools.py
+++ b/pyemma/_ext/variational/estimators/covar_c/covartools.py
@@ -34,7 +34,7 @@ def variable_cols(X, tol=0.0, min_constant=0):
                                                                         variable_cols_long,
                                                                         variable_cols_char)
     # prepare column array
-    cols = numpy.zeros(X.shape[1], dtype=numpy.bool, order='C')
+    cols = numpy.zeros(X.shape[1], dtype=numpy.bool_, order='C')
 
     if X.dtype == numpy.float64:
         completed = variable_cols_double(cols, X, tol, min_constant)
@@ -44,13 +44,13 @@ def variable_cols(X, tol=0.0, min_constant=0):
         completed = variable_cols_int(cols, X, 0, min_constant)
     elif X.dtype == numpy.int64:
         completed = variable_cols_long(cols, X, 0, min_constant)
-    elif X.dtype == numpy.bool:
+    elif X.dtype == numpy.bool_:
         completed = variable_cols_char(cols, X, 0, min_constant)
     else:
         raise TypeError('unsupported type of X: %s' % X.dtype)
 
     # if interrupted, return all ones. Otherwise return the variable columns as bool array
     if completed == 0:
-        return numpy.ones_like(cols, dtype=numpy.bool)
+        return numpy.ones_like(cols, dtype=numpy.bool_)
 
     return cols

--- a/pyemma/_ext/variational/estimators/moments.py
+++ b/pyemma/_ext/variational/estimators/moments.py
@@ -531,10 +531,10 @@ def _M2(Xvar, Yvar, mask_X=None, mask_Y=None, xsum=0, xconst=0, ysum=0, yconst=0
     else:
         # Check if one of the masks is not None, modify it and also adjust the constant columns:
         if mask_X is None:
-            mask_X = np.ones(Xvar.shape[1], dtype=np.bool)
+            mask_X = np.ones(Xvar.shape[1], dtype=np.bool_)
             xconst = np.ones(0, dtype=float)
         if mask_Y is None:
-            mask_Y = np.ones(Yvar.shape[1], dtype=np.bool)
+            mask_Y = np.ones(Yvar.shape[1], dtype=np.bool_)
             yconst = np.ones(0, dtype=float)
     if _is_zero(xsum) and _is_zero(ysum) or _is_zero(xconst) and _is_zero(yconst):
         return _M2_sparse(Xvar, mask_X, Yvar, mask_Y, weights=weights)
@@ -560,10 +560,10 @@ def _M2_symmetric(Xvar, Yvar, mask_X=None, mask_Y=None, xsum=0, xconst=0, ysum=0
     else:
         # Check if one of the masks is not None, modify it and also adjust the constant columns:
         if mask_X is None:
-            mask_X = np.ones(Xvar.shape[1], dtype=np.bool)
+            mask_X = np.ones(Xvar.shape[1], dtype=np.bool_)
             xconst = np.ones(0, dtype=float)
         if mask_Y is None:
-            mask_Y = np.ones(Yvar.shape[1], dtype=np.bool)
+            mask_Y = np.ones(Yvar.shape[1], dtype=np.bool_)
             yconst = np.ones(0, dtype=float)
         if _is_zero(xsum) and _is_zero(ysum) or _is_zero(xconst) and _is_zero(yconst):
             Cxxyy, Cxyyx = _M2_sparse_sym(Xvar, mask_X, Yvar, mask_Y, weights=weights, column_selection=column_selection)

--- a/pyemma/_ext/variational/estimators/tests/test_moments.py
+++ b/pyemma/_ext/variational/estimators/tests/test_moments.py
@@ -35,10 +35,10 @@ class TestMoments(unittest.TestCase):
         cls.Y_100_sparseconst[:, :10] = cls.Y_100[:, :10]
         # boolean data
         cls.Xb_2 = np.random.randint(0, 2, size=(10000, 2))
-        cls.Xb_2 = cls.Xb_2.astype(np.bool)
+        cls.Xb_2 = cls.Xb_2.astype(np.bool_)
         cls.Xb_10 = np.random.randint(0, 2, size=(10000, 10))
-        cls.Xb_10 = cls.Xb_10.astype(np.bool)
-        cls.Xb_10_sparsezero = np.zeros((10000, 10), dtype=np.bool)
+        cls.Xb_10 = cls.Xb_10.astype(np.bool_)
+        cls.Xb_10_sparsezero = np.zeros((10000, 10), dtype=np.bool_)
         cls.Xb_10_sparsezero[:, 0] = cls.Xb_10[:, 0]
         # generate weights:
         cls.weights = np.random.rand(10000)


### PR DESCRIPTION
Substitute uses of numpy.bool with numpy.bool_
Since NumPy 1.20 the usage of `numpy.bool` is [deprecated](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations). As a replacement `numpy.bool_` can be used.